### PR TITLE
chore(pre-align): align heading structure with ko

### DIFF
--- a/en/alimtalk-api-guide-v1.4.md
+++ b/en/alimtalk-api-guide-v1.4.md
@@ -1422,6 +1422,107 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | Result message    |
 | - isSuccessful  | Boolean | Successful or not |
 
+### Get PlusFriend
+
+<!-- TODO: translate body -->
+
+#### Request
+
+[URL]
+
+```
+GET  /alimtalk/v1.4/appkeys/{appkey}/plus-friends/{plusFriendId}
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| Name |	Type|	Description|
+|---|---|---|
+|appkey|	String|	Unique app key|
+|plusFriendId| String | Plus Friend ID |
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| Name |	Type|	Required|	Description|
+|---|---|---|---|
+|X-Secret-Key|	String| O | You can create this in the console.  |
+
+#### Response
+
+{  
+   "header":{  
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
+   },
+   "plusFriend":{  
+         "plusFriendId": String,
+         "plusFriendType": String,
+         "senderKey": String,
+         "categoryCode": String,
+         "status": String,
+         "statusName": String,
+         "kakaoStatus": String,
+         "kakaoStatusName": String,
+         "kakaoProfileStatus": String,
+         "kakaoProfileStatusName": String,
+         "createDate": String,
+         "alimtalk": {  
+                "resendAppKey": String,
+                "isResend": Boolean,
+                "resendSendNo": String,
+                "dailyMaxCount": Integer,
+                "sentCount": Integer
+          },
+         "friendtalk": {
+                "resendAppKey": String,
+                "isResend": Boolean,
+                "resendSendNo": String,
+                "resendUnsubscribeNo": String,
+                "dailyMaxCount": Integer,
+                "sentCount": Integer
+         },
+         "createDate": String
+    }
+}
+
+| Name |	Type|	Description|
+|---|---|---|
+|header|	Object|	Header area|
+|- resultCode|	Integer|	Result code|
+|- resultMessage|	String| Result message|
+|- isSuccessful|	Boolean| Success status|
+|plusFriend|	Object|	Plus Friend|
+|- plusFriendId | String |	Plus Friend ID |
+|- plusFriendType | String | Plus Friend type (NORMAL, GROUP) |
+|- senderKey | String |	Sender key |
+|- categoryCode | String |	Category code |
+|- status | String |	NHN Cloud Plus Friend status code <br>(YSC02: Registration pending, YSC03: Normal registration) |
+|- statusName | String |	NHN Cloud Plus Friend status name (Registration pending, Normal registration) |
+|- kakaoStatus | String |	Kakao Plus Friend status code<br>(A: Normal, S: Blocked, D: Deleted)<br>When status is YSC02, kakaoStatus has a null value. |
+|- kakaoStatusName | String |	Kakao Plus Friend status name (Normal, Blocked, Deleted)<br>When status is YSC02, kakaoStatusName has a null value. |
+|- kakaoProfileStatus | String |	Kakao Plus Friend profile status code<br>(A: Activated, B: Blocked, C: Deactivated, D: Deleted, E: Being deleted)<br>When status is YSC02, kakaoProfileStatus has a null value.|
+|- kakaoProfileStatusName | String | Kakao Plus Friend profile status name (Activated, Deactivated, Blocked, Being deleted, Deleted)<br>When status is YSC02, kakaoProfileStatusName has a null value. |
+|- alimtalk|	Object|	AlimTalk settings information|
+|-- resendAppKey | String | SMS service app key to set for alternative delivery |
+|-- isResend | String | Alternative delivery setting (resend) status|
+|-- resendSendNo | String |	tc-sms sender number for resending |
+|-- dailyMaxCount | Integer |	AlimTalk daily maximum delivery count<br>(No count limit when the value is 0) |
+|-- sentCount | Integer |	AlimTalk daily delivery count<br>(No count limit when the value is 0) |
+|- friendtalk|	Object|	FriendTalk settings information|
+|-- resendAppKey | String | SMS service app key to set for alternative delivery |
+|-- isResend | String | Alternative delivery setting (resend) status|
+|-- resendSendNo | String |	tc-sms sender number for resending |
+|-- resendUnsubscribeNo | String |	tc-sms 080 opt-out number for resending |
+|-- dailyMaxCount | Integer |	FriendTalk daily maximum delivery count<br>(No count limit when the value is 0) |
+|-- sentCount | Integer |	FriendTalk daily delivery count<br>(No count limit when the value is 0) |
+|- createDate | String |	Registration date |
+
 ### List PlusFriends
 
 #### Requet
@@ -2029,3 +2130,117 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- activated         | Boolean | activated or not                                             |
 | -- createDate        | String  | Date and time of creation                                    |
 | - totalCount         | Integer | Total count                                                  |
+## Manage Alternative Sending
+
+<!-- TODO: translate body -->
+
+### Register SMS AppKey
+
+[URL]
+
+```
+POST  /alimtalk/v1.4/appkeys/{appkey}/failback/appkey
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| Name |	Type|	Description|
+|---|---|---|
+|appkey|	String|	Unique app key|
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| Name |	Type|	Required|	Description|
+|---|---|---|---|
+|X-Secret-Key|	String| O | You can create this in the console.  |
+
+
+[Request body]
+
+```
+{
+    "resendAppKey": String
+}
+```
+
+| Name |	Type|	Required|	Description|
+|---|---|---|---|
+|resendAppKey|	String|	O | SMS service app key to set for alternative delivery |
+
+[Example]
+```
+curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v1.4/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
+```
+
+#### Response
+
+{
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
+  }
+}
+
+### Register Alternative Sending Settings
+
+[URL]
+
+```
+POST  /alimtalk/v1.4/appkeys/{appkey}/failback
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| Name |	Type|	Description|
+|---|---|---|
+|appkey|	String|	Unique app key|
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| Name |	Type|	Required|	Description|
+|---|---|---|---|
+|X-Secret-Key|	String| O | You can create this in the console.  |
+
+
+[Request body]
+
+```
+{  
+   "plusFriendId": String,
+   "isResend": Boolean,
+   "resendSendNo": String
+}
+```
+
+| Name |	Type|	Required|	Description|
+|---|---|---|---|
+|plusFriendId|	String|	O | Plus Friend ID |
+|isResend|	Boolean|	O | Whether to send alternative text message when delivery fails<br>When alternative delivery is configured in the Console, it is resent by default. |
+|resendSendNo|	String|	O | Alternative delivery sender number<br><span style="color:red">(If the sender number is not registered in the SMS product, alternative delivery may fail.)</span> |
+
+[Example]
+```
+curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v1.4/appkeys/{appkey}/failback/appkey -d '{"plusFriendId": "@Plus Friend","isResend": true,"resendSendNo": "01012341234" }
+```
+
+#### Response
+
+{
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
+  }
+}
+

--- a/en/alimtalk-api-guide-v1.5.md
+++ b/en/alimtalk-api-guide-v1.5.md
@@ -2382,3 +2382,123 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- activated         | Boolean | activated or not                                             |
 | -- createDate        | String  | Date and time of creation                                    |
 | - totalCount         | Integer | Total count                                                  |
+## Alternative Sending Management
+
+<!-- TODO: translate body -->
+
+### Register SMS AppKey
+
+[URL]
+
+```
+POST  /alimtalk/v1.5/appkeys/{appkey}/failback/appkey
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| Name |	Type|	Description|
+|---|---|---|
+|appkey|	String|	Unique app key|
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| Name |	Type|	Required|	Description|
+|---|---|---|---|
+|X-Secret-Key|	String| O | You can create this in the console.  |
+
+
+[Request body]
+
+```
+{
+    "resendAppKey": String
+}
+```
+
+| Name |	Type|	Required|	Description|
+|---|---|---|---|
+|resendAppKey|	String|	O | SMS service app key to set for alternative delivery |
+
+[Example]
+```
+curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v1.5/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
+```
+
+#### Response
+
+```
+
+{
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
+  }
+}
+```
+
+### Register Alternative Sending Settings
+
+[URL]
+
+```
+POST  /alimtalk/v1.5/appkeys/{appkey}/failback
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| Name | Type | Description |
+|---|---|---|
+|appkey| String | Unique app key |
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| Name | Type | Required | Description |
+|---|---|---|---|
+|X-Secret-Key| String| O | You can create this in the console. |
+
+
+[Request body]
+
+```
+{  
+   "plusFriendId": String,
+   "isResend": Boolean,
+   "resendSendNo": String
+}
+```
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+|plusFriendId| String| O | Plus Friend ID |
+|isResend| Boolean| O | Whether to send alternative SMS when delivery fails<br>When alternative sending is configured in the console, resending is done by default. |
+|resendSendNo| String| O | Alternative delivery sender number<br><span style="color:red">(If the sender number is not registered in the SMS service, alternative sending may fail.)</span> |
+
+[Example]
+```
+curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v1.5/appkeys/{appkey}/failback/appkey -d '{"plusFriendId": "@플러스친구","isResend": true,"resendSendNo": "01012341234" }
+```
+
+#### Response
+
+```
+
+{
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
+  }
+}
+```
+

--- a/en/alimtalk-api-guide-v2.0.md
+++ b/en/alimtalk-api-guide-v2.0.md
@@ -450,7 +450,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
-#### Status of Sending SMS/LMS
+### Status of Sending SMS/LMS
 | Value | Description                                      |
 | ----- | ------------------------------------------------ |
 | RSC01 | No target of resending                           |
@@ -1006,6 +1006,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/auth/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<!-- pre-align: ko에 대응 섹션 없음 — 검토 필요 (SMS/LMS status section for Authentication Messages has no Korean counterpart) -->
 #### Status of Resending SMS/LMS
 | Value | Description                                     |
 | ----- | ----------------------------------------------- |
@@ -2001,3 +2002,123 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- activated         | Boolean | activated or not                                             |
 | -- createDate        | String  | Date and time of creation                                    |
 | - totalCount         | Integer | Total count                                                  |
+## Alternative Sending Management
+
+<!-- TODO: translate body -->
+
+### SMS AppKey Registration
+
+[URL]
+
+```
+POST  /alimtalk/v2.0/appkeys/{appkey}/failback/appkey
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| Name | Type | Description |
+|---|---|---|
+|appkey| String | Unique app key |
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| Name | Type | Required | Description |
+|---|---|---|---|
+|X-Secret-Key| String | O | You can create this in the console. |
+
+
+[Request body]
+
+```
+{
+    "resendAppKey": String
+}
+```
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+|resendAppKey| String | O | SMS service app key to set for alternative delivery |
+
+[Example]
+```
+curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
+```
+
+#### Response
+
+```
+
+{
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
+  }
+}
+```
+
+### Alternative Sending Settings Registration
+
+[URL]
+
+```
+POST  /alimtalk/v2.0/appkeys/{appkey}/failback
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| Name |	Type|	Description|
+|---|---|---|
+|appkey|	String|	Unique app key|
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| Name |	Type|	Required|	Description|
+|---|---|---|---|
+|X-Secret-Key|	String| O | You can create this in the console.  |
+
+
+[Request body]
+
+```
+{  
+   "senderKey": String,
+   "isResend": Boolean,
+   "resendSendNo": String
+}
+```
+
+| Name |	Type|	Required|	Description|
+|---|---|---|---|
+|senderKey|	String|	O | Sender Key |
+|isResend|	Boolean|	O | Whether to send SMS alternative delivery when delivery fails<br>When alternative sending settings are configured in the Console, alternative delivery is sent by default. |
+|resendSendNo|	String|	O | Alternative delivery sender number<br><span style="color:red">(If it is not a sender number registered in the SMS service, alternative delivery may fail.)</span> |
+
+[Example]
+```
+curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/failback/appkey -d '{"senderKey": "0be23c29de88d6888798aeda57062516354d74ba","isResend": true,"resendSendNo": "01012341234" }
+```
+
+#### Response
+
+```
+
+{
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
+  }
+}
+```
+

--- a/en/alimtalk-api-guide-v2.1.md
+++ b/en/alimtalk-api-guide-v2.1.md
@@ -448,7 +448,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
-#### Status of Sending SMS/LMS
+### Status of Sending SMS/LMS
 | Value | Description                                      |
 | ----- | ------------------------------------------------ |
 | RSC01 | No target of resending                           |
@@ -1004,6 +1004,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/auth/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<!-- pre-align: ko에 대응 섹션 없음 — 검토 필요 (duplicate status section misplaced from k34) -->
 #### Status of Resending SMS/LMS
 | Value | Description                                     |
 | ----- | ----------------------------------------------- |
@@ -2076,3 +2077,120 @@ curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}
 | templateImage        | Object  | Body area                                                    |
 | - templateImageName  | String  | Image name                                                   |
 | - templateImageUrl   | String  | Image URL                                                    |
+## Alternative Sending Management
+
+<!-- TODO: translate body -->
+
+### Register SMS AppKey
+
+[URL]
+
+```
+POST  /alimtalk/v2.1/appkeys/{appkey}/failback/appkey
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| Name |	Type|	Description|
+|---|---|---|
+|appkey|	String|	Unique app key|
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| Name |	Type|	Required|	Description|
+|---|---|---|---|
+|X-Secret-Key|	String| O | You can create this in the console.  |
+
+
+[Request body]
+
+```
+{
+    "resendAppKey": String
+}
+```
+
+| Name |	Type|	Required|	Description|
+|---|---|---|---|
+|resendAppKey|	String|	O | SMS service app key to set for alternative delivery |
+
+[Example]
+```
+curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
+```
+
+#### Response
+
+{
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
+  }
+}
+
+### Register Alternative Sending Settings
+
+[URL]
+
+```
+POST  /alimtalk/v2.1/appkeys/{appkey}/failback
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| Name |	Type|	Description|
+|---|---|---|
+|appkey|	String|	Unique app key|
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| Name |	Type|	Required|	Description|
+|---|---|---|---|
+|X-Secret-Key|	String| O | Can be created in the console.  |
+
+
+[Request body]
+
+```
+{  
+   "senderKey": String,
+   "isResend": Boolean,
+   "resendSendNo": String
+}
+```
+
+| Name |	Type|	Required|	Description|
+|---|---|---|---|
+|senderKey|	String|	O | Sender Key |
+|isResend|	Boolean|	O | Whether to send SMS alternative delivery when delivery fails<br>When alternative delivery is configured in the console, alternative delivery is sent by default. |
+|resendSendNo|	String|	O | Alternative delivery sender number<br><span style="color:red">(If it is not a sender number registered in the SMS service, alternative delivery may fail.)</span> |
+
+[Example]
+```
+curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/failback/appkey -d '{"senderKey": "0be23c29de88d6888798aeda57062516354d74ba","isResend": true,"resendSendNo": "01012341234" }
+```
+
+#### Response
+
+```
+
+{
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
+  }
+}
+```
+

--- a/en/alimtalk-api-guide.md
+++ b/en/alimtalk-api-guide.md
@@ -3013,6 +3013,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result message|
 |- isSuccessful|	Boolean| Successful or not|
 
+### Delete Template Plugin
+
+<!-- TODO: translate body -->
+
+<!-- pre-align: ko에 대응 섹션 없음 — 검토 필요 (duplicate Modify Template Plugin with no Korean counterpart) -->
 ### Modify Template Plugin
 #### Request
 [URL]

--- a/en/common-api-guide.md
+++ b/en/common-api-guide.md
@@ -153,3 +153,375 @@
     }
 }
 ```
+## Kakao Statistics
+
+* You can retrieve statistics data provided by Kakao Biz Center.
+* You can retrieve statistics data by sender key on a daily (DAILY) or monthly (MONTHLY) basis.
+* DAILY: You can retrieve only data within the last 90 days, and the query range is up to 90 days.
+* MONTHLY: You can retrieve only data within the last 3 months, and the query range is up to 3 months.
+
+In Sender Profile Management, if you click **Go to Kakao Statistics**, you can view Kakao statistics in a new window. Statistics criteria include delivery statistics and template statistics, and query conditions vary depending on the message channel. You can view the query results in charts and tables.
+
+* Real-time statistics are not provided. Data collected from the previous day is provided daily around 7 AM.
+* AlimTalk statistics are first provided on D+1 and finalized on D+2.
+* Valid read counts are not duplicated for the same message.
+* Click counts are duplicated for the same message.
+* If the number of successful deliveries is 10 or less, valid read counts and click counts are not provided.
+
+### Send Statistics
+
+Queries daily delivery count, valid read count, and click count based on Sender Profile. You can query by setting the period, delivery identifier, Message Type, and other parameters.
+
+### Template Statistics
+
+You can query daily delivery counts, valid read counts, and click counts based on templates and group tags. You can query by setting the period, message type, and other parameters.
+
+* Brand Message free-form is provided only when group tags are used.
+
+### AlimTalk Send Statistics Query
+
+<!-- TODO: translate body -->
+
+#### Request
+
+[URL]
+
+|Http method| URI|
+|---|---|
+|GET| /common/v2.2/appkeys/{appKey}/kakao-statistics/delivery-statistics/ALIMTALK |
+
+[Path parameter]
+
+| Name | Type | Description |
+|---|---|---|
+| appKey | String | Unique app key |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| X-Secret-Key | String | O | You can create this in the console. |
+
+[Query parameter]
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| senderKey | String | O | Sender Key |
+| periodType | String | O | Statistics category (DAILY: daily, MONTHLY: monthly) |
+| startDate | String | O | Query start date<br/>DAILY: yyyy-MM-dd (within the last 90 days), MONTHLY: yyyy-MM (within the last 3 months) |
+| endDate | String | O | Query end date<br/>DAILY: yyyy-MM-dd (maximum range 90 days), MONTHLY: yyyy-MM (maximum range 3 months) |
+| messageType | String | X | Message Type (AT: general AlimTalk, AI: image AlimTalk) |
+| receiveUserType | String | X | Recipient type (PhoneNumber: phone number, None: no recipient identifier) |
+| limit | Integer | X | Query count (Default: 500, Max: 1000) |
+| offset | Integer | X | Start position (Default: 0) |
+
+#### Response
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "success",
+        "isSuccessful": true
+    },
+    "totalCount": 1,
+    "alimtalkDeliveryStatistics": [
+        {
+            "date": "2026-04-01",
+            "messageType": "NORMAL",
+            "receiveUserType": "ALL",
+            "totalSendRequestCount": 100,
+            "validSendRequestCount": 95,
+            "validReadCount": 80
+        }
+    ]
+}
+```
+
+| Name | Type | Not Null | Description |
+|---|---|:---:|---|
+| header | Object | O | Header area |
+| - resultCode | Integer | O | Result code |
+| - resultMessage | String | O | Result message |
+| - isSuccessful | Boolean | O | Success status |
+| totalCount | Integer | O | Total count |
+| alimtalkDeliveryStatistics | List | O | AlimTalk delivery statistics list |
+| - date | String | O | Date |
+| - messageType | String | O | Message Type (AT: General AlimTalk, AI: Image AlimTalk) |
+| - receiveUserType | String | O | Recipient type (PhoneNumber: Phone number, None: No recipient identifier) |
+| - totalSendRequestCount | Integer | O | Total send request count |
+| - validSendRequestCount | Integer | O | Valid send request count |
+| - validReadCount | Integer | O | Valid read count |
+
+### AlimTalk Template Statistics Query
+
+<!-- TODO: translate body -->
+
+#### Request
+
+[URL]
+
+|Http method| URI|
+|---|---|
+|GET| /common/v2.2/appkeys/{appKey}/kakao-statistics/template-statistics/ALIMTALK |
+
+[Path parameter]
+
+| Name | Type | Description |
+|---|---|---|
+| appKey | String | Unique app key |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| X-Secret-Key | String | O | You can create it in the console. |
+
+[Query parameter]
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| senderKey | String | O | Sender Key |
+| periodType | String | O | Statistics classification (DAILY: daily, MONTHLY: monthly) |
+| startDate | String | O | Query start date<br/>DAILY: yyyy-MM-dd (within the last 90 days), MONTHLY: yyyy-MM (within the last 3 months) |
+| endDate | String | O | Query end date<br/>DAILY: yyyy-MM-dd (maximum range of 90 days), MONTHLY: yyyy-MM (maximum range of 3 months) |
+| kakaoTemplateCode | String | X | Kakao Template Code |
+| messageType | String | X | Message Type (AT: general AlimTalk, AI: image AlimTalk) |
+| limit | Integer | X | Number of queries (Default: 500, Max: 1000) |
+| offset | Integer | X | Start position (Default: 0) |
+
+#### Response
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "success",
+        "isSuccessful": true
+    },
+    "totalCount": 1,
+    "alimtalkTemplateStatistics": [
+        {
+            "date": "2026-04-01",
+            "messageType": "NORMAL",
+            "templateCode": "template01",
+            "totalSendSuccessCount": 90,
+            "validReadCount": 75,
+            "totalClickCount": 30
+        }
+    ]
+}
+```
+
+| Name | Type | Not Null | Description |
+|---|---|:---:|---|
+| header | Object | O | Header area |
+| - resultCode | Integer | O | Result code |
+| - resultMessage | String | O | Result message |
+| - isSuccessful | Boolean | O | Success status |
+| totalCount | Integer | O | Total count |
+| alimtalkTemplateStatistics | List | O | AlimTalk template statistics list |
+| - date | String | O | Date |
+| - messageType | String | O | Message type (AT: general AlimTalk, AI: image AlimTalk) |
+| - templateCode | String | O | Template Code |
+| - totalSendSuccessCount | Integer | O | Total delivery success count |
+| - validReadCount | Integer | O | Valid read count |
+| - totalClickCount | Integer | O | Total click count |
+
+### Brand Message Send Statistics Query
+
+<!-- TODO: translate body -->
+
+#### Request
+
+[URL]
+
+|Http method| URI|
+|---|---|
+|GET| /common/v2.2/appkeys/{appKey}/kakao-statistics/delivery-statistics/BRANDMESSAGE |
+
+[Path parameter]
+
+| Name | Type | Description |
+|---|---|---|
+| appKey | String | Unique app key |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| X-Secret-Key | String | O | You can create it in the console. |
+
+[Query parameter]
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| senderKey | String | O | Sender Key |
+| periodType | String | O | Statistics classification (DAILY: Daily, MONTHLY: Monthly) |
+| startDate | String | O | Query start date<br/>DAILY: yyyy-MM-dd (within the last 90 days), MONTHLY: yyyy-MM (within the last 3 months) |
+| endDate | String | O | Query end date<br/>DAILY: yyyy-MM-dd (maximum range 90 days), MONTHLY: yyyy-MM (maximum range 3 months) |
+| messageSpec | String | X | Message specification (BASIC: Basic type, FREESTYLE: Freestyle type) |
+| chatBubbleType | String | X | Chat bubble type (TEXT: Text Type, IMAGE: Image Type, WIDE: Wide Image, WIDE_ITEM_LIST: Wide Item List, CAROUSEL_FEED: Carousel Feed, PREMIUM_VIDEO: Premium Video, COMMERCE: Commerce, CAROUSEL_COMMERCE: Carousel Commerce) |
+| targeting | String | X | Targeting (M: All marketing consent users, N: Exclude Channel Friends, I: Channel Friends only, F: All Channel Friends) |
+| friendType | String | X | Friend type (F: Friend, N: Non-friend) |
+| receiveUserType | String | X | Recipient type (PhoneNumber: Phone number, None: No recipient identifier) |
+| limit | Integer | X | Number of queries (Default: 500, Max: 1000) |
+| offset | Integer | X | Start position (Default: 0) |
+
+#### Response
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "success",
+        "isSuccessful": true
+    },
+    "totalCount": 1,
+    "brandmessageDeliveryStatistics": [
+        {
+            "date": "2026-04-01",
+            "messageSpec": "TEMPLATE",
+            "chatBubbleType": "TEXT",
+            "targeting": "ALL",
+            "friendType": "ALL",
+            "receiveUserType": "ALL",
+            "totalSendRequestCount": 200,
+            "validSendRequestCount": 190,
+            "validReadCount": 150,
+            "totalClickCount": 60
+        }
+    ]
+}
+```
+
+| Name | Type | Not Null | Description |
+|---|---|:---:|---|
+| header | Object | O | Header area |
+| - resultCode | Integer | O | Result code |
+| - resultMessage | String | O | Result message |
+| - isSuccessful | Boolean | O | Success status |
+| totalCount | Integer | O | Total count |
+| brandmessageDeliveryStatistics | List | O | Brand Message delivery statistics list |
+| - date | String | O | Date |
+| - messageSpec | String | O | Message specification (BASIC: Basic type, FREESTYLE: Freestyle type) |
+| - chatBubbleType | String | O | Chat bubble type (TEXT: Text Type, IMAGE: Image Type, WIDE: Wide Image Type, WIDE_ITEM_LIST: Wide Item List Type, CAROUSEL_FEED: Carousel Feed Type, PREMIUM_VIDEO: Premium Video Type, COMMERCE: Commerce Type, CAROUSEL_COMMERCE: Carousel Commerce Type) |
+| - targeting | String | O | Targeting (M: All users who agreed to marketing, N: Excluding channel friends, I: Channel friends only, F: All channel friends) |
+| - friendType | String | O | Friend type (F: Friend, N: Non-friend) |
+| - receiveUserType | String | O | Recipient type (PhoneNumber: Phone number, None: No recipient identifier) |
+| - totalSendRequestCount | Integer | O | Total send request count |
+| - validSendRequestCount | Integer | O | Valid send request count |
+| - validReadCount | Integer | O | Valid read count |
+| - totalClickCount | Integer | O | Total click count |
+
+### Brand Message Template Statistics Query
+
+<!-- TODO: translate body -->
+
+#### Request
+
+[URL]
+
+|Http method| URI|
+|---|---|
+|GET| /common/v2.2/appkeys/{appKey}/kakao-statistics/template-statistics/BRANDMESSAGE |
+
+[Path parameter]
+
+| Name | Type | Description |
+|---|---|---|
+| appKey | String | Unique app key |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| X-Secret-Key | String | O | You can create this in the console. |
+
+[Query parameter]
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| senderKey | String | O | Sender Key |
+| periodType | String | O | Statistics type (DAILY: Daily, MONTHLY: Monthly) |
+| startDate | String | O | Query start date<br/>DAILY: yyyy-MM-dd (within the last 90 days), MONTHLY: yyyy-MM (within the last 3 months) |
+| endDate | String | O | Query end date<br/>DAILY: yyyy-MM-dd (maximum range of 90 days), MONTHLY: yyyy-MM (maximum range of 3 months) |
+| kakaoTemplateCode | String | X | Kakao Template Code |
+| groupTagKey | String | X | Group tag key |
+| messageSpec | String | X | Message specification (BASIC: Basic type, FREESTYLE: Freestyle type) |
+| chatBubbleType | String | X | Chat bubble type (TEXT: Text Type, IMAGE: Image Type, WIDE: Wide Image, WIDE_ITEM_LIST: Wide Item List, CAROUSEL_FEED: Carousel Feed, PREMIUM_VIDEO: Premium Video, COMMERCE: Commerce, CAROUSEL_COMMERCE: Carousel Commerce) |
+| targeting | String | X | Targeting (M: All users who consented to marketing, N: Excluding channel friends, I: Channel friends only, F: All channel friends) |
+| friendType | String | X | Friend type (F: Friends, N: Non-friends) |
+| limit | Integer | X | Number of queries (Default: 500, Max: 1000) |
+| offset | Integer | X | Start position (Default: 0) |
+
+#### Response
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "success",
+        "isSuccessful": true
+    },
+    "totalCount": 1,
+    "brandmessageTemplateStatistics": [
+        {
+            "date": "2026-04-01",
+            "templateCode": "brandtemplate01",
+            "groupTagKey": "group01",
+            "messageSpec": "TEMPLATE",
+            "chatBubbleType": "TEXT",
+            "targeting": "ALL",
+            "friendType": "ALL",
+            "totalSendSuccessCount": 180,
+            "validReadCount": 140,
+            "totalClickCount": 55
+        }
+    ]
+}
+```
+
+| Name | Type | Not Null | Description |
+|---|---|:---:|---|
+| header | Object | O | Header area |
+| - resultCode | Integer | O | Result code |
+| - resultMessage | String | O | Result message |
+| - isSuccessful | Boolean | O | Success status |
+| totalCount | Integer | O | Total count |
+| brandmessageTemplateStatistics | List | O | Brand Message template statistics list |
+| - date | String | O | Date |
+| - templateCode | String | O | Template Code |
+| - groupTagKey | String | X | Group tag key |
+| - messageSpec | String | O | Message spec (BASIC: Basic type, FREESTYLE: Freestyle type) |
+| - chatBubbleType | String | O | Chat bubble type (TEXT: Text Type, IMAGE: Image Type, WIDE: Wide Image, WIDE_ITEM_LIST: Wide Item List, CAROUSEL_FEED: Carousel Feed, PREMIUM_VIDEO: Premium Video, COMMERCE: Commerce, CAROUSEL_COMMERCE: Carousel Commerce) |
+| - targeting | String | O | Targeting (M: All users who agreed to marketing, N: Excluding channel friends, I: Channel friends only, F: All channel friends) |
+| - friendType | String | O | Friend type (F: Friend, N: Non-friend) |
+| - totalSendSuccessCount | Integer | O | Total delivery success count |
+| - validReadCount | Integer | O | Valid read count |
+| - totalClickCount | Integer | O | Total click count |
+

--- a/en/friendtalk-api-guide-v1.4.md
+++ b/en/friendtalk-api-guide-v1.4.md
@@ -1,5 +1,11 @@
 ## Notification > KakaoTalk Bizmessage > FriendTalk > API v1.4 Guide
 
+## FriendTalk End of Service Notice
+
+* December 31, 2025 - We will discontinue FriendTalk service support.
+* For existing customers, we recommend that you migrate to Brand Message.
+* For more information, see [Brand Message Migration Guide](https://docs.nhncloud.com/en/Notification/KakaoTalk%20Bizmessage/ko/friendtalk-compatible-api-guide).
+
 ## FriendTalk
 
 #### [API Domain]
@@ -370,6 +376,72 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - senderGroupingKey    | String  | Sender's grouping key                                        |
 | - recipientGroupingKey | String  | Recipient's grouping key                                     |
 
+## Messages
+
+<!-- TODO: translate body -->
+
+### Send canceled Messages
+
+<!-- TODO: translate body -->
+
+#### Request
+
+[URL]
+
+```
+DELETE  /friendtalk/v1.4/appkeys/{appkey}/messages/{requestId}
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| Name | Type | Description |
+|---|---|---|
+|appkey| String | Unique app key |
+|requestId| String| Request ID |
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| Name | Type | Required | Description |
+|---|---|---|---|
+|X-Secret-Key| String| O | You can create this in the console. |
+
+[Query parameter]
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+|recipientSeq| String| X | Recipient sequence number<br>(If not entered, all delivery requests for the request ID are cancelled) |
+
+* You can cancel both general and authentication messages using the same API.
+
+#### Response
+
+```
+{
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
+  }
+}
+```
+
+| Name |	Type|	Description|
+|---|---|---|
+|header|	Object|	Header area|
+|- resultCode|	Integer|	Result code|
+|- resultMessage|	String| Result message|
+|- isSuccessful|	Boolean| Success status|
+
+[Example]
+```
+curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/friendtalk/v1.4/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
+```
+
 ### Query Updated Message Results
 
 #### Request
@@ -677,3 +749,124 @@ curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Ke
 | - resultCode    | Integer | Result code       |
 | - resultMessage | String  | Result message    |
 | - isSuccessful  | Boolean | Successful or not |
+## Alternative Sending Management
+
+<!-- TODO: translate body -->
+
+### SMS AppKey Registration
+
+[URL]
+
+```
+POST  /friendtalk/v1.4/appkeys/{appkey}/failback/appkey
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| Name |	Type|	Description|
+|---|---|---|
+|appkey|	String|	Unique app key|
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| Name |	Type|	Required|	Description|
+|---|---|---|---|
+|X-Secret-Key|	String| O | Can be created in the console.  |
+
+
+[Request body]
+
+```
+{
+    "resendAppKey": String
+}
+```
+
+| Name |	Type|	Required|	Description|
+|---|---|---|---|
+|resendAppKey|	String|	O | SMS service app key to set for alternative delivery |
+
+[Example]
+```
+curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/friendtalk/v1.4/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
+```
+
+#### Response
+
+```
+
+{
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
+  }
+}
+```
+
+### Alternative Sending Settings Registration
+
+[URL]
+
+```
+POST  /friendtalk/v1.4/appkeys/{appkey}/failback
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| Name |	Type|	Description|
+|---|---|---|
+|appkey|	String|	Unique app key|
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| Name |	Type|	Required|	Description|
+|---|---|---|---|
+|X-Secret-Key|	String| O | Can be created in the console.  |
+
+
+[Request body]
+
+```
+{  
+   "plusFriendId": String,
+   "isResend": Boolean,
+   "resendSendNo": String,
+   "resendUnsubscribeNo": String
+}
+```
+
+| Name |	Type|	Required|	Description|
+|---|---|---|---|
+|plusFriendId|	String|	O | Plus Friend ID |
+|isResend|	Boolean|	O | Whether to send SMS as alternative delivery when delivery fails<br>When alternative delivery is configured in the console, it is resent by default. |
+|resendSendNo|	String|	O | Alternative delivery sender number<br><span style="color:red">(Alternative delivery may fail if the sender number is not registered with the SMS service.)</span> |
+|resendUnsubscribeNo|	String|	X | Alternative delivery 080 unsubscribe number<br><span style="color:red">(Alternative delivery may fail if the 080 unsubscribe number is not registered with the SMS service.)</span> |
+
+[Example]
+```
+curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/friendtalk/v1.4/appkeys/{appkey}/failback/appkey -d '{"plusFriendId": "@플러스친구","isResend": true,"resendSendNo": "01012341234", "resendUnsubscribeNo": "0801234567" }
+```
+
+#### Response
+
+```
+{
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
+  }
+}
+```
+

--- a/en/friendtalk-api-guide-v1.5.md
+++ b/en/friendtalk-api-guide-v1.5.md
@@ -1,5 +1,11 @@
 ## Notification > KakaoTalk Bizmessage > FriendTalk > API v1.5 Guide
 
+## FriendTalk End of Service Notice
+
+* Support for FriendTalk service will end on December 31, 2025.
+* We recommend that existing customers migrate to Brand Message.
+* For more information, see [Brand Message Migration Guide](https://docs.nhncloud.com/en/Notification/KakaoTalk%20Bizmessage/ko/friendtalk-compatible-api-guide).
+
 ## FriendTalk
 
 #### [API Domain]
@@ -392,6 +398,72 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - senderGroupingKey    | String  | Sender's grouping key                                        |
 | - recipientGroupingKey | String  | Recipient's grouping key                                     |
 
+## Messages
+
+<!-- TODO: translate body -->
+
+### Cancel Message Sending
+
+<!-- TODO: translate body -->
+
+#### Request
+
+[URL]
+
+```
+DELETE  /friendtalk/v1.5/appkeys/{appkey}/messages/{requestId}
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| Name |	Type|	Description|
+|---|---|---|
+|appkey|	String|	Unique app key|
+|requestId| String| Request ID|
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| Name |	Type|	Required|	Description|
+|---|---|---|---|
+|X-Secret-Key|	String| O | You can create this in the console.  |
+
+[Query parameter]
+
+| Name |	Type|	Required|	Description|
+|---|---|---|---|
+|recipientSeq|	String|	X | Recipient sequence number<br>(If not entered, all delivery requests for the request ID are cancelled) |
+
+* You can cancel both general and authentication messages using the same API.
+
+#### Response
+
+```
+{
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
+  }
+}
+```
+
+| Name |	Type|	Description|
+|---|---|---|
+|header|	Object|	Header area|
+|- resultCode|	Integer|	Result code|
+|- resultMessage|	String| Result message|
+|- isSuccessful|	Boolean| Success status|
+
+[Example]
+```
+curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/friendtalk/v1.5/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
+```
+
 ### Query Updated Message Results
 
 #### Request
@@ -699,3 +771,124 @@ curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Ke
 | - resultCode    | Integer | Result code       |
 | - resultMessage | String  | Result message    |
 | - isSuccessful  | Boolean | Successful or not |
+## Manage Alternative Sending
+
+<!-- TODO: translate body -->
+
+### Register SMS AppKey
+
+[URL]
+
+```
+POST  /friendtalk/v1.5/appkeys/{appkey}/failback/appkey
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| Name |	Type|	Description|
+|---|---|---|
+|appkey|	String|	Unique app key|
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| Name |	Type|	Required|	Description|
+|---|---|---|---|
+|X-Secret-Key|	String| O | You can create this in the console.  |
+
+
+[Request body]
+
+```
+{
+    "resendAppKey": String
+}
+```
+
+| Name |	Type|	Required|	Description|
+|---|---|---|---|
+|resendAppKey|	String|	O | SMS service app key to set for alternative delivery |
+
+[Example]
+```
+curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/friendtalk/v1.5/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
+```
+
+#### Response
+
+```
+
+{
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
+  }
+}
+```
+
+### Register Alternative Sending Settings
+
+[URL]
+
+```
+POST  /friendtalk/v1.5/appkeys/{appkey}/failback
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| Name |	Type|	Description|
+|---|---|---|
+|appkey|	String|	Unique app key|
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| Name |	Type|	Required|	Description|
+|---|---|---|---|
+|X-Secret-Key|	String| O | You can create it in the console.  |
+
+
+[Request body]
+
+```
+{  
+   "plusFriendId": String,
+   "isResend": Boolean,
+   "resendSendNo": String,
+   "resendUnsubscribeNo": String
+}
+```
+
+| Name |	Type|	Required|	Description|
+|---|---|---|---|
+|plusFriendId|	String|	O | Plus Friend ID |
+|isResend|	Boolean|	O | Whether to send alternative SMS when delivery fails<br>When alternative sending is configured in the console, it is resent by default. |
+|resendSendNo|	String|	O | Alternative delivery sender number<br><span style="color:red">(If it is not a sender number registered in the SMS service, alternative delivery may fail.)</span> |
+|resendUnsubscribeNo|	String|	X | Alternative delivery 080 unsubscribe number<br><span style="color:red">(If it is not an 080 unsubscribe number registered in the SMS service, alternative delivery may fail.)</span> |
+
+[Example]
+```
+curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/friendtalk/v1.5/appkeys/{appkey}/failback/appkey -d '{"plusFriendId": "@PlusFriend","isResend": true,"resendSendNo": "01012341234", "resendUnsubscribeNo": "0801234567" }
+```
+
+#### Response
+
+```
+{
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
+  }
+}
+```
+

--- a/en/friendtalk-api-guide-v2.0.md
+++ b/en/friendtalk-api-guide-v2.0.md
@@ -1,5 +1,9 @@
 ## Notification > KakaoTalk Bizmessage > FriendTalk > API v2.0 Guide
 
+## FriendTalk End of Service Notice
+
+<!-- TODO: translate body -->
+
 ## FriendTalk
 
 #### [API Domain]
@@ -392,6 +396,22 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - senderGroupingKey    | String  | Sender's grouping key                                        |
 | - recipientGroupingKey | String  | Recipient's grouping key                                     |
 
+## Messages
+
+<!-- TODO: translate body -->
+
+### Cancel Message Sending
+
+<!-- TODO: translate body -->
+
+#### Request
+
+<!-- TODO: translate body -->
+
+#### Response
+
+<!-- TODO: translate body -->
+
 ### Query Updated Message Results
 
 #### Request
@@ -699,3 +719,23 @@ curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Ke
 | - resultCode    | Integer | Result code       |
 | - resultMessage | String  | Result message    |
 | - isSuccessful  | Boolean | Successful or not |
+## Alternative Sending Management
+
+<!-- TODO: translate body -->
+
+### SMS AppKey Registration
+
+<!-- TODO: translate body -->
+
+#### Response
+
+<!-- TODO: translate body -->
+
+### Alternative Sending Settings Registration
+
+<!-- TODO: translate body -->
+
+#### Response
+
+<!-- TODO: translate body -->
+

--- a/ja/alimtalk-api-guide-v2.0.md
+++ b/ja/alimtalk-api-guide-v2.0.md
@@ -444,7 +444,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
-#### SMS/LMS再送信ステータス
+### SMS/LMS再送信ステータス
 | 値 | 説明                      |
 | ----- | ------------------------------- |
 | RSC01 | 再送信の対象ではない                 |
@@ -1006,6 +1006,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/auth/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<!-- pre-align: ko에 대응 섹션 없음 — 검토 필요 (duplicate SMS/LMS status section, already covered by t13) -->
 #### SMS/LMS再送信ステータス
 | 値 | 説明                      |
 | ----- | ------------------------------- |

--- a/ja/alimtalk-api-guide-v2.1.md
+++ b/ja/alimtalk-api-guide-v2.1.md
@@ -445,6 +445,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<!-- pre-align: ko에 대응 섹션 없음 — 검토 필요 (misplaced SMS/LMS status section, incorrect translation) -->
 #### SMS/LMS再送信ステータス
 | 値 | 説明                      |
 | ----- | ------------------------------- |
@@ -1007,6 +1008,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/auth/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<!-- pre-align: ko에 대응 섹션 없음 — 검토 필요 (duplicate SMS/LMS status section, incorrect translation) -->
 #### SMS/LMS再送信ステータス
 | 値 | 説明                      |
 | ----- | ------------------------------- |
@@ -1293,6 +1295,16 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/message-results?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
+
+### SMS/LMS代替送信ステータスコード
+
+| 名前 |	説明|
+|---|---|
+|RSC01|	代替送信非対象|
+|RSC02|	代替送信対象（送信結果失敗時、代替送信が実行されます。）|
+|RSC03|	代替送信中|
+|RSC04|	代替送信成功|
+|RSC05|	代替送信失敗|
 
 ## テンプレート
 

--- a/ja/alimtalk-api-guide-v2.2.md
+++ b/ja/alimtalk-api-guide-v2.2.md
@@ -475,6 +475,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<!-- pre-align: ko에 대응 섹션 없음 — 검토 필요 (SMS/LMS resend status appears in target but source has alternative sending status) -->
 #### SMS/LMS再送信ステータス
 | 値 | 説明                      |
 | ----- | ------------------------------- |
@@ -1072,6 +1073,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/auth/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<!-- pre-align: ko에 대응 섹션 없음 — 검토 필요 (Duplicate SMS/LMS resend status section not in source) -->
 #### SMS/LMS再送信ステータス
 | 値 | 説明                      |
 | ----- | ------------------------------- |
@@ -1364,6 +1366,16 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/message-results?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
+
+### SMS/LMS代替送信ステータスコード
+
+| 名前 |	説明|
+|---|---|
+|RSC01|	代替送信非対象|
+|RSC02|	代替送信対象（送信結果が失敗した場合、代替送信が進行されます。）|
+|RSC03|	代替送信中|
+|RSC04|	代替送信成功|
+|RSC05|	代替送信失敗|
 
 ## 大量送信
 ### 大量送信リクエストリスト照会

--- a/ja/common-api-guide.md
+++ b/ja/common-api-guide.md
@@ -153,3 +153,375 @@
     }
 }
 ```
+## カカオ統計
+
+* カカオビズセンターで提供される統計データを照会します。
+* 統計データは発信キー基準で日別（DAILY）または月別（MONTHLY）で照会できます。
+* DAILY：最近 90 日以内のデータのみ照会可能で、照会範囲は最大 90 日です。
+* MONTHLY：最近 3 か月以内のデータのみ照会可能で、照会範囲は最大 3 か月です。
+
+発信プロフィール管理で **[カカオ統計ショートカット]** をクリックすると、新しいウィンドウでカカオ統計を照会できます。統計基準には送信統計とテンプレート統計があり、メッセージチャンネルによって照会条件が異なります。照会結果をチャートと表で確認できます。
+
+* リアルタイム統計は提供せず、前日に収集したデータを毎日午前 7 時頃に提供します。
+* お知らせトーク統計は D+1 で最初に提供され、D+2 で確定します。
+* 有効読み取り数は同じメッセージについて重複集計しません。
+* クリック数は同じメッセージについて重複集計します。
+* 送信成功件数が 10 件以下の場合、有効読み取り数とクリック数は提供しません。
+
+### 送信統計
+
+発信プロフィールを基準として、日別の送信数、有効読み取り数、クリック数を照会します。期間、送信識別子、メッセージタイプなどを設定して照会できます。
+
+### テンプレート統計
+
+テンプレートおよびグループタグを基準に日別送信数、有効開封数、クリック数を照会します。期間、メッセージタイプなどを設定して照会できます。
+
+* ブランドメッセージ自由型はグループタグを使用した場合のみ提供します。
+
+### お知らせトーク送信統計照会
+
+<!-- TODO: translate body -->
+
+#### 要請
+
+[URL]
+
+|Http method| URI|
+|---|---|
+|GET| /common/v2.2/appkeys/{appKey}/kakao-statistics/delivery-statistics/ALIMTALK |
+
+[Path parameter]
+
+| 名前 | 種類 | 説明 |
+|---|---|---|
+| appKey | String | 固有のアプリキー |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前 | 種類 | 必須 | 説明 |
+|---|---|---|---|
+| X-Secret-Key | String | O | コンソールで作成できます。 |
+
+[Query parameter]
+
+| 名前 | 種類 | 必須 | 説明 |
+|---|---|---|---|
+| senderKey | String | O | 発信キー |
+| periodType | String | O | 統計区分（DAILY：日別、MONTHLY：月別） |
+| startDate | String | O | 照会開始日付<br/>DAILY：yyyy-MM-dd（最近90日以内）、MONTHLY：yyyy-MM（最近3か月以内） |
+| endDate | String | O | 照会終了日付<br/>DAILY：yyyy-MM-dd（最大範囲90日）、MONTHLY：yyyy-MM（最大範囲3か月） |
+| messageType | String | X | メッセージタイプ（AT：一般お知らせトーク、AI：画像お知らせトーク） |
+| receiveUserType | String | X | 受信者タイプ（PhoneNumber：電話番号、None：受信者識別子なし） |
+| limit | Integer | X | 照会件数（Default：500、Max：1000） |
+| offset | Integer | X | 開始位置（Default：0） |
+
+#### レスポンス
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "success",
+        "isSuccessful": true
+    },
+    "totalCount": 1,
+    "alimtalkDeliveryStatistics": [
+        {
+            "date": "2026-04-01",
+            "messageType": "NORMAL",
+            "receiveUserType": "ALL",
+            "totalSendRequestCount": 100,
+            "validSendRequestCount": 95,
+            "validReadCount": 80
+        }
+    ]
+}
+```
+
+| 名前 | タイプ | Not Null | 説明 |
+|---|---|:---:|---|
+| header | Object | O | ヘッダー領域 |
+| - resultCode | Integer | O | 結果コード |
+| - resultMessage | String | O | 結果メッセージ |
+| - isSuccessful | Boolean | O | 成功可否 |
+| totalCount | Integer | O | 総数 |
+| alimtalkDeliveryStatistics | List | O | お知らせトーク送信統計リスト |
+| - date | String | O | 日付 |
+| - messageType | String | O | メッセージタイプ(AT: 一般お知らせトーク、AI: 画像お知らせトーク) |
+| - receiveUserType | String | O | 受信者タイプ(PhoneNumber: 電話番号、None: 受信者識別子なし) |
+| - totalSendRequestCount | Integer | O | 総送信リクエスト数 |
+| - validSendRequestCount | Integer | O | 有効送信リクエスト数 |
+| - validReadCount | Integer | O | 有効閲覧数 |
+
+### お知らせトークテンプレート統計照会
+
+<!-- TODO: translate body -->
+
+#### 要請
+
+[URL]
+
+|Http method| URI|
+|---|---|
+|GET| /common/v2.2/appkeys/{appKey}/kakao-statistics/template-statistics/ALIMTALK |
+
+[パスパラメータ]
+
+| 名前 | タイプ | 説明 |
+|---|---|---|
+| appKey | String | 固有のアプリキー |
+
+[ヘッダー]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前 | タイプ | 必須 | 説明 |
+|---|---|---|---|
+| X-Secret-Key | String | O | コンソールで作成できます。 |
+
+[クエリパラメータ]
+
+| 名前 | タイプ | 必須 | 説明 |
+|---|---|---|---|
+| senderKey | String | O | 発信キー |
+| periodType | String | O | 統計区分（DAILY: 日別、MONTHLY: 月別） |
+| startDate | String | O | 照会開始日付<br/>DAILY: yyyy-MM-dd（最近 90 日以内）、MONTHLY: yyyy-MM（最近 3 か月以内） |
+| endDate | String | O | 照会終了日付<br/>DAILY: yyyy-MM-dd（最大範囲 90 日）、MONTHLY: yyyy-MM（最大範囲 3 か月） |
+| kakaoTemplateCode | String | X | カカオテンプレートコード |
+| messageType | String | X | メッセージタイプ（AT: 一般お知らせトーク、AI: 画像お知らせトーク） |
+| limit | Integer | X | 照会件数（Default: 500、Max: 1000） |
+| offset | Integer | X | 開始位置（Default: 0） |
+
+#### レスポンス
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "success",
+        "isSuccessful": true
+    },
+    "totalCount": 1,
+    "alimtalkTemplateStatistics": [
+        {
+            "date": "2026-04-01",
+            "messageType": "NORMAL",
+            "templateCode": "template01",
+            "totalSendSuccessCount": 90,
+            "validReadCount": 75,
+            "totalClickCount": 30
+        }
+    ]
+}
+```
+
+| 名前 | タイプ | Not Null | 説明 |
+|---|---|:---:|---|
+| header | Object | O | ヘッダー領域 |
+| - resultCode | Integer | O | 結果コード |
+| - resultMessage | String | O | 結果メッセージ |
+| - isSuccessful | Boolean | O | 成功可否 |
+| totalCount | Integer | O | 総個数 |
+| alimtalkTemplateStatistics | List | O | お知らせトークテンプレート統計リスト |
+| - date | String | O | 日付 |
+| - messageType | String | O | メッセージタイプ（AT: 一般お知らせトーク、AI: 画像お知らせトーク） |
+| - templateCode | String | O | テンプレートコード |
+| - totalSendSuccessCount | Integer | O | 総送信成功数 |
+| - validReadCount | Integer | O | 有効閲覧数 |
+| - totalClickCount | Integer | O | 総クリック数 |
+
+### ブランドメッセージ送信統計照会
+
+<!-- TODO: translate body -->
+
+#### 要請
+
+[URL]
+
+|Http method| URI|
+|---|---|
+|GET| /common/v2.2/appkeys/{appKey}/kakao-statistics/delivery-statistics/BRANDMESSAGE |
+
+[Path parameter]
+
+| 名前 | 種類 | 説明 |
+|---|---|---|
+| appKey | String | 一意のアプリキー |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前 | 種類 | 必須 | 説明 |
+|---|---|---|---|
+| X-Secret-Key | String | O | コンソールで作成できます。 |
+
+[Query parameter]
+
+| 名前 | 種類 | 必須 | 説明 |
+|---|---|---|---|
+| senderKey | String | O | 発信キー |
+| periodType | String | O | 統計区分（DAILY: 日別、MONTHLY: 月別） |
+| startDate | String | O | 照会開始日<br/>DAILY: yyyy-MM-dd（最近90日以内）、MONTHLY: yyyy-MM（最近3か月以内） |
+| endDate | String | O | 照会終了日<br/>DAILY: yyyy-MM-dd（最大範囲90日）、MONTHLY: yyyy-MM（最大範囲3か月） |
+| messageSpec | String | X | メッセージスペック（BASIC: 基本型、FREESTYLE: 自由型） |
+| chatBubbleType | String | X | 吹き出しタイプ（TEXT: テキスト型、IMAGE: 画像型、WIDE: ワイド画像型、WIDE_ITEM_LIST: ワイドアイテムリストタイプ、CAROUSEL_FEED: カルーセルフィード型、PREMIUM_VIDEO: プレミアム動画型、COMMERCE: コマース型、CAROUSEL_COMMERCE: カルーセルコマース型） |
+| targeting | String | X | ターゲティング（M: マーケティング受信同意ユーザー全体、N: チャンネルフレンド除外、I: チャンネルフレンドのみ、F: チャンネルフレンド全体） |
+| friendType | String | X | フレンドタイプ（F: フレンド、N: 非フレンド） |
+| receiveUserType | String | X | 受信者タイプ（PhoneNumber: 電話番号、None: 受信者識別子なし） |
+| limit | Integer | X | 照会件数（Default: 500、Max: 1000） |
+| offset | Integer | X | 開始位置（Default: 0） |
+
+#### レスポンス
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "success",
+        "isSuccessful": true
+    },
+    "totalCount": 1,
+    "brandmessageDeliveryStatistics": [
+        {
+            "date": "2026-04-01",
+            "messageSpec": "TEMPLATE",
+            "chatBubbleType": "TEXT",
+            "targeting": "ALL",
+            "friendType": "ALL",
+            "receiveUserType": "ALL",
+            "totalSendRequestCount": 200,
+            "validSendRequestCount": 190,
+            "validReadCount": 150,
+            "totalClickCount": 60
+        }
+    ]
+}
+```
+
+| 名前 | 種類 | Not Null | 説明 |
+|---|---|:---:|---|
+| header | Object | O | ヘッダー領域 |
+| - resultCode | Integer | O | 結果コード |
+| - resultMessage | String | O | 結果メッセージ |
+| - isSuccessful | Boolean | O | 成功可否 |
+| totalCount | Integer | O | 総数 |
+| brandmessageDeliveryStatistics | List | O | ブランドメッセージ送信統計リスト |
+| - date | String | O | 日付 |
+| - messageSpec | String | O | メッセージスペック（BASIC: 基本型、FREESTYLE: 自由型） |
+| - chatBubbleType | String | O | 吹き出しタイプ（TEXT: テキスト型、IMAGE: 画像型、WIDE: ワイド画像型、WIDE_ITEM_LIST: ワイドアイテムリストタイプ、CAROUSEL_FEED: カルーセルフィードタイプ、PREMIUM_VIDEO: プレミアム動画型、COMMERCE: コマースタイプ、CAROUSEL_COMMERCE: カルーセルコマースタイプ） |
+| - targeting | String | O | ターゲティング（M: マーケティング受信同意ユーザー全体、N: チャンネルフレンド除外、I: チャンネルフレンドのみ、F: チャンネルフレンド全体） |
+| - friendType | String | O | フレンドタイプ（F: フレンド、N: 非フレンド） |
+| - receiveUserType | String | O | 受信者タイプ（PhoneNumber: 電話番号、None: 受信者識別子なし） |
+| - totalSendRequestCount | Integer | O | 総送信リクエスト数 |
+| - validSendRequestCount | Integer | O | 有効送信リクエスト数 |
+| - validReadCount | Integer | O | 有効閲覧数 |
+| - totalClickCount | Integer | O | 総クリック数 |
+
+### ブランドメッセージテンプレート統計照会
+
+<!-- TODO: translate body -->
+
+#### 要請
+
+[URL]
+
+|Http method| URI|
+|---|---|
+|GET| /common/v2.2/appkeys/{appKey}/kakao-statistics/template-statistics/BRANDMESSAGE |
+
+[Path parameter]
+
+| 名前 | タイプ | 説明 |
+|---|---|---|
+| appKey | String | 一意のアプリキー |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前 | タイプ | 必須 | 説明 |
+|---|---|---|---|
+| X-Secret-Key | String | O | コンソールで作成できます。 |
+
+[Query parameter]
+
+| 名前 | タイプ | 必須 | 説明 |
+|---|---|---|---|
+| senderKey | String | O | 発信キー |
+| periodType | String | O | 統計区分（DAILY: 日別、MONTHLY: 月別） |
+| startDate | String | O | 照会開始日付<br/>DAILY: yyyy-MM-dd（直近90日以内）、MONTHLY: yyyy-MM（直近3ヶ月以内） |
+| endDate | String | O | 照会終了日付<br/>DAILY: yyyy-MM-dd（最大範囲90日）、MONTHLY: yyyy-MM（最大範囲3ヶ月） |
+| kakaoTemplateCode | String | X | カカオテンプレートコード |
+| groupTagKey | String | X | グループタグキー |
+| messageSpec | String | X | メッセージスペック（BASIC: 基本型、FREESTYLE: 自由型） |
+| chatBubbleType | String | X | 吹き出しタイプ（TEXT: テキスト型、IMAGE: 画像型、WIDE: ワイド画像型、WIDE_ITEM_LIST: ワイドアイテムリスト型、CAROUSEL_FEED: カルーセルフィード型、PREMIUM_VIDEO: プレミアム動画型、COMMERCE: コマース型、CAROUSEL_COMMERCE: カルーセルコマース型） |
+| targeting | String | X | ターゲティング（M: マーケティング受信同意ユーザー全体、N: チャンネルフレンド除外、I: チャンネルフレンドのみ、F: チャンネルフレンド全体） |
+| friendType | String | X | フレンドタイプ（F: フレンド、N: 非フレンド） |
+| limit | Integer | X | 照会件数（Default: 500、Max: 1000） |
+| offset | Integer | X | 開始位置（Default: 0） |
+
+#### レスポンス
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "success",
+        "isSuccessful": true
+    },
+    "totalCount": 1,
+    "brandmessageTemplateStatistics": [
+        {
+            "date": "2026-04-01",
+            "templateCode": "brandtemplate01",
+            "groupTagKey": "group01",
+            "messageSpec": "TEMPLATE",
+            "chatBubbleType": "TEXT",
+            "targeting": "ALL",
+            "friendType": "ALL",
+            "totalSendSuccessCount": 180,
+            "validReadCount": 140,
+            "totalClickCount": 55
+        }
+    ]
+}
+```
+
+| 名前 | タイプ | Not Null | 説明 |
+|---|---|:---:|---|
+| header | Object | O | ヘッダー領域 |
+| - resultCode | Integer | O | 結果コード |
+| - resultMessage | String | O | 結果メッセージ |
+| - isSuccessful | Boolean | O | 成功可否 |
+| totalCount | Integer | O | 総件数 |
+| brandmessageTemplateStatistics | List | O | ブランドメッセージテンプレート統計リスト |
+| - date | String | O | 日付 |
+| - templateCode | String | O | テンプレートコード |
+| - groupTagKey | String | X | グループタグキー |
+| - messageSpec | String | O | メッセージ仕様（BASIC：基本型、FREESTYLE：自由型） |
+| - chatBubbleType | String | O | チャットバブルタイプ（TEXT：テキスト型、IMAGE：画像型、WIDE：ワイド画像型、WIDE_ITEM_LIST：ワイドアイテムリスト型、CAROUSEL_FEED：カルーセルフィード型、PREMIUM_VIDEO：プレミアムビデオ型、COMMERCE：コマース型、CAROUSEL_COMMERCE：カルーセルコマース型） |
+| - targeting | String | O | ターゲティング（M：マーケティング受信同意ユーザー全体、N：チャンネルフレンド除外、I：チャンネルフレンドのみ、F：チャンネルフレンド全体） |
+| - friendType | String | O | フレンドタイプ（F：フレンド、N：非フレンド） |
+| - totalSendSuccessCount | Integer | O | 総送信成功件数 |
+| - validReadCount | Integer | O | 有効閲覧件数 |
+| - totalClickCount | Integer | O | 総クリック件数 |
+

--- a/ja/friendtalk-api-guide-v1.4.md
+++ b/ja/friendtalk-api-guide-v1.4.md
@@ -1,5 +1,11 @@
 ## Notification > KakaoTalk Bizmessage > カカともへのメッセージ > API v1.4 Guide
 
+## フレンドトークサービス終了案内
+
+* 2025-12-31（水）フレンドトークサービスのサポートを終了します。
+* 既存のご利用中のお客様には、ブランドメッセージへの移行をお勧めします。
+* 詳細については、[ブランドメッセージ移行ガイド](https://docs.nhncloud.com/ja/Notification/KakaoTalk%20Bizmessage/ko/friendtalk-compatible-api-guide)を参照してください。
+
 ## カカともへのメッセージ
 
 #### [APIドメイン]

--- a/ja/friendtalk-api-guide-v1.5.md
+++ b/ja/friendtalk-api-guide-v1.5.md
@@ -1,5 +1,11 @@
 ## Notification > KakaoTalk Bizmessage > カカともへのメッセージ > API v1.5 Guide
 
+## フレンドトークサービス終了案内
+
+* 2025-12-31(水) フレンドトークサービスの提供を終了します。
+* 現在ご利用中のお客様には、ブランドメッセージへの移行をお勧めします。
+* 詳細については、[ブランドメッセージ移行ガイド](https://docs.nhncloud.com/ja/Notification/KakaoTalk%20Bizmessage/ko/friendtalk-compatible-api-guide)を参照してください。
+
 ## カカともへのメッセージ
 
 #### [APIドメイン]


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Existing body text is never modified.** The heading match only sees outlines and edits heading lines. Missing sections, however, get a **machine-translated body** (58 section[s] this run) — review the translated wording before merging.

## Analysis

| | |
| --- | --- |
| Engine | `claude-code (CLI)` |
| Model | `claude-sonnet-4-20250514` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `master` |
| Scope | 32 doc(s); 15 file(s) changed |
| Self-verify | ⚠️ 14 mismatch(es) remain |
| Jenkins build | http://testlab.cloud.toastoven.net:8080/job/user-guide-agent/job/align-heading/job/260521/46/ |
| Generated | 2026-06-09T12:13:53 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`master`): [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FAlimtalk%2Ftree%2Fmaster&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FAlimtalk%2Fpull%2F218&source=ko&langs=en%2Cja)

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra removed | verify |
| --- | --: | --: | --: | --: | --: | --: | :--: |
| `en/alimtalk-api-guide-v1.4.md` | 0 | 8 | 6 | 0 | 0 | 0 | ✅ |
| `en/alimtalk-api-guide-v1.5.md` | 0 | 5 | 4 | 0 | 0 | 0 | ✅ |
| `en/alimtalk-api-guide-v2.0.md` | 1 | 5 | 4 | 0 | 1 | 0 | ⚠️ 3 |
| `ja/alimtalk-api-guide-v2.0.md` | 1 | 0 | 0 | 0 | 1 | 0 | ⚠️ 3 |
| `en/alimtalk-api-guide-v2.1.md` | 1 | 5 | 4 | 0 | 1 | 0 | ⚠️ 3 |
| `ja/alimtalk-api-guide-v2.1.md` | 0 | 1 | 1 | 0 | 2 | 0 | ⚠️ 2 |
| `ja/alimtalk-api-guide-v2.2.md` | 0 | 1 | 1 | 0 | 2 | 0 | ⚠️ 2 |
| `en/alimtalk-api-guide.md` | 0 | 1 | 0 | 0 | 1 | 0 | ⚠️ 1 |
| `en/common-api-guide.md` | 0 | 15 | 11 | 0 | 0 | 0 | ✅ |
| `ja/common-api-guide.md` | 0 | 15 | 11 | 0 | 0 | 0 | ✅ |
| `en/friendtalk-api-guide-v1.4.md` | 0 | 10 | 7 | 0 | 0 | 0 | ✅ |
| `ja/friendtalk-api-guide-v1.4.md` | 0 | 1 | 1 | 0 | 0 | 0 | ✅ |
| `en/friendtalk-api-guide-v1.5.md` | 0 | 10 | 7 | 0 | 0 | 0 | ✅ |
| `ja/friendtalk-api-guide-v1.5.md` | 0 | 1 | 1 | 0 | 0 | 0 | ✅ |
| `en/friendtalk-api-guide-v2.0.md` | 0 | 10 | 0 | 0 | 0 | 0 | ✅ |

<details><summary>남은 불일치 (검토 필요)</summary>

- `en/alimtalk-api-guide-v2.0.md`:
  - extra_in_target (ko#None/en#14)
  - extra_in_target (ko#None/en#23)
  - missing_in_target (ko#34/en#None)
- `ja/alimtalk-api-guide-v2.0.md`:
  - extra_in_target (ko#None/ja#14)
  - extra_in_target (ko#None/ja#23)
  - missing_in_target (ko#34/ja#None)
- `en/alimtalk-api-guide-v2.1.md`:
  - extra_in_target (ko#None/en#14)
  - extra_in_target (ko#None/en#23)
  - missing_in_target (ko#34/en#None)
- `ja/alimtalk-api-guide-v2.1.md`:
  - extra_in_target (ko#None/ja#13)
  - extra_in_target (ko#None/ja#23)
- `ja/alimtalk-api-guide-v2.2.md`:
  - extra_in_target (ko#None/ja#13)
  - extra_in_target (ko#None/ja#23)
- `en/alimtalk-api-guide.md`:
  - extra_in_target (ko#None/en#92)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/Alimtalk`