### PR TITLE
chore(pre-align): align heading structure with ko

### DIFF
--- a/en/alimtalk-api-guide.md
+++ b/en/alimtalk-api-guide.md
@@ -1,6 +1,10 @@
 ## Notification > KakaoTalk Bizmessage > AlimTalk > API v2.3 Guide
 
+<a id="alimtalk"></a>
+
 ## AlimTalk
+
+<a id="api-domain"></a>
 
 #### [API Domain]
 
@@ -17,6 +21,8 @@
 </tbody>
 </table>
 
+<a id="overview-of-v23-api"></a>
+
 ## Overview of v2.3 API
 1. Added Quick Reply, Item List, Talk Biz plugin, Main Link, and Business Form button.
 
@@ -24,7 +30,11 @@
 3. Added APIs to register, modify, delete, and retrieve AlimTalk plugins.
 4. Removed the buttons field from the API to retrieve message list.
 
+<a id="general-messages"></a>
+
 ## General Messages
+
+<a id="request-of-sending-replaced-messages"></a>
 
 ### Request of Sending Replaced Messages
 
@@ -151,6 +161,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages -d '{"senderKey":"{outgoing key}","templateCode":"{template code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{incoming number}","templateParameter":{"{replacer field}":"{replacement data}"}}]}'
 ```
 
+<a id="response"></a>
+
 #### Response
 
 ```
@@ -191,6 +203,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 |-- resultCode | Integer | Result code of delivery request |
 |-- resultMessage | String | Result message of delivery request |
 |-- recipientGroupingKey | String | Recipient's grouping key |
+
+<a id="request-of-sending-full-text"></a>
 
 ### Request of Sending Full Text
 
@@ -384,6 +398,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/raw-messages -d '{"senderKey":"{outgoing key}","templateCode":"{template code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{incoming number}","content":"{content}","buttons":[{"ordering":"{button sequence}","type":"{button type}","name":"{button name}","linkMo":"{mobile web link}"}]}]}'
 ```
 
+<a id="response-2"></a>
+
 #### Response
 
 ```
@@ -425,7 +441,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 |-- resultMessage | String | Result message of delivery request |
 |-- recipientGroupingKey | String | Recipient's grouping key |
 
+<a id="list-messages"></a>
+
 ### List Messages
+
+<a id="request"></a>
 
 #### Request
 
@@ -474,6 +494,8 @@ Content-Type: application/json;charset=UTF-8
 
 * Cannot query data requested for delivery which are dated before 90 days.
 * The maximum available days for delivery request is 30 days.
+
+<a id="response-3"></a>
 
 #### Response
 ```
@@ -544,7 +566,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<a id="get-messages"></a>
+
 ### Get Messages
+
+<a id="request-2"></a>
 
 #### Request
 
@@ -577,6 +603,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-4"></a>
 
 #### Response
 ```
@@ -755,6 +783,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |- senderGroupingKey | String | Sender's grouping key                                                                                                                                                                                              |
 |- recipientGroupingKey | String | 	Recipient's grouping key                                                                                                                                                                                          |
 
+<a id="authentication-messages"></a>
+
 ## Authentication Messages
 
 <span id="precautions-authword"></span>
@@ -767,6 +797,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 - Example 1-1) Delivery shall fail if the full text(including template replacement) does not include authentication words, in the request of Authentication Messages API(for emergency)
 - Example 1-2) Validity for English words shall be checked regardless of small or capital letters
 
+
+<a id="request-of-sending-replaced-messages-2"></a>
 
 ### Request of Sending Replaced Messages
 
@@ -797,6 +829,8 @@ Content-Type: application/json;charset=UTF-8
 [Request body]
 [Same as the above](./alimtalk-api-guide/#request-of-sending-replaced-messages)
 
+<a id="request-of-sending-full-text-2"></a>
+
 ### Request of Sending Full Text
 
 [URL]
@@ -826,7 +860,11 @@ Content-Type: application/json;charset=UTF-8
 [Request Body]
 [Same as the above](./alimtalk-api-guide/#request-of-sending-full-text)
 
+<a id="list-messages-2"></a>
+
 ### List Messages
+
+<a id="request-3"></a>
 
 #### Request
 
@@ -856,7 +894,11 @@ Content-Type: application/json;charset=UTF-8
 [Query parameter]
 [Same as the above](./alimtalk-api-guide/#list-messages)
 
+<a id="get-messages-2"></a>
+
 ### Get Messages
+
+<a id="request-4"></a>
 
 #### Request
 
@@ -890,11 +932,19 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/messages/{requestId}/{recipientSeq}"
 ```
 
+<a id="response-5"></a>
+
 #### Response
 [Same as the above](./alimtalk-api-guide/#get-messages)
 
+<a id="message"></a>
+
 ## Message
+<a id="cancel-sending-messages"></a>
+
 ### Cancel Sending Messages
+
+<a id="request-5"></a>
 
 #### Request
 
@@ -930,6 +980,8 @@ Content-Type: application/json;charset=UTF-8
 
 * Both general and authentication messages can be canceled by the same API.
 
+<a id="response-6"></a>
+
 #### Response
 ```
 {
@@ -953,7 +1005,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
 ```
 
+<a id="query-updates-of-message-result"></a>
+
 ### Query Updates of Message Result
+
+<a id="request-6"></a>
 
 #### Request
 
@@ -989,6 +1045,8 @@ Content-Type: application/json;charset=UTF-8
 |alimtalkMessageType|	String| X |	AlimTalk message type(NORMAL, AUTH) |
 |pageNum|	Integer|	X|	Page number(default: 1)|
 |pageSize|	Integer|	X|	Number of queries(default: 15, Max: 1000)|
+
+<a id="response-7"></a>
 
 #### Response
 ```
@@ -1042,7 +1100,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/message-results?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
+<a id="query-the-number-of-message-result-updates"></a>
+
 ### Query the Number of Message Result Updates
+
+<a id="request-7"></a>
 
 #### Request
 
@@ -1079,6 +1141,8 @@ Content-Type: application/json;charset=UTF-8
 | endUpdateDate       | 	String  | O   | 	Result update query end time (yyyy-MM-dd HH:mm) |
 | alimtalkMessageType | 	String  | X   | 	AlimTalk message type (NORMAL, AUTH)           |
 
+<a id="response-8"></a>
+
 #### Response
 
 ```
@@ -1106,6 +1170,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/message-results/count?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
+<a id="status-code-of-smslms-resending"></a>
+
 ### Status Code of SMS/LMS Resending
 | Name |	Description|
 |---|---|
@@ -1115,8 +1181,14 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |RSC04|	Resending successful|
 |RSC05|	Resending failed|
 
+<a id="mass-delivery"></a>
+
 ## Mass Delivery
+<a id="list-mass-delivery-requests"></a>
+
 ### List Mass Delivery Requests
+
+<a id="request-8"></a>
 
 #### Request
 [URL]
@@ -1156,6 +1228,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum | optional, Integer | - | X | Page number |
 | pageSize | optional, Integer | 1000 | X | Search count |
 
+<a id="curl"></a>
+
 #### cURL
 ```
 curl -X GET \
@@ -1163,6 +1237,8 @@ curl -X GET \
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-9"></a>
 
 #### Response
 ```
@@ -1219,7 +1295,11 @@ curl -X GET \
 | - totalCount | Integer | Total count |
 
 
+<a id="list-mass-delivery-recipients"></a>
+
 ### List Mass Delivery Recipients
+
+<a id="request-9"></a>
 
 #### Request
 [URL]
@@ -1258,6 +1338,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum | optional, Integer | - | X | Page number |
 | pageSize | optional, Integer | 1000 | X | Search count |
 
+<a id="curl-2"></a>
+
 #### cURL
 ```
 curl -X GET \
@@ -1265,6 +1347,8 @@ curl -X GET \
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-10"></a>
 
 #### Response
 ```
@@ -1310,7 +1394,11 @@ curl -X GET \
 | -- resultCodeName | String | Result code content |
 | - totalCount | Integer | Total count |
 
+<a id="get-a-mass-delivery-recipient"></a>
+
 ### Get a Mass Delivery Recipient
+
+<a id="request-10"></a>
 
 #### Request
 [URL]
@@ -1350,6 +1438,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum | optional, Integer | - | X | Page number |
 | pageSize | optional, Integer | 1000 | X | Search count |
 
+<a id="curl-3"></a>
+
 #### cURL
 ```
 curl -X GET \
@@ -1357,6 +1447,8 @@ curl -X GET \
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-11"></a>
 
 #### Response
 ```
@@ -1524,9 +1616,15 @@ curl -X GET \
 | -- bizFormId|	String| 	Plugin ID(up to 24 characters) |
 | -- target|	String| 	In the case of a web link type, out link used when adding "target":"out" attribute<br>Send with the default in-app link |
 
+<a id="templates"></a>
+
 ## Templates
 
+<a id="list-template-categories"></a>
+
 ### List Template Categories
+<a id="request-11"></a>
+
 #### Request
 [URL]
 
@@ -1550,6 +1648,8 @@ Content-Type: application/json;charset=UTF-8
 | Name |	Type|	Required|	Description|
 |---|---|---|---|
 |X-Secret-Key|	String| O | Can be created on console.   |
+
+<a id="response-12"></a>
 
 #### Response
 ```
@@ -1592,7 +1692,11 @@ Content-Type: application/json;charset=UTF-8
 |-- inclusion | String |	Description of templates to which the category applies |
 |-- exclusion| String| Description of templates to which the category does not apply |
 
+<a id="register-templates"></a>
+
 ### Register Templates
+<a id="request-12"></a>
+
 #### Request
 [URL]
 
@@ -1744,6 +1848,8 @@ Content-Type: application/json;charset=UTF-8
 * The Add Channel(AC) button must be registered with a fixed button name of "Add Channel".
 
 
+<a id="response-13"></a>
+
 #### Response
 ```
 {
@@ -1762,7 +1868,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="modify-templates"></a>
+
 ### Modify Templates
+<a id="request-13"></a>
+
 #### Request
 [URL]
 
@@ -1909,6 +2019,8 @@ Content-Type: application/json;charset=UTF-8
 * The Add Chanel button must be in the first when modifying the AD included(AD) or Mixed Purposes(MI) message type template.
 * The Add Channel(AC) button must be modified with a fixed button name of "Add Channel".
 
+<a id="response-14"></a>
+
 #### Response
 ```
 {
@@ -1927,7 +2039,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="delete-templates"></a>
+
 ### Delete Templates
+<a id="request-14"></a>
+
 #### Request
 [URL]
 
@@ -1955,6 +2071,8 @@ Content-Type: application/json;charset=UTF-8
 * A template remaining in Kakao becomes dormant if it is not used for 1 year, and gets deleted if it remains dormant for 1 year.(If a template becomes dormant or gets deleted on Kakao, the person in charge will be notified.)
 
 
+<a id="response-15"></a>
+
 #### Response
 ```
 {
@@ -1973,7 +2091,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="inquire-of-templates"></a>
+
 ### Inquire of Templates
+<a id="request-15"></a>
+
 #### Request
 [URL]
 
@@ -2014,6 +2136,8 @@ Content-Type: application/json;charset=UTF-8
 
 * When commenting a template in the REJ status, it will be changed to the REQ status.
 
+<a id="response-16"></a>
+
 #### Response
 ```
 {
@@ -2032,7 +2156,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="send-inquiry-on-templates-with-file-attachment"></a>
+
 ### Send Inquiry on Templates with File Attachment
+<a id="request-16"></a>
+
 #### Request
 [URL]
 
@@ -2075,6 +2203,8 @@ Content-Type: application/json;charset=UTF-8
 
 * When commenting a template in the REJ status, it will be changed to the REQ status.
 
+<a id="response-17"></a>
+
 #### Response
 ```
 {
@@ -2093,7 +2223,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="change-template-to-channel-add-type"></a>
+
 ### Change Template to Channel-Add Type
+
+<a id="request-17"></a>
 
 #### Request
 [URL]
@@ -2122,6 +2256,8 @@ Content-Type: application/json;charset=UTF-8
 
 * The template registered in sender group cannot be converted to a add-channel type.
 
+<a id="response-18"></a>
+
 #### Response
 ```
 {
@@ -2140,7 +2276,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="single-query-for-template"></a>
+
 ### Single Query for Template
+
+<a id="request-18"></a>
 
 #### Request
 
@@ -2183,6 +2323,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}"
 ```
+
+<a id="response-19"></a>
 
 #### Response
 
@@ -2362,7 +2504,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - createDate | String | O | Created at |
 | - updateDate | String | X | Modified at |
 
+<a id="list-templates"></a>
+
 ### List Templates
+
+<a id="request-19"></a>
 
 #### Request
 
@@ -2411,6 +2557,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates?templateStatus={template status code}"
 ```
+
+<a id="response-20"></a>
 
 #### Response
 ```
@@ -2587,7 +2735,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- updateDate            | String | Date of modification                                                                                                                                                                                                                                                                                   |
 | - totalCount             | Integer | Total count                                                                                                                                                                                                                                                                                            |
 
+<a id="list-template-modifications"></a>
+
 ### List Template modifications
+
+<a id="request-20"></a>
 
 #### Request
 
@@ -2620,6 +2772,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}/modifications"
 ```
+
+<a id="response-21"></a>
 
 #### Response
 ```
@@ -2772,7 +2926,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |-- updateDate | String | Date of modification |
 |- totalCount | Integer | Total count |
 
+<a id="register-template-image"></a>
+
 ### Register Template Image
+<a id="request-21"></a>
+
 #### Request
 [URL]
 
@@ -2808,6 +2966,8 @@ Content-Type: multipart/form-data
 curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/template-image" -F "file=@alimtalk-template-image.jpeg"
 ```
 
+<a id="response-22"></a>
+
 #### Response
 ```
 {
@@ -2833,7 +2993,11 @@ curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}
 |- templateImageName | String |	Image name(name of uploaded file) |
 |- templateImageUrl | String |	Image URL |
 
+<a id="register-template-item-highlight-images"></a>
+
 ### Register Template Item Highlight Images
+<a id="request-22"></a>
+
 #### Request
 [URL]
 
@@ -2869,6 +3033,8 @@ Content-Type: multipart/form-data
 curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/template-image/item-highlight" -F "file=@alimtalk-template-image.jpeg"
 ```
 
+<a id="response-23"></a>
+
 #### Response
 ```
 {
@@ -2894,7 +3060,11 @@ curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}
 |- templateImageName | String |	Image name(name of uploaded file) |
 |- templateImageUrl | String |	Image URL |
 
+<a id="register-template-plugin"></a>
+
 ### Register Template Plugin
+<a id="request-23"></a>
+
 #### Request
 [URL]
 
@@ -2936,6 +3106,8 @@ Content-Type: application/json;charset=UTF-8
 |pluginId|	String |	O | Plugin ID |
 |callbackUrl|	String |	O | The callback URL to receive when the plugin button is clicked |
 
+<a id="response-24"></a>
+
 #### Response
 ```
 {
@@ -2954,7 +3126,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="modify-template-plugin"></a>
+
 ### Modify Template Plugin
+<a id="request-24"></a>
+
 #### Request
 [URL]
 
@@ -2995,6 +3171,8 @@ Content-Type: application/json;charset=UTF-8
 |pluginType|	String |	O | Plugin type(SECURE_IMAGE: secure image transmission, ONE_TIME_PROFILE: personal information use) |
 |callbackUrl|	String |	O | The callback URL to receive when the plugin button is clicked |
 
+<a id="response-25"></a>
+
 #### Response
 ```
 {
@@ -3013,7 +3191,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="modify-template-plugin-2"></a>
+
 ### Modify Template Plugin
+<a id="request-25"></a>
+
 #### Request
 [URL]
 
@@ -3040,6 +3222,8 @@ Content-Type: application/json;charset=UTF-8
 |---|---|---|---|
 |X-Secret-Key|	String| O | Can be created on console.   |
 
+<a id="response-26"></a>
+
 #### Response
 ```
 {
@@ -3058,7 +3242,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="retrieve-template-plugin"></a>
+
 ### Retrieve Template Plugin
+<a id="request-26"></a>
+
 #### Request
 [URL]
 
@@ -3083,6 +3271,8 @@ Content-Type: application/json;charset=UTF-8
 | Name |	Type|	Required|	Description|
 |---|---|---|---|
 |X-Secret-Key|	String| O | Can be created on console.   |
+
+<a id="response-27"></a>
 
 #### Response
 ```
@@ -3120,7 +3310,11 @@ Content-Type: application/json;charset=UTF-8
 |- modifiable|	Boolean| Modifiable |
 |- deletable|	Boolean| Deletable |
 
+<a id="manage-alternative-delivery"></a>
+
 ## Manage Alternative Delivery
+<a id="register-an-sms-appkey"></a>
+
 ### Register an SMS AppKey
 
 [URL]
@@ -3164,6 +3358,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
 ```
 
+<a id="response-28"></a>
+
 #### Response
 ```
 
@@ -3175,6 +3371,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
   }
 }
 ```
+
+<a id="register-alternative-delivery-settings"></a>
 
 ### Register Alternative Delivery Settings
 
@@ -3222,6 +3420,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/failback/appkey -d '{"senderKey": "0be23c29de88d6888798aeda57062516354d74ba","isResend": true,"resendSendNo": "01012341234" }
 ```
+
+<a id="response-29"></a>
 
 #### Response
 ```

--- a/ja/alimtalk-api-guide-align-v2.md
+++ b/ja/alimtalk-api-guide-align-v2.md
@@ -1,0 +1,3331 @@
+## Notification > KakaoTalk Bizmessage > お知らせトーク > API v2.3 Guide
+
+<a id="alimtalk"></a>
+
+## お知らせトーク
+
+<a id="api-domain"></a>
+
+#### [APIドメイン]
+
+<table>
+<thead>
+<tr>
+<th>ドメイン</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>https://kakaotalk-bizmessage.api.nhncloudservice.com</td>
+</tr>
+</tbody>
+</table>
+
+<a id="overview-of-v23-api"></a>
+
+## v2.3 API紹介
+1. お知らせトーク大量送信照会、統計照会APIが追加されました。
+2. 置換メッセージ送信時、buttonsフィールドが追加されました。
+3. 専門メッセージ送信時、buttonsフィールドにchatExtra、chatEvent、targetフィールドが追加されました。
+4. メッセージ照会時、buttonsフィールドにchatExtra、chatEvent、targetフィールドが追加されました。
+
+<a id="general-messages"></a>
+
+## 一般メッセージ
+
+<a id="request-of-sending-replaced-messages"></a>
+
+### メッセージ置換送信リクエスト
+
+[URL]
+
+```
+POST  /alimtalk/v2.3/appkeys/{appkey}/messages
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 値 | タイプ | 説明 |
+| ------ | ------ | ------ |
+| appkey | String | 固有のアプリキー |
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| 値    | タイプ | 必須 | 説明                               |
+| ------------ | ------ | ---- | ---------------------------------------- |
+| X-Secret-Key | String | O    | コンソールで作成できます。 |
+|X-NC-API-IDEMPOTENCY-KEY|	String| X | 重複メッセージ送信要求基準key<br>10分間同じkeyで要求すると、その要求を失敗処理します。 |
+
+[Request body]
+
+
+```
+{
+    "senderKey": String,
+    "templateCode": String,
+    "requestDate": String,
+    "senderGroupingKey": String,
+    "createUser": String,
+    "recipientList": [{
+        "recipientNo": String,
+        "templateParameter": {
+            String: String
+        },
+        "resendParameter": {
+          "isResend": boolean,
+          "resendType": String,
+          "resendTitle": String,
+          "resendContent": String,
+          "resendSendNo": String
+        },
+        "buttons": [
+          {
+            "ordering": Integer,
+            "chatExtra": String,
+            "chatEvent": String,
+            "relayId": String,
+            "oneClickId": String,
+            "productId": String,
+            "target": String,
+            "telNumber": String
+          }
+        ],
+        "quickReplies": [
+            "ordering": Integer,
+            "chatExtra": String,
+            "chatEvent": String,
+            "target": String
+        ],
+        "recipientGroupingKey": String
+    }],
+    "messageOption": {
+      "price": Integer,
+      "currencyType": String
+    },
+    "statsId": String
+}
+```
+
+| 値               | タイプ | 必須 | 説明                                |
+| ---------------------- | ------- | ---- | ---------------------------------------- |
+| senderKey              | String  | O    | 発信キー                            |
+| templateCode           | String  | O    | 登録した送信テンプレートコード(最大20桁)                    |
+| requestDate            | String  | X    | リクエスト日時(yyyy-MM-dd HH:mm)<br>(入力しない場合は即時送信)<br>最大60日後まで予約可能 |
+| senderGroupingKey      | String  | X    | 発信グルーピングキー(最大100文字)                        |
+| createUser             | String  | X    | 登録者(コンソールから送信する場合、ユーザーUUIDとして保存)|
+| recipientList          | List    | O    | 受信者リスト(最大1000人)                         |
+| - recipientNo          | String  | O    | 受信番号(最大15桁)                            |
+| - templateParameter    | Object  | X    | テンプレートパラメータ<br>(テンプレートに置換する変数が含まれる時は必須)       |
+| -- key                 | String  | X    | 置換キー(#{key})                             |
+| -- value               | String  | X    | 置換キーにマッピングされるvalue値                |
+| - resendParameter      | Object  | X    | 代替発送情報 |
+| -- isResend            | boolean | X    | 送信失敗時、代替送信するかどうか<br>コンソールで送信失敗設定をした時、デフォルト設定は再送信になっています。 |
+| -- resendType          | String  | X    | 代替送信タイプ(SMS、LMS)<br>値がない場合は、テンプレート本文の長さに応じてタイプが決まります。 |
+| -- resendTitle         | String  | X    | LMS代替送信タイトル(最大20文字)<br>(値がない場合は、プラスフレンドIDで再送信されます。) |
+| -- resendContent       | String  | X    | 代替送信内容(最大1000文字)<br>(値がない場合は、テンプレートの内容で再送信されます。) |
+| -- resendSendNo        | String  | X    | 代替送信発信番号(最大13桁)<br><span style="color:red">(SMSサービスに登録された発信番号ではない場合、代替送信が失敗することがあります。)</span> |
+| - buttons              | List    | X    | ボタン追加情報 |
+| -- ordering            | Integer | X    |	ボタン順序(ボタンがある場合は必須) |
+| -- chatExtra           | String  | X    |	BC(相談トークに切替) / BT(Botに切替)タイプボタンの時、伝達するメタ情報 |
+| -- chatEvent           | String  | X    |	BT(Bot切替)タイプボタンの時、接続するBotイベント名 |
+| -- target              | String  | X    |	Webリンクボタンの場合、"target":"out"プロパティ追加時のアウトリンク<br>基本インアプリリンクで送信 |
+| -- telNumber | String | X | TN(電話する)タイプのボタンの場合、伝達する電話番号 |
+| - recipientGroupingKey | String  | X    | 受信者グルーピングキー(最大100文字)                       |
+| messageOption          | Object  | X    |	メッセージオプション                                         |
+| - price                | Integer | X    |	message(ユーザーに伝達されるメッセージ)内に含まれた価格/金額/決済金額(モーメント広告に該当) |
+| - currencyType         | String  | X    |	message(ユーザーに伝達されるメッセージ)内に含まれた価格/金額/決済金額(モーメント広告に該当) |
+| statsId                | String  | X    |	統計ID(発信検索条件には含まれません, 最大8文字) |
+
+* <b>リクエスト日時は呼び出す時点から60日後まで設定可能です。</b>
+* <b>SMSサービスで代替送信されるため、SMSサービスの送信APIの仕様に応じてフィールドを入力する必要があります。(SMSサービスに登録された発信番号、各種フィールドの長さ制限など)</b>
+* <b>SMSサービスは、国際SMSのみサポートします。国際受信者番号の場合、 resendType(代替送信タイプ)をSMSに変更すると正常に代替送信できます。</b>
+* <b>指定した代替送信タイプのバイト制限を超える代替送信のタイトルや内容は、途中で切れて代替送信されることがあります。([[SMS注意事項](https://docs.toast.com/ko/Notification/SMS/ko/api-guide/#_1)]参考)</b>
+* <b>templateTitleとtemplateItemHighlight.titleフィールドの一番後ろに日本語識別子とtemplateParameterを利用して`\s`文字を追加する場合、取り消し線スタイルを適用できます。</b>
+    * <b>ただし、テンプレート登録時にあらかじめ\sをフィールドに追加しておいた場合は適用されません。</b>
+
+[例]
+```
+curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","templateParameter":{"{日本語識別子フィールド}":"{置換データ}"}}]}'
+```
+
+<a id="response"></a>
+
+#### レスポンス
+
+```
+{
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
+  },
+  "message": {
+    "requestId": String,
+    "senderGroupingKey": String,
+    "sendResults": [
+      {
+        "recipientSeq": Integer,
+        "recipientNo": String,
+        "resultCode": Integer,
+        "resultMessage": String,
+        "recipientGroupingKey": String
+      }
+    ]
+  }
+}
+```
+
+| 値                | タイプ | 説明    |
+| ----------------------- | ------- | ------------ |
+| header                  | Object  | ヘッダ領域 |
+| - resultCode            | Integer | 結果コード |
+| - resultMessage         | String  | 結果メッセージ |
+| - isSuccessful          | Boolean | 成否  |
+| message                 | Object  | 本文領域 |
+| - requestId             | String  | リクエストID        |
+| - senderGroupingKey     | String  | 発信グルーピングキー |
+| - sendResults           | Object  | 送信リクエスト結果 |
+| -- recipientSeq         | Integer | 受信者シーケンス番号 |
+| -- recipientNo          | String  | 受信番号 |
+| -- resultCode           | Integer | 送信リクエスト結果コード |
+| -- resultMessage        | String  | 送信リクエスト結果メッセージ |
+| -- recipientGroupingKey | String  | 受信者グルーピングキー |
+
+<a id="request-of-sending-full-text"></a>
+
+### メッセージ全文送信リクエスト
+
+[URL]
+
+```
+POST  /alimtalk/v2.3/appkeys/{appkey}/raw-messages
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 値 | タイプ | 説明 |
+| ------ | ------ | ------ |
+| appkey | String | 固有のアプリキー |
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| 値    | タイプ | 必須 | 説明                               |
+| ------------ | ------ | ---- | ---------------------------------------- |
+| X-Secret-Key | String | O    | コンソールで作成できます。 |
+|X-NC-API-IDEMPOTENCY-KEY|	String| X | 重複メッセージ送信要求基準key<br>10分間同じkeyで要求すると、その要求を失敗処理します。 |
+
+[Request body]
+
+```
+{
+    "senderKey": String,
+    "templateCode": String,
+    "requestDate": String,
+    "senderGroupingKey": String,
+    "createUser": String,
+    "recipientList": [
+        {
+            "recipientNo": String,
+            "content": String,
+            "templateTitle": String,
+            "templateHeader": String,
+            "templateItem": {
+              "list": [{
+                "title": String,
+                "description": String
+              }],
+              "summary": {
+                "title": String,
+                "description": String
+              }
+            },
+            "templateItemHighlight": {
+              "title": String,
+              "description": String,
+              "imageUrl": String
+            },
+            "templateRepresentLink": {
+              "linkMo": String,
+              "linkPc": String,
+              "schemeIos": String,
+              "schemeAndroid": String,
+            },
+            "buttons": [
+                {
+                    "ordering": Integer,
+                    "type": String,
+                    "name": String,
+                    "linkMo": String,
+                    "linkPc": String,
+                    "schemeIos": String,
+                    "schemeAndroid": String,
+                    "chatExtra": String,
+                    "chatEvent": String,
+                    "bizFormId": Integer,
+                    "pluginId": String,
+                    "relayId": String,
+                    "oneClickId": String,
+                    "productId": String,
+                    "target": String,
+                    "telNumber": String
+                }
+            ],
+            "quickReplies": [
+                {
+                    "ordering": Integer,
+                    "type": String,
+                    "name": String,
+                    "linkMo": String,
+                    "linkPc": String,
+                    "schemeIos": String,
+                    "schemeAndroid": String,
+                    "chatExtra": String,
+                    "chatEvent": String,
+                    "bizFormId": Integer,
+                    "target": String
+                }
+            ],
+            "resendParameter": {
+              "isResend": boolean,
+              "resendType": String,
+              "resendTitle": String,
+              "resendContent": String,
+              "resendSendNo": String
+            },
+            "recipientGroupingKey": String
+        }
+    ],
+    "messageOption": {
+      "price": Integer,
+      "currencyType": String
+    },
+    "statsId": String
+}
+```
+
+| 値               | タイプ | 必須 | 説明                                |
+| ---------------------- | ------- | ---- | ---------------------------------------- |
+| senderKey           | String  | O    | 発信キー                                   |
+| templateCode           | String  | O    | 登録した送信テンプレートコード(最大20桁)                    |
+| requestDate            | String  | X    | リクエスト日時(yyyy-MM-dd HH:mm)<br>(入力しない場合は即時送信) |
+| senderGroupingKey      | String  | X    | 発信グルーピングキー(最大100文字)                        |
+| recipientList          | List    | O    | 受信者リスト(最大1,000人)                        |
+| - recipientNo          | String  | O    | 受信番号(最大15桁)                            |
+| - content              | String  | O    | 内容(最大1300文字)                             |
+| - templateTitle        | String  | X    | テンプレートハイライトタイトル(最大50桁) |
+| - buttons              | List    | X    | ボタンリスト(最大5個)                             |
+| -- ordering            | Integer | X    | ボタン順序(ボタンがある場合は必須)                      |
+| -- type                | String  | X    | ボタンタイプ(WL：Webリンク、AL：アプリリンク、DS：配送照会、BK：Botキーワード、MD：メッセージ伝達、BC：相談トーク転換、BT：Bot転換、AC：チャンネル追加、 TN:電話発信) |
+| -- name                | String  | X    | ボタン名(ボタンがある場合は必須、最大14文字)              |
+| -- linkMo              | String  | X    | モバイルWebリンク(WLタイプの場合は必須フィールド、最大500文字)       |
+| -- linkPc              | String  | X    | PC Webリンク(WLタイプの場合は任意フィールド、最大500文字)        |
+| -- schemeIos           | String  | X    | iOSアプリリンク(ALタイプの場合は必須フィールド、最大500文字)       |
+| -- schemeAndroid       | String  | X    | Androidアプリリンク(ALタイプの場合は必須フィールド、最大500文字)   |
+| -- chatExtra           | String  | X    |	BC(相談トークに切替) / BT(Botに切替)タイプボタンの時、伝達するメタ情報 |
+| -- chatEvent           | String  | X    |	BT(Botに切替)タイプボタンの時、接続するBotイベント名 |
+| -- target              | String  | X    |	Webリンクボタンの場合、 "target":"out"プロパティ追加時のアウトリンク<br>基本インアプリリンクで送信 |
+| -- telNumber | String | X | TN(電話する)タイプのボタンの場合、伝達する電話番号 |
+| - resendParameter      | Object  | X    | 代替発送情報 |
+| -- isResend            | boolean | X    | 送信失敗時、代替送信するかどうか<br>コンソールで送信失敗設定をした時、デフォルト設定は再送信になっています。 |
+| -- resendType          | String  | X    | 代替送信タイプ(SMS、LMS)<br>値がない場合は、テンプレート本文の長さに応じてタイプが決まります。 |
+| -- resendTitle         | String  | X    | LMS代替送信タイトル(最大20文字)<br>(値がない場合は、プラスフレンドIDで再送信されます。) |
+| -- resendContent       | String  | X    | 代替送信内容(最大1000文字)<br>(値がない場合は、テンプレートの内容で再送信されます。) |
+| -- resendSendNo        | String  | X    | 代替送信発信番号(最大13桁)<br><span style="color:red">(SMSサービスに登録された発信番号ではない場合、代替送信が失敗することがあります。)</span> |
+| - recipientGroupingKey | String  | X    | 受信者グルーピングキー(最大100文字)                       |
+| messageOption          | Object  | X    |	メッセージオプション                                         |
+| - price                | Integer | X    |	message(ユーザーに伝達されるメッセージ)内に含まれた価格/金額/決済金額(モーメント広告に該当) |
+| - currencyType         | String  | X    |	message(ユーザーに伝達されるメッセージ)内に含まれた価格/金額/決済金額(モーメント広告に該当) |
+| statsId                | String  | X    |	統計ID(発信検索条件には含まれません, 最大8文字) |
+
+* <b>本文とボタンに置換が完了したデータを入れてください。</b>
+* <b>リクエスト日時は呼び出す時点から60日後まで設定可能です。</b>
+* <b>SMSサービスで代替送信されるため、SMSサービスの送信APIの仕様に応じてフィールドを入力する必要があります。(SMSサービスに登録された発信番号、各種フィールドの長さ制限など)</b>
+* <b>SMSサービスは、国際SMSのみサポートします。国際受信者番号の場合、 resendType(代替送信タイプ)をSMSに変更すると正常に代替送信できます。</b>
+* <b>指定した代替送信タイプのバイト制限を超える代替送信のタイトルや内容は、途中で切れて代替送信されることがあります。([[SMS注意事項](https://docs.toast.com/ko/Notification/SMS/ko/api-guide/#_1)]参考)<
+* <b>送信時にtemplateTitleとtemplateItemHighlight.titleフィールドの一番後ろに`\s`文字を追加すると、取り消し線スタイルを適用できます。</b>
+    * <b>ただし、テンプレート登録時にあらかじめ\sをフィールドに追加しておいた場合は適用されません。</b>
+
+[例]
+```
+curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/raw-messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","content":"{内容}","buttons":[{"ordering":"{ボタン順序}","type":"{ボタンタイプ}","name":"{ボタン名}","linkMo":"{モバイルWebリンク}"}]}]}'
+```
+
+<a id="response-2"></a>
+
+#### レスポンス
+
+```
+{
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
+  },
+  "message": {
+    "requestId": String,
+    "senderGroupingKey": String,
+    "sendResults": [
+      {
+        "recipientSeq": Integer,
+        "recipientNo": String,
+        "resultCode": Integer,
+        "resultMessage": String,
+        "recipientGroupingKey": String
+      }
+    ]
+  }
+}
+```
+
+| 値                | タイプ | 説明    |
+| ----------------------- | ------- | ------------ |
+| header                  | Object  | ヘッダ領域 |
+| - resultCode            | Integer | 結果コード |
+| - resultMessage         | String  | 結果メッセージ |
+| - isSuccessful          | Boolean | 成否  |
+| message                 | Object  | 本文領域 |
+| - requestId             | String  | リクエストID        |
+| - senderGroupingKey     | String  | 発信グルーピングキー |
+| - sendResults           | Object  | 送信リクエスト結果 |
+| -- recipientSeq         | Integer | 受信者シーケンス番号 |
+| -- recipientNo          | String  | 受信番号 |
+| -- resultCode           | Integer | 送信リクエスト結果コード |
+| -- resultMessage        | String  | 送信リクエスト結果メッセージ |
+| -- recipientGroupingKey | String  | 受信者グルーピングキー |
+
+<a id="list-messages"></a>
+
+### メッセージリストの照会
+
+<a id="request"></a>
+
+#### リクエスト
+
+[URL]
+
+```
+GET  /alimtalk/v2.3/appkeys/{appkey}/messages
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 値 | タイプ | 説明 |
+| ------ | ------ | ------ |
+| appkey | String | 固有のアプリキー |
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| 値    | タイプ | 必須 | 説明                               |
+| ------------ | ------ | ---- | ---------------------------------------- |
+| X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+[Query parameter] 1番or(2番、 3番)の条件は必須
+
+| 値             | タイプ | 必須 | 説明                                |
+| -------------------- | ------- | --------- | ---------------------------------------- |
+| requestId            | String  | 条件必須(1番) | リクエストID                                    |
+| startRequestDate     | String  | 条件必須(2番) | 送信リクエスト日の開始値(yyyy-MM-dd HH:mm)          |
+| endRequestDate       | String  | 条件必須(2番) | 送信リクエスト日の終了値(yyyy-MM-dd HH:mm)           |
+| startCreateDate      | String  | 条件必須(3番) | 登録日開始値(yyy-MM-dd HH:mm)                   |
+| endCreateDate        | String  | 条件必須(3番) | 登録日終値(yyy-MM-dd HH:mm)                    |
+| recipientNo          | String  | X         | 受信番号                             |
+| senderKey            | String  | X         | 発信キー                                 |
+| templateCode         | String  | X         | テンプレートコード                            |
+| senderGroupingKey    | String  | X         | 発信グルーピングキー                            |
+| recipientGroupingKey | String  | X         | 受信者グルーピングキー                           |
+| messageStatus        | String  | X         | リクエストステータス(COMPLETED -> 成功、FAILED -> 失敗、CANCEL -> キャンセル) |
+| resultCode           | String  | X         | 送信結果(MRC01 -> 成功、MRC02 -> 失敗)          |
+| createUser           | String  | X         | 登録者(コンソールから送信する場合、ユーザーUUIDとして保存)|
+| pageNum              | Integer | X         | ページ番号(基本：1)                            |
+| pageSize             | Integer | X         | 照会件数(基本：15、最大: 1000)                |
+
+* 90日以上前の送信リクエストデータは照会されません。
+* 送信リクエスト日時の範囲は最大30日です。
+
+<a id="response-3"></a>
+
+#### レスポンス
+```
+{
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
+  },
+  "messageSearchResultResponse": {
+    "messages": [
+    {
+      "requestId": String,
+      "recipientSeq": Integer,
+      "plusFriendId": String,
+      "senderKey": String,
+      "templateCode": String,
+      "recipientNo": String,
+      "content": String,
+      "requestDate": String,
+      "createDate": String,
+      "receiveDate": String,
+      "resendStatus": String,
+      "resendStatusName": String,
+      "messageStatus": String,
+      "resultCode": String,
+      "resultCodeName": String,
+      "createUser": String,
+      "senderGroupingKey": String,
+      "recipientGroupingKey": String
+    }
+    ],
+    "totalCount": Integer
+  }
+}
+```
+
+| 値                   | タイプ | 説明                               |
+| --------------------------- | ------- | ---------------------------------------- |
+| header                      | Object  | ヘッダ領域                            |
+| - resultCode                | Integer | 結果コード                            |
+| - resultMessage             | String  | 結果メッセージ                           |
+| - isSuccessful              | Boolean | 成否                             |
+| messageSearchResultResponse | Object  | 本文領域                            |
+| - messages                  | List    | メッセージリスト                           |
+| -- requestId                | String  | リクエストID                                    |
+| -- recipientSeq             | Integer | 受信者シーケンス番号                       |
+| -- plusFriendId             | String  | プラスフレンドID                                 |
+| -- senderKey                | String  | 発信キー                                  |
+| -- templateCode             | String  | テンプレートコード                           |
+| -- recipientNo              | String  | 受信番号                            |
+| -- content                  | String  | 本文                               |
+| -- requestDate              | String  | リクエスト日
+| -- createDate               | String  | 登録日時                            |
+| -- receiveDate              | String  | 受信日時                            |
+| -- resendStatus             | String  | 再送信ステータスコード                        |
+| -- resendStatusName         | String  | 再送信ステータスコード名                        |
+| -- messageStatus            | String  | リクエストステータス(COMPLETED -> 成功、FAILED -> 失敗、CANCEL -> キャンセル) |
+| -- createUser               | String  | 登録者(コンソールから送信する場合、ユーザーUUIDとして保存) |
+| -- resultCode               | String  | 受信結果コード                         |
+| -- resultCodeName           | String  | 受信結果コード名                         |
+| -- buttons                  | List    | ボタンリスト                            |
+| --- ordering                | Integer | ボタン順序                            |
+| --- type                    | String  | ボタンタイプ(WL：Webリンク、AL：アプリリンク、DS：配送照会、BK：Botキーワード、MD：メッセージ伝達、BC：相談トーク転換、BT：Bot転換、AC：チャンネル追加) |
+| --- name                    | String  | ボタン名                            |
+| --- linkMo                  | String  | モバイルWebリンク(WLタイプの場合は必須フィールド)                |
+| --- linkPc                  | String  | PC Webリンク(WLタイプの場合は任意フィールド)                 |
+| --- schemeIos               | String  | iOSアプリリンク(ALタイプの場合は必須フィールド)                |
+| --- schemeAndroid           | String  | Androidアプリリンク(ALタイプの場合は必須フィールド)            |
+| --- chatExtra               | String  | BC(相談トークに切替) / BT(Botに切替)タイプボタンの時、伝達するメタ情報 |
+| --- chatEvent               | String  | BT(Botに切替)タイプボタンの時、接続するBotイベント名 |
+| --- target                  | String  | Webリンクボタンの場合、 "target":"out"プロパティ追加時のアウトリンク<br>基本インアプリリンクで送信 |
+| -- telNumber | String | X | TN(電話する)タイプのボタンの場合、伝達する電話番号 |
+| -- senderGroupingKey        | String  | 発信グルーピングキー                            |
+| -- recipientGroupingKey     | String  | 受信者グルーピングキー                           |
+| - totalCount                | Integer | 総個数                              |
+
+[例]
+```
+curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
+```
+
+**SMS/LMS再送信ステータス**
+| 値 | 説明                      |
+| ----- | ------------------------------- |
+| RSC01 | 再送信の対象ではない                 |
+| RSC02 | 再送信の対象(送信結果が失敗の時、再送信が行われます。) |
+| RSC03 | 再送信中                    |
+| RSC04 | 再送信成功                  |
+| RSC05 | 再送信失敗                  |
+
+<a id="get-messages"></a>
+
+### メッセージ単件照会
+
+<a id="request-2"></a>
+
+#### リクエスト
+
+[URL]
+
+```
+GET  /alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}/{recipientSeq}
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 値    | タイプ | 説明 |
+| ------------ | ------- | ---------- |
+| appkey       | String  | 固有のアプリキー |
+| requestId    | String  | リクエストID      |
+| recipientSeq | Integer | 受信者シーケンス番号 |
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| 値    | タイプ | 必須 | 説明                               |
+| ------------ | ------ | ---- | ---------------------------------------- |
+| X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+[例]
+```
+curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}/{recipientSeq}"
+```
+
+<a id="response-4"></a>
+
+#### レスポンス
+```
+{
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
+  },
+  "message": {
+      "requestId": String,
+      "recipientSeq": Integer,
+      "plusFriendId": String,
+      "senderKey": String,
+      "templateCode": String,
+      "recipientNo": String,
+      "content": String,
+      "templateTitle": String,
+      "templateSubtitle": String,
+      "templateExtra": String,
+      "templateAd": String,
+      "templateHeader": String,
+      "templateItem": {
+        "list": [{
+          "title": String,
+          "description": String
+        }],
+        "summary": {
+          "title": String,
+          "description": String
+        }
+      },
+      "templateItemHighlight": {
+        "title": String,
+        "description": String,
+        "imageUrl": String
+      },
+      "templateRepresentLink": {
+        "linkMo": String,
+        "linkPc": String,
+        "schemeIos": String,
+        "schemeAndroid": String,
+      },
+      "requestDate": String,
+      "receiveDate": String,
+      "createDate": String,
+      "resendStatus": String,
+      "resendStatusName": String,
+      "resendResultCode": String,
+      "resendRequestId": String,
+      "messageStatus": String,
+      "resultCode": String,
+      "resultCodeName": String,
+      "createUser": String,
+      "buttons": [
+        {
+          "ordering": Integer,
+          "type": String,
+          "name": String,
+          "linkMo": String,
+          "linkPc": String,
+          "schemeIos": String,
+          "schemeAndroid": String,
+          "chatExtra": String,
+          "chatEvent": String,
+          "bizFormId": Integer,
+          "pluginId": String,
+          "relayId": String,
+          "oneClickId": String,
+          "productId": String,
+          "target": String,
+          "telNumber": String
+        }
+      ],
+      "quickReplies": [
+        {
+          "ordering": Integer,
+          "type": String,
+          "name": String,
+          "linkMo": String,
+          "linkPc": String,
+          "schemeIos": String,
+          "schemeAndroid": String,
+          "chatExtra": String,
+          "chatEvent": String,
+          "bizFormId": Integer,
+          "target": String
+          }
+      ],
+      "messageOption": {
+        "price": Integer,
+        "currencyType": String
+      },
+      "senderGroupingKey": String,
+      "recipientGroupingKey": String
+  }
+}
+```
+
+| 値               | タイプ | 説明                                |
+| ---------------------- | ------- | ---------------------------------------- |
+| header                 | Object  | ヘッダ領域                             |
+| - resultCode           | Integer | 結果コード                             |
+| - resultMessage        | String  | 結果メッセージ                            |
+| - isSuccessful         | Boolean | 成否                              |
+| message                | Object  | メッセージ                               |
+| - requestId            | String  | リクエストID                                    |
+| - recipientSeq         | Integer | 受信者シーケンス番号                        |
+| - plusFriendId         | String  | プラスフレンドID                                 |
+| - senderKey            | String  | 発信キー                                   |
+| - templateCode         | String  | テンプレートコード                            |
+| - recipientNo          | String  | 受信番号                             |
+| - content              | String  | 本文                                |
+|- templateTitle         | String  | テンプレートハイライトタイトル              |
+|- templateSubtitle      | String  | テンプレートハイライトサブタイトル           |
+|- templateExtra         | String  | テンプレート付加情報                     |
+|- templateAd            | String  | テンプレート内の受信同意または簡単な広告文句   |
+| - templateHeader | String | X | テンプレートヘッダ(最大16文字) |
+| - templateItem | Object | X | アイテム |
+| -- list | List | X | アイテムリスト(最小2件、最大10件) |
+| --- title | String | X | タイトル(最大6文字) |
+| --- description | String | X | 説明(最大23文字) |
+| -- summary | Object | X | アイテム要約情報 |
+| --- title | String | X | タイトル(最大6文字) |
+| --- description | String | X | 説明(変数及び通貨単位、数字、カンマ、ピリオドのみ使用可能、最大14文字) |
+| - templateItemHighlight | Object  |    X     | アイテムハイライト                                                                                                                                                            |
+| --- title | String | X | タイトル(最大30文字、サムネイル画像がある場合は21文字) |
+| --- description | String | X | 説明(最大19文字、サムネイル画像がある場合は13文字) |
+| --- imageUrl            | String  |    X     | サムネイル画像アドレス                                                                                                                                                           |
+| - templateRepresentLink | Object  |    X     | 代表リンク                                                                                                                                                                |
+| -- linkMo               | String  |    X     | モバイルWebリンク(最大500文字)                                                                                                                                                      |
+| -- linkPc               | String  |    X     | PC Webリンク(最大500文字)                                                                                                                                                       |
+| -- schemeIos            | String  |    X     | iOSアプリリンク(最大500文字)                                                                                                                                                      |
+| -- schemeAndroid        | String  |    X     | Androidアプリリンク(最大500文字)                                                                                                                                                    |
+| - requestDate          | String  | リクエスト日時                             |
+| - receiveDate          | String  | 受信日時                             |
+| - createDate           | String  | 登録日時                            |
+| - resendStatus         | String  | 再送信ステータスコード                         |
+| - resendStatusName     | String  | 再送信ステータスコード名                          |
+| - resendResultCode      | String  |    X     | 代替送信結果コード[SMS結果コード](https://docs.toast.com/ko/Notification/SMS/ko/error-code/#api)                                                                                 |
+| - resendRequestId       | String  |    X     | 代替送信SMSリクエストID                                                                                                                                                        |
+| - messageStatus        | String  | リクエストステータス(COMPLETED -> 成功、FAILED -> 失敗、CANCEL -> キャンセル) |
+| - resultCode           | String  | 受信結果コード                          |
+| - resultCodeName       | String  | 受信結果コード名                           |
+| - createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
+| - buttons              | List    | ボタンリスト                             |
+| -- ordering            | Integer | ボタン順序                             |
+| -- type                | String  | ボタンタイプ(WL：Webリンク、AL：アプリリンク、DS：配送照会、BK：Botキーワード、MD：メッセージ伝達、BC：相談トーク転換、BT：Bot転換、AC：チャンネル追加、 TN:電話発信) |
+| -- name                | String  | ボタン名                             |
+| -- linkMo              | String  | モバイルWebリンク(WLタイプの場合は必須フィールド)                |
+| -- linkPc              | String  | PC Webリンク(WLタイプの場合は任意フィールド)                 |
+| -- schemeIos           | String  | iOSアプリリンク(ALタイプの場合は必須フィールド)                |
+| -- schemeAndroid       | String  | Androidアプリリンク(ALタイプの場合は必須フィールド)            |
+| -- chatExtra           | String  | BC(相談トークに切替) / BT(Botに切替)タイプボタンの時、伝達するメタ情報 |
+| -- chatEvent           | String  | BT(Botに切替)タイプボタンの時、接続するBotイベント名 |
+| -- bizFormId | Integer | X | ビジネスフォームID(BFタイプの場合、必須) |
+| -- pluginId             | String  |    X     | プラグインID(最大24文字)                                                                                                                                                        |
+| -- relayId | String | X | プラグイン実行の際、X-Kakao-Plugin-Relay-Idヘッダを介して受け取る値 |
+| -- oneClickId | String | X | ワンクリック決済プラグインで使用する決済情報 |
+| -- productId | String | X | ワンクリック決済プラグインで使用する決済情報 |
+| -- target              | String  | Webリンクボタンの場合、 "target":"out"プロパティ追加時のアウトリンク<br>基本インアプリリンクで送信 |
+| - quickReplies | List | X | クイック返信リスト(最大5件) |
+| -- ordering | Integer | X | クイック返信の順序(クイック返信がある場合、必須) |
+| -- type | String | X | クイック返信タイプ(WL: Webリンク、AL:アプリリンク、BK: ボットキーワード、BC:相談トーク切り替え、BT: ボット切り替え、BF:ビジネスフォーム) |
+| -- name | String | X | クイック返信名(クイック返信がある場合、必須、最大14文字) |
+| -- linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド、最大500文字) |
+| -- linkPc | String | X | PCWebリンク(WLタイプの場合、任意フィールド、最大500文字) |
+| -- schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド、最大500文字) |
+| -- schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド、最大500文字) |
+| -- pluginId             | String  |    X     | プラグインID(最大24文字)                                                                                                                                                        |
+| -- target | String | X | Webリンクタイプの場合、「"target":"out"」属性を追加すると外部リンク<br>デフォルトではアプリ内リンクとして送信 |
+| -- telNumber | String | X | TN(電話する)タイプのボタンの場合、伝達する電話番号 |
+| - messageOption        | Object  |	メッセージオプション                                         |
+| -- price               | Integer |	message(ユーザーに伝達されるメッセージ)内に含まれた価格/金額/決済金額(モーメント広告に該当) |
+| -- currencyType        | String  |	message(ユーザーに伝達されるメッセージ)内に含まれた価格/金額/決済金額(モーメント広告に該当) |
+| - senderGroupingKey    | String  | 発信グルーピングキー                            |
+| - recipientGroupingKey | String  | 受信者グルーピングキー                           |
+
+<a id="authentication-messages"></a>
+
+## 認証メッセージ
+
+<span id="precautions-authword"></span>
+1. 認証メッセージの送信時、含まれる必要がある認証文言案内
+
+| 区分 | 認証文言 |
+| --- | --- |
+| 認証メッセージ | auth、password、verif、にんしょう、認証、パスワード、認証 |
+
+- 例1)認証メッセージAPI送信リクエストした時、全文(テンプレート日本語識別子含む)に認証文言が含まれていない場合は、送信に失敗します。
+- 例2)認証文言が英文の場合、大文字/小文字の区別なしで有効性チェックが行われます。
+
+
+<a id="request-of-sending-replaced-messages-2"></a>
+
+### メッセージ置換送信リクエスト
+
+[URL]
+
+```
+POST  /alimtalk/v2.3/appkeys/{appkey}/auth/messages
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 値 | タイプ | 説明 |
+| ------ | ------ | ------ |
+| appkey | String | 固有のアプリキー |
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| 値    | タイプ | 必須 | 説明                               |
+| ------------ | ------ | ---- | ---------------------------------------- |
+| X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+[Request body]
+
+```
+{
+    "senderKey": String,
+    "templateCode": String,
+    "requestDate": String,
+    "senderGroupingKey": String,
+    "createUser" : String,
+    "recipientList": [{
+        "recipientNo": String,
+        "templateParameter": {
+            String: String
+        },
+        "resendParameter": {
+          "isResend" : boolean,
+          "resendType" : String,
+          "resendTitle" : String,
+          "resendContent" : String,
+          "resendSendNo" : String
+        },
+        "buttons": [
+          {
+            "ordering": Integer,
+            "chatExtra": String,
+            "chatEvent": String,
+            "target": String
+          }
+        ],
+        "recipientGroupingKey": String
+    }],
+    "messageOption": {
+      "price": Integer,
+      "currencyType": String
+    },
+    "statsId": String
+}
+```
+
+| 値               | タイプ | 必須 | 説明                                |
+| ---------------------- | ------- | ---- | ---------------------------------------- |
+| senderKey              | String  | O    | 発信キー                         |
+| templateCode           | String  | O    | 登録した送信テンプレートコード(最大20桁)                    |
+| requestDate            | String  | X    | リクエスト日時(yyyy-MM-dd HH:mm)<br>(入力しない場合は即時送信) |
+| createUser             | String  | X    | 登録者(コンソールから送信する場合、ユーザーUUIDとして保存)|
+| senderGroupingKey      | String  | X    | 発信グルーピングキー(最大100文字)                        |
+| recipientList          | List    | O    | 受信者リスト(最大1000人)                         |
+| - recipientNo          | String  | O    | 受信番号(最大15桁)                            |
+| - templateParameter    | Object  | X    | テンプレートパラメータ<br>(テンプレートに置換する変数が含まれる時は必須)       |
+| -- key                 | String  | X    | 置換キー(#{key})                             |
+| -- value               | String  | X    | 置換キーにマッピングされるvalue値                |
+| - resendParameter      | Object  | X    | 代替発送情報 |
+| -- isResend            | boolean | X    | 送信失敗時、代替送信するかどうか<br>コンソールで送信失敗設定をした時、デフォルト設定は再送信になっています。 |
+| -- resendType          | String  | X    | 代替送信タイプ(SMS、LMS)<br>値がない場合は、テンプレート本文の長さに応じてタイプが決まります。 |
+| -- resendTitle         | String  | X    | LMS代替送信タイトル(最大20文字)<br>(値がない場合は、プラスフレンドIDで再送信されます。) |
+| -- resendContent       | String  | X    | 代替送信内容(最大1000文字)<br>(値がない場合は、テンプレートの内容で再送信されます。) |
+| -- resendSendNo        | String  | X    | 代替送信発信番号(最大13桁)<br><span style="color:red">(SMSサービスに登録された発信番号ではない場合、代替送信が失敗することがあります。)</span> |
+| - buttons              | List    | X    | ボタン追加情報 |
+| -- ordering            | Integer | X    |	ボタン順序(ボタンがある場合は必須) |
+| -- chatExtra           | String  | X    |	BC(相談トークに切替) / BT(Botに切替)タイプボタンの時、伝達するメタ情報 |
+| -- chatEvent           | String  | X    |	BT(Botに切替)タイプボタンの時、接続するBotイベント名 |
+| -- target              | String  | X    |	Webリンクボタンの場合、 "target":"out"プロパティ追加時のアウトリンク<br>基本インアプリリンクで送信 |
+| - recipientGroupingKey | String  | X    | 受信者グルーピングキー(最大100文字)                       |
+| messageOption          | Object  | X    |	メッセージオプション                                         |
+| - price                | Integer | X    |	message(ユーザーに伝達されるメッセージ)内に含まれた価格/金額/決済金額(モーメント広告に該当) |
+| - currencyType         | String  | X    |	message(ユーザーに伝達されるメッセージ)内に含まれた価格/金額/決済金額(モーメント広告に該当) |
+| statsId                | String  | X    |	統計ID(発信検索条件には含まれません, 最大8文字) |
+
+* <b>リクエスト日時は呼び出す時点から60日後まで設定可能です。</b>
+* <b>SMSサービスで代替送信されるため、SMSサービスの送信APIの仕様に応じてフィールドを入力する必要があります。(SMSサービスに登録された発信番号、各種フィールドの長さ制限など)</b>
+* <b>指定した代替送信タイプのバイト制限を超える代替送信のタイトルや内容は、途中で切れて代替送信されることがあります。([[SMS注意事項](https://docs.toast.com/ko/Notification/SMS/ko/api-guide/#_1)]参考)</b>
+
+[例]
+```
+curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","templateParameter":{"{日本語識別子フィールド}":"{置換データ}"}}]}'
+```
+
+**レスポンス**
+
+```
+{
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
+  },
+  "messages": [
+    {
+      "requestId": String,
+      "recipientSeq": Integer,
+      "requestDate": String,
+      "createDate": String,
+      "receiveDate": String,
+      "resendStatus": String,
+      "resendStatusName": String,
+      "resendResultCode": String,
+      "resendRequestId": String,
+      "messageStatus": String,
+      "resultCode": String,
+      "resultCodeName": String
+    }
+  ]
+}
+```
+
+| 値                | タイプ | 説明    |
+| ----------------------- | ------- | ------------ |
+| header                  | Object  | ヘッダ領域 |
+| - resultCode            | Integer | 結果コード |
+| - resultMessage         | String  | 結果メッセージ |
+| - isSuccessful          | Boolean | 成否  |
+| message                 | Object  | 本文領域 |
+| - requestId             | String  | リクエストID        |
+| - senderGroupingKey     | String  | 発信グルーピングキー |
+| - sendResults           | Object  | 送信リクエスト結果 |
+| -- recipientSeq         | Integer | 受信者シーケンス番号 |
+| -- recipientNo          | String  | 受信番号 |
+| -- resultCode           | Integer | 送信リクエスト結果コード |
+| -- resultMessage        | String  | 送信リクエスト結果メッセージ |
+| -- recipientGroupingKey | String  | 受信者グルーピングキー |
+
+<a id="request-of-sending-full-text-2"></a>
+
+### メッセージ全文送信リクエスト
+
+[URL]
+
+```
+POST  /alimtalk/v2.3/appkeys/{appkey}/auth/raw-messages
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 値 | タイプ | 説明 |
+| ------ | ------ | ------ |
+| appkey | String | 固有のアプリキー |
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| 値    | タイプ | 必須 | 説明                               |
+| ------------ | ------ | ---- | ---------------------------------------- |
+| X-Secret-Key | String | O    | コンソールで作成できます。 |
+|X-NC-API-IDEMPOTENCY-KEY|	String| X | 重複メッセージ送信要求基準key<br>10分間同じkeyで要求すると、その要求を失敗処理します。 |
+
+[Request body]
+
+```
+{
+    "senderKey": String,
+    "templateCode": String,
+    "requestDate": String,
+    "senderGroupingKey": String,
+    "createUser": String,
+    "recipientList": [
+        {
+            "recipientNo": String,
+            "content": String,
+            "templateTitle" : String,
+            "buttons": [
+                {
+                    "ordering": Integer,
+                    "type": String,
+                    "name": String,
+                    "linkMo": String,
+                    "linkPc": String,
+                    "schemeIos": String,
+                    "schemeAndroid": String,
+                    "chatExtra": String,
+                    "chatEvent": String,
+                    "target": String
+                }
+            ],
+            "resendParameter": {
+              "isResend" : boolean,
+              "resendType" : String,
+              "resendTitle" : String,
+              "resendContent" : String,
+              "resendSendNo" : String
+            },
+            "recipientGroupingKey": String
+        }
+    ],
+    "messageOption": {
+      "price": Integer,
+      "currencyType": String
+    },
+    "statsId": String
+}
+```
+
+| 値               | タイプ | 必須 | 説明                                |
+| ---------------------- | ------- | ---- | ---------------------------------------- |
+| senderKey              | String  | O    | 発信キー                         |
+| templateCode           | String  | O    | 登録した送信テンプレートコード(最大20桁)                    |
+| requestDate            | String  | X    | リクエスト日時(yyyy-MM-dd HH:mm)<br>(入力しない場合は即時送信) |
+| senderGroupingKey      | String  | X    | 発信グルーピングキー(最大100文字)                        |
+| createUser             | String  | X    | 登録者(コンソールから送信する場合、ユーザーUUIDとして保存) |
+| recipientList          | List    | O    | 受信者リスト(最大1,000人)                        |
+| - recipientNo          | String  | O    | 受信番号(最大15桁)                            |
+| - content              | String  | O    | 内容(最大1000文字)                             |
+| - templateTitle        | String  | X    | タイトル(最大50桁)                            |
+| - buttons              | List    | X    | ボタンリスト(最大5個)                             |
+| -- ordering            | Integer | X    | ボタン順序(ボタンがある場合は必須)                      |
+| -- type                | String  | X    | ボタンタイプ(WL：Webリンク、AL：アプリリンク、DS：配送照会、BK：Botキーワード、MD：メッセージ伝達、BC：相談トーク転換、BT：Bot転換、AC：チャンネル追加) |
+| -- name                | String  | X    | ボタン名(ボタンがある場合は必須、最大14文字)              |
+| -- linkMo              | String  | X    | モバイルWebリンク(WLタイプの場合は必須フィールド、最大500文字)       |
+| -- linkPc              | String  | X    | PC Webリンク(WLタイプの場合は任意フィールド、最大500文字)        |
+| -- schemeIos           | String  | X    | iOSアプリリンク(ALタイプの場合は必須フィールド、最大500文字)       |
+| -- schemeAndroid       | String  | X    | Androidアプリリンク(ALタイプの場合は必須フィールド、最大500文字)   |
+| -- chatExtra           | String  | X    |	BC(相談トークに切替) / BT(Botに切替)タイプボタンの時、伝達するメタ情報 |
+| -- chatEvent           | String  | X    |	BT(Botに切替)タイプボタンの時、接続するBotイベント名 |
+| -- target              | String  | X    |	Webリンクボタンの場合、 "target":"out"プロパティ追加時のアウトリンク<br>基本インアプリリンクで送信 |
+| - resendParameter      | Object  | X    | 代替発送情報 |
+| -- isResend            | boolean | X    | 送信失敗時、代替送信するかどうか<br>コンソールで送信失敗設定をした時、デフォルト設定は再送信になっています。 |
+| -- resendType          | String  | X    | 代替送信タイプ(SMS、LMS)<br>値がない場合は、テンプレート本文の長さに応じてタイプが決まります。 |
+| -- resendTitle         | String  | X    | LMS代替送信タイトル(最大20文字)<br>(値がない場合は、プラスフレンドIDで再送信されます。) |
+| -- resendContent       | String  | X    | 代替送信内容(最大1000文字)<br>(値がない場合は、テンプレートの内容で再送信されます。) |
+| -- resendSendNo        | String  | X    | 代替送信発信番号(最大13桁)<br><span style="color:red">(SMSサービスに登録された発信番号ではない場合、代替送信が失敗することがあります。)</span> |
+| - recipientGroupingKey | String  | X    | 受信者グルーピングキー(最大100文字)                       |
+| messageOption          | Object  | X    |	メッセージオプション                                         |
+| - price                | Integer | X    |	message(ユーザーに伝達されるメッセージ)内に含まれた価格/金額/決済金額(モーメント広告に該当) |
+| - currencyType         | String  | X    |	message(ユーザーに伝達されるメッセージ)内に含まれた価格/金額/決済金額(モーメント広告に該当) |
+| statsId                | String  | X    |	統計ID(発信検索条件には含まれません, 最大8文字) |
+
+* <b>本文とボタンに置換が完了したデータを入れてください。</b>
+* <b>リクエスト日時は呼び出す時点から60日後まで設定可能です。</b>
+
+[例]
+```
+curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/raw-messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","content":"{内容}","buttons":[{"ordering":"{ボタン順序}","type":"{ボタンタイプ}","name":"{ボタン名}","linkMo":"{モバイルWebリンク}"}]}]}'
+```
+
+**レスポンス**
+
+```
+{
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
+  },
+  "body": {
+    "messages": [
+      {
+        "requestId": String,
+        "requestDate": String,
+        "plusFriendId": String,
+        "senderKey": String,
+        "templateCode": String,
+        "masterStatusCode": String,
+        "content": String,
+        "fileId": String,
+        "autoSendYn": String,
+        "statsId": String,
+        "createDate": String,
+        "createUser": String
+      }
+    ],
+    "totalCount": Integer
+  }
+}
+```
+
+| 値                | タイプ | 説明    |
+| ----------------------- | ------- | ------------ |
+| header                  | Object  | ヘッダ領域 |
+| - resultCode            | Integer | 結果コード |
+| - resultMessage         | String  | 結果メッセージ |
+| - isSuccessful          | Boolean | 成否  |
+| message                 | Object  | 本文領域 |
+| - requestId             | String  | リクエストID        |
+| - senderGroupingKey     | String  | 発信グルーピングキー |
+| - sendResults           | Object  | 送信リクエスト結果 |
+| -- recipientSeq         | Integer | 受信者シーケンス番号 |
+| -- recipientNo          | String  | 受信番号 |
+| -- resultCode           | Integer | 送信リクエスト結果コード |
+| -- resultMessage        | String  | 送信リクエスト結果メッセージ |
+| -- recipientGroupingKey | String  | 受信者グルーピングキー |
+
+<a id="list-messages-2"></a>
+
+### メッセージリストの照会
+
+<a id="request-3"></a>
+
+#### リクエスト
+
+[URL]
+
+```
+GET  /alimtalk/v2.3/appkeys/{appkey}/auth/messages
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 値 | タイプ | 説明 |
+| ------ | ------ | ------ |
+| appkey | String | 固有のアプリキー |
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| 値    | タイプ | 必須 | 説明                               |
+| ------------ | ------ | ---- | ---------------------------------------- |
+| X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+[Query parameter] 1番or(2番、 3番)の条件は必須
+
+| 値             | タイプ | 必須 | 説明                                |
+| -------------------- | ------- | --------- | ---------------------------------------- |
+| requestId            | String  | 条件必須(1番) | リクエストID                                    |
+| startRequestDate     | String  | 条件必須(2番) | 送信リクエスト日の開始値(yyyy-MM-dd HH:mm)          |
+| endRequestDate       | String  | 条件必須(2番) | 送信リクエスト日の終了値(yyyy-MM-dd HH:mm)           |
+| startCreateDate      | String  | 条件必須(3番) | 登録日開始値(yyy-MM-dd HH:mm)                   |
+| endCreateDate        | String  | 条件必須(3番) | 登録日終値(yyy-MM-dd HH:mm)                    |
+| recipientNo          | String  | X         | 受信番号                             |
+| senderKey            | String  | X         | 発信キー                                 |
+| templateCode         | String  | X         | テンプレートコード                            |
+| senderGroupingKey    | String  | X         | 発信グルーピングキー                            |
+| recipientGroupingKey | String  | X         | 受信者グルーピングキー                           |
+| messageStatus        | String  | X         | リクエストステータス(COMPLETED -> 成功、FAILED -> 失敗、CANCEL -> キャンセル) |
+| createUser           | String  | X         | 登録者(コンソールから送信する場合、ユーザーUUIDとして保存)|
+| resultCode           | String  | X         | 送信結果(MRC01 -> 成功、MRC02 -> 失敗)          |
+| pageNum              | Integer | X         | ページ番号(基本：1)                            |
+| pageSize             | Integer | X         | 照会件数(基本：15、最大: 1000)                |
+
+* 90日以上前の送信リクエストデータは照会されません。
+* 送信リクエスト日時の範囲は最大30日です。
+
+**レスポンス**
+```
+{
+  "header" : {
+      "resultCode" :  Integer,
+      "resultMessage" :  String,
+      "isSuccessful" :  boolean
+  },
+  "messageSearchResultResponse" : {
+    "messages" : [
+    {
+      "requestId" :  String,
+      "recipientSeq" : Integer,
+      "plusFriendId" :  String,
+      "senderKey"    :  String,
+      "templateCode" :  String,
+      "recipientNo" :  String,
+      "content" :  String,
+      "requestDate" :  String,
+      "createDate" : String,
+      "receiveDate" : String,
+      "resendStatus" :  String,
+      "resendStatusName" :  String,
+      "messageStatus" :  String,
+      "resultCode" :  String,
+      "resultCodeName" : String,
+      "createUser" : String,
+      "buttons" : [
+        {
+          "ordering" :  Integer,
+          "type" :  String,
+          "name" :  String,
+          "linkMo" :  String,
+          "linkPc": String,
+          "schemeIos": String,
+          "schemeAndroid": String,
+          "chatExtra": String,
+          "chatEvent": String,
+          "target": String
+        }
+      ],
+      "senderGroupingKey": String,
+      "recipientGroupingKey": String
+    }
+    ],
+    "totalCount" :  Integer
+  }
+}
+```
+
+| 値                   | タイプ | 説明                               |
+| --------------------------- | ------- | ---------------------------------------- |
+| header                      | Object  | ヘッダ領域                            |
+| - resultCode                | Integer | 結果コード                            |
+| - resultMessage             | String  | 結果メッセージ                           |
+| - isSuccessful              | Boolean | 成否                             |
+| messageSearchResultResponse | Object  | 本文領域                            |
+| - messages                  | List    | メッセージリスト                           |
+| -- requestId                | String  | リクエストID                                    |
+| -- recipientSeq             | Integer | 受信者シーケンス番号                       |
+| -- plusFriendId             | String  | プラスフレンドID                                 |
+| -- senderKey                | String  | 発信キー                                  |
+| -- templateCode             | String  | テンプレートコード                           |
+| -- recipientNo              | String  | 受信番号                            |
+| -- content                  | String  | 本文                               |
+| -- requestDate              | String  | リクエスト日時                            |
+| -- createDate               | String  | 登録日時                            |
+| -- receiveDate              | String  | 受信日時                            |
+| -- resendStatus             | String  | 再送信ステータスコード                        |
+| -- resendStatusName         | String  | 再送信ステータスコード名                        |
+| -- messageStatus            | String  | リクエストステータス(COMPLETED -> 成功、FAILED -> 失敗、CANCEL -> キャンセル) |
+| -- resultCode               | String  | 受信結果コード                         |
+| -- resultCodeName           | String  | 受信結果コード名                         |
+| -- createUser               | String  | 登録者(コンソールから送信する場合、ユーザーUUIDとして保存)|
+| -- buttons                  | List    | ボタンリスト                            |
+| --- ordering                | Integer | ボタン順序                            |
+| --- type                    | String  | ボタンタイプ(WL：Webリンク、AL：アプリリンク、DS：配送照会、BK：Botキーワード、MD：メッセージ伝達、BC：相談トーク転換、BT：Bot転換、AC：チャンネル追加) |
+| --- name                    | String  | ボタン名                            |
+| --- linkMo                  | String  | モバイルWebリンク(WLタイプの場合は必須フィールド)                |
+| --- linkPc                  | String  | PC Webリンク(WLタイプの場合は任意フィールド)                 |
+| --- schemeIos               | String  | iOSアプリリンク(ALタイプの場合は必須フィールド)                |
+| --- schemeAndroid           | String  | Androidアプリリンク(ALタイプの場合は必須フィールド)            |
+| --- chatExtra               | String  | BC(相談トークに切替) / BT(Botに切替)タイプボタンの時、伝達するメタ情報 |
+| --- chatEvent               | String  | BT(Botに切替)タイプボタンの時、接続するBotイベント名 |
+| --- target                  | String  | Webリンクボタンの場合、 "target":"out"プロパティ追加時のアウトリンク<br>基本インアプリリンクで送信 |
+| -- senderGroupingKey        | String  | 発信グルーピングキー                            |
+| -- recipientGroupingKey     | String  | 受信者グルーピングキー                           |
+| - totalCount                | Integer | 総個数                              |
+
+[例]
+```
+curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
+```
+
+<a id="query-the-number-of-message-result-updates"></a>
+
+### メッセージ結果アップデート件数の照会
+
+<a id="request-7"></a>
+
+#### リクエスト
+
+[URL]
+
+```
+GET  /alimtalk/v2.3/appkeys/{appkey}/message-results/count
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 名前    | 	タイプ    | 	説明    |
+|--------|---------|---------|
+| appkey | 	String | 	固有のアプリキー |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前          | 	タイプ    | 	必須 | 	説明             |
+|--------------|---------|-----|------------------|
+| X-Secret-Key |	String | O | コンソールで作成できます。 |
+
+[Query parameter]
+
+| 名前                 | 	タイプ     | 	必須 | 	説明                                |
+|---------------------|----------|-----|-------------------------------------|
+| startUpdateDate     | 	String  | 	O  | 結果アップデート照会開始時間(yyyy-MM-dd HH:mm)  |
+| endUpdateDate       | 	String  | O   | 	結果アップデート照会終了時間(yyyy-MM-dd HH:mm) |
+| alimtalkMessageType | 	String  | X   | 	お知らせトークのメッセージタイプ(NORMAL, AUTH)           |
+
+<a id="response-8"></a>
+
+#### レスポンス
+
+```
+{
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
+  },
+  "totalCount": Integer
+}
+```
+
+| 名前             | タイプ     | Not Null | 説明    |
+|-----------------|---------|:--------:|--------|
+| header          | Object  |    O     | ヘッダ領域 |
+| - resultCode    | Integer |    O     | 結果コード |
+| - resultMessage | String  |    O     | 結果メッセージ |
+| - isSuccessful  | Boolean |    O     | 成否 |
+| totalCount      | Integer |    O     | 総件数  |
+
+[例]
+
+```
+curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/message-results/count?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
+```
+
+<a id="status-code-of-smslms-resending"></a>
+
+### SMS/LMS再送信ステータス
+| 値 | 説明                      |
+| ----- | ------------------------------- |
+| RSC01 | 再送信の対象ではない                 |
+| RSC02 | 再送信の対象(送信結果が失敗の時、再送信が行われます。) |
+| RSC03 | 再送信中                    |
+| RSC04 | 再送信成功                  |
+| RSC05 | 再送信失敗                  |
+
+<a id="get-messages-2"></a>
+
+### メッセージ単件照会
+
+<a id="request-4"></a>
+
+#### リクエスト
+
+[URL]
+
+```
+GET  /alimtalk/v2.3/appkeys/{appkey}/auth/messages/{requestId}/{recipientSeq}
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 値    | タイプ | 説明 |
+| ------------ | ------- | ---------- |
+| appkey       | String  | 固有のアプリキー |
+| requestId    | String  | リクエストID      |
+| recipientSeq | Integer | 受信者シーケンス番号 |
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| 値    | タイプ | 必須 | 説明                               |
+| ------------ | ------ | ---- | ---------------------------------------- |
+| X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+[例]
+```
+curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/messages/{requestId}/{recipientSeq}"
+```
+
+<a id="response-5"></a>
+
+#### レスポンス
+```
+{
+    "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
+    },
+    "body": {
+        "recipients": [
+            {
+                "requestId": String,
+                "recipientSeq": Integer,
+                "recipientNo": String,
+                "requestDate": String,
+                "receiveDate": String,
+                "messageStatus": String,
+                "resultCode": String,
+                "resultCodeName": String
+            }
+        ],
+        "totalCount": Integer
+    }
+}
+```
+
+| 値               | タイプ | 説明                                |
+| ---------------------- | ------- | ---------------------------------------- |
+| header                 | Object  | ヘッダ領域                             |
+| - resultCode           | Integer | 結果コード                             |
+| - resultMessage        | String  | 結果メッセージ                            |
+| - isSuccessful         | Boolean | 成否                              |
+| message                | Object  | メッセージ                               |
+| - requestId            | String  | リクエストID                                    |
+| - recipientSeq         | Integer | 受信者シーケンス番号                        |
+| - plusFriendId         | String  | プラスフレンドID                                 |
+| - senderKey            | String  | 発信キー                                   |
+| - templateCode         | String  | テンプレートコード                            |
+| - recipientNo          | String  | 受信番号                             |
+| - content              | String  | 本文                                |
+| - templateTitle        | String  | テンプレートハイライトタイトル              |
+| - templateSubtitle     | String  | テンプレートハイライトサブタイトル           |
+| - templateExtra        | String  | テンプレート付加情報                     |
+| - templateAd           | String  | テンプレート内の受信同意または簡単な広告文句   |
+| - requestDate          | String  | リクエスト日時                             |
+| - createDate           | String  | 登録日時                            |
+| - receiveDate          | String  | 受信日時                             |
+| - resendStatus         | String  | 再送信ステータスコード                         |
+| - resendStatusName     | String  | 再送信ステータスコード名                          |
+| - resendResultCode     | String  | 再送結果コード[SMS結果コード](https://docs.toast.com/ja/Notification/SMS/ja/error-code/#api) |
+| - resendRequestId      | String  | 再送SMSリクエストID                                                  |
+| - messageStatus        | String  | リクエストステータス(COMPLETED -> 成功、FAILED -> 失敗、CANCEL -> キャンセル) |
+| - resultCode           | String  | 受信結果コード                          |
+| - resultCodeName       | String  | 受信結果コード名                           |
+| - createUser           | String  | 登録者(コンソールから送信する場合、ユーザーUUIDとして保存)|
+| - buttons              | List    | ボタンリスト                             |
+| -- ordering            | Integer | ボタン順序                             |
+| -- type                | String  | ボタンタイプ(WL：Webリンク、AL：アプリリンク、DS：配送照会、BK：Botキーワード、MD：メッセージ伝達、BC：相談トーク転換、BT：Bot転換、AC：チャンネル追加、 TN:電話発信) |
+| -- name                | String  | ボタン名                             |
+| -- linkMo              | String  | モバイルWebリンク(WLタイプの場合は必須フィールド)                |
+| -- linkPc              | String  | PC Webリンク(WLタイプの場合は任意フィールド)                 |
+| -- schemeIos           | String  | iOSアプリリンク(ALタイプの場合は必須フィールド)                |
+| -- schemeAndroid       | String  | Androidアプリリンク(ALタイプの場合は必須フィールド)            |
+| -- chatExtra           | String  | BC(相談トークに切替) / BT(Botに切替)タイプボタンの時、伝達するメタ情報 |
+| -- chatEvent           | String  | BT(Botに切替)タイプボタンの時、接続するBotイベント名 |
+| -- target              | String  | Webリンクボタンの場合、 "target":"out"プロパティ追加時のアウトリンク<br>基本インアプリリンクで送信 |
+| - messageOption        | Object  |	メッセージオプション                                         |
+| -- price               | Integer |	message(ユーザーに伝達されるメッセージ)内に含まれた価格/金額/決済金額(モーメント広告に該当) |
+| -- currencyType        | String  |	message(ユーザーに伝達されるメッセージ)内に含まれた価格/金額/決済金額(モーメント広告に該当) |
+| - senderGroupingKey    | String  | 発信グルーピングキー                            |
+| - recipientGroupingKey | String  | 受信者グルーピングキー                           |
+
+<a id="message"></a>
+
+## メッセージ
+<a id="cancel-sending-messages"></a>
+
+### メッセージ送信取消
+
+<a id="request-5"></a>
+
+#### リクエスト
+
+[URL]
+
+```
+DELETE  /alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 値 | タイプ | 説明 |
+| --------- | ------ | ------ |
+| appkey    | String | 固有のアプリキー |
+| requestId | String | リクエストID  |
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| 値    | タイプ | 必須 | 説明                               |
+| ------------ | ------ | ---- | ---------------------------------------- |
+| X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+[Query parameter]
+
+| 値    | タイプ | 必須 | 説明                               |
+| ------------ | ------ | ---- | ---------------------------------------- |
+| recipientSeq | String | X    | 受信者シーケンス番号<br>(入力しない場合、リクエストIDのすべての送信件をキャンセル) |
+
+* 一般/認証メッセージは同じAPIでキャンセルできます。
+
+<a id="response-6"></a>
+
+#### レスポンス
+```
+{
+  "header" : {
+      "resultCode" :  Integer,
+      "resultMessage" :  String,
+      "isSuccessful" :  boolean
+  }
+}
+```
+
+| 値       | タイプ | 説明 |
+| --------------- | ------- | ------ |
+| header          | Object  | ヘッダ領域 |
+| - resultCode    | Integer | 結果コード |
+| - resultMessage | String  | 結果メッセージ |
+| - isSuccessful  | Boolean | 成否 |
+
+[例]
+```
+curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
+```
+
+<a id="query-updates-of-message-result"></a>
+
+### メッセージ結果アップデートの照会
+
+<a id="request-6"></a>
+
+#### リクエスト
+
+[URL]
+
+```
+GET  /alimtalk/v2.3/appkeys/{appkey}/message-results
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 値 | タイプ | 説明 |
+| ------ | ------ | ------ |
+| appkey | String | 固有のアプリキー |
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| 値    | タイプ | 必須 | 説明                               |
+| ------------ | ------ | ---- | ---------------------------------------- |
+| X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+[Query parameter]
+
+| 値            | タイプ | 必須 | 説明                          |
+| ------------------- | ------- | ---- | ---------------------------------- |
+| startUpdateDate     | String  | O    | 結果アップデート照会開始時間(yyyy-MM-dd HH:mm) |
+| endUpdateDate       | String  | O    | 結果アップデート照会終了時間(yyyy-MM-dd HH:mm) |
+| alimtalkMessageType | String  | X    | お知らせトークメッセージタイプ(NORMAL、AUTH)           |
+| pageNum             | Integer | X    | ページ番号(基本：1)                      |
+| pageSize            | Integer | X    | 照会件数(基本：15、最大: 1000)          |
+
+<a id="response-7"></a>
+
+#### レスポンス
+```
+{
+  "header" : {
+      "resultCode" :  Integer,
+      "resultMessage" :  String,
+      "isSuccessful" :  boolean
+  },
+  "messages" : [
+    {
+      "requestId" :  String,
+      "recipientSeq" : Integer,
+      "requestDate" :  String,
+      "createDate" :  String,
+      "receiveDate" : String,
+      "resendStatus" :  String,
+      "resendStatusName" :  String,
+      "resendResultCode" :  String,
+      "resendRequestId" :  String,
+      "messageStatus" :  String,
+      "resultCode" :  String,
+      "resultCodeName" : String
+    }
+  ]
+}
+```
+
+| 値                   | タイプ | 説明                               |
+| --------------------------- | ------- | ---------------------------------------- |
+| header                      | Object  | ヘッダ領域                            |
+| - resultCode                | Integer | 結果コード                            |
+| - resultMessage             | String  | 結果メッセージ                           |
+| - isSuccessful              | Boolean | 成否                             |
+| messages                  | List    | メッセージリスト                           |
+| - requestId                | String  | リクエストID                                    |
+| - recipientSeq             | Integer | 受信者シーケンス番号                       |
+| - requestDate              | String  | リクエスト日時                            |
+| - createDate               | String  | 作成日時                            |
+| - receiveDate              | String  | 受信日時                            |
+| - resendStatus             | String  | 再送信ステータスコード                        |
+| - resendStatusName         | String  | 再送信ステータスコード名                        |
+| - resendResultCode         | String  | 再送結果コード[SMS結果コード](https://docs.toast.com/ja/Notification/SMS/ja/error-code/#api)                        |
+| - resendRequestId          | String  | 再送SMSリクエストID                        |
+| - messageStatus            | String  | リクエストステータス(COMPLETED -> 成功、FAILED -> 失敗、CANCEL -> キャンセル) |
+| - resultCode               | String  | 受信結果コード                         |
+| - resultCodeName           | String  | 受信結果コード名                         |
+
+[例]
+```
+curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/message-results?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
+```
+
+<a id="mass-delivery"></a>
+
+## 大量送信
+<a id="list-mass-delivery-requests"></a>
+
+### 大量送信リクエストリスト照会
+
+<a id="request-8"></a>
+
+#### リクエスト
+[URL]
+```
+GET /alimtalk/v2.3/appkeys/{appKey}/mass-messages
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+|値|	タイプ|	説明|
+|---|---|---|
+|appKey|	String|	固有のアプリキー|
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+|値|	タイプ|	説明|
+|---|---|---|
+|X-Secret-Key|	String|	固有のシークレットキー |
+
+[Query parameter]
+* requestIdまたはstartRequestDate + endRequestDateまたはstartCreateDate + endCreateDateは必須です。
+
+|値|	タイプ| 最大長さ |	必須|	説明|
+|---|---|---|---|---|
+| requestId | String | - | O | リクエストID |
+| startRequestDate | String | - | O | 送信日の開始 |
+| endRequestDate | String | - | O | 送信日の終了 |
+| startCreateDate |	String| - |	O |	登録日の開始 |
+| endCreateDate |	String| - |	O |	登録日の終了 |
+| pageNum | optional, Integer | - | X | ページ番号 |
+| pageSize | optional, Integer | 1000 | X | 検索数 |
+
+<a id="curl"></a>
+
+#### cURL
+```
+curl -X GET \
+https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appKey}/'"${APP_KEY}"'/mass-messages?requestId='"${REQUEST_ID}" \
+-H 'Content-Type: application/json;charset=UTF-8' \
+-H 'X-Secret-Key:{secretkey}'
+```
+
+<a id="response-9"></a>
+
+#### レスポンス
+```
+{
+  "header": {
+    "resultCode" :  Integer,
+    "resultMessage" :  String,
+    "isSuccessful" :  boolean
+  },
+  "body": {
+    "messages": [
+      {
+        "requestId": String,
+        "requestDate": String,
+        "plusFriendId": String,
+        "senderKey": String,
+        "templateCode": String,
+        "masterStatusCode": String,
+        "content": String,
+        "buttons": [
+          {
+            "ordering": 1,
+            "type": String,
+            "name": String,
+            "linkMo": String,
+            "linkPc": String,
+            "schemeIos": String,
+            "schemeAndroid": String,
+            "chatExtra": String,
+            "chatEvent": String,
+            "target": String
+          }
+        ],
+        "fileId": String,
+        "templateExtra": String,
+        "templateAd": String,
+        "templateTitle": String,
+        "templateSubtitle": String,
+        "autoSendYn": String,
+        "statsId": String,
+        "createDate": String,
+        "createUser": String
+      }
+    ],
+    "totalCount": Integer
+  }
+}
+```
+
+|値|	タイプ|	説明|
+|---|---|---|
+| header | Object |	ヘッダ領域 |
+| - resultCode |	Integer |	結果コード |
+| - resultMessage |	String | 結果メッセージ |
+| - isSuccessful |	Boolean | 成否 |
+| body | Object | 本文領域 |
+| - messages | Object | メッセージリスト |
+| -- requestId | String | リクエストID |
+| -- requestDate | String | リクエスト日 |
+| -- createDate | String | 作成日 |
+| -- createUser | String | 作成日 |
+| -- plusFriendId | String | プラスフレンドID |
+| -- senderKey | String| 発信キー(40文字) |
+| -- masterStatusCode | String | 大量送信ステータスコード(WAIT, READY, SENDREADY, SENDWAIT, SENDING, COMPLETE, CANCEL, FAIL) |
+| -- content | String | 内容 |
+| -- buttons | List | ボタンリスト |
+| --- ordering | String | ボタンの順序 |
+| --- type | String | ボタンの種類<br/> - WL：Webリンク<br/> - AL：アプリリンク<br/> - DS：配送照会<br/> - BK：Botキーワード<br/> - MD：メッセージ伝達<br/> - BC：相談トーク切り替え<br/> - BT：Bot切り替え<br/> - AC：チャンネル追加[広告追加/複合型のみ], TN:電話発信) |
+| --- name | String | ボタン名 |
+| --- linkMo | String | モバイルWebリンク(WLタイプの場合は必須フィールド) |
+| --- linkPc | String | PC Webリンク(WLタイプの場合は任意フィールド)|
+| --- schemeIos | String | IOSアプリリンク(ALタイプの場合は必須フィールド) |
+| --- schemeAndroid | String | Androidアプリリンク(ALタイプの場合は必須フィールド) |
+| --- chatExtra | String | BC：相談トークに切り替える時に伝達するメタ情報<br/> BT：Botに切り替える時に伝達するメタ情報 |
+| --- chatEvent | String | BT：Botに切り替える時に接続するBotイベント名 |
+| --- target|	String|	Webリンクボタンの場合、"target"："out"プロパティを追加時アウトリンク<br>基本アプリ内リンクで送信 |
+| -- fileId | String | 添付ファイルID |
+| -- templateCode |	String | テンプレートコード(最大20文字) |
+| -- templateExtra | String | テンプレート付加情報(テンプレートメッセージタイプが[付加情報型/複合型]の場合は必須) |
+| -- templateAd | String | テンプレート内の受信同意リクエストまたは簡単な広告文言 |
+| -- tempalteTitle| String | テンプレートタイトル(最大50文字、Android：2行、23文字以上省略処理、IOS：2行、27文字以上省略処理) |
+| -- templateSubtitle| String | テンプレート補助文言(最大50文字、Android：18文字以上省略処理、IOS：21文字以上省略処理) |
+| -- autoSendYn | String | 自動送信を行うかどうか |
+| -- statsId | String | 統計ID |
+| -- createDate | String | 作成日 |
+| -- createUser | String | 登録者(コンソールから送信時、ユーザーUUIDに保存) |
+| - totalCount | Integer | 総数
+
+
+<a id="list-mass-delivery-recipients"></a>
+
+### 大量送信大量送信受信者リスト照会
+
+<a id="request-9"></a>
+
+#### リクエスト
+[URL]
+```
+GET /alimtalk/v2.3/appkeys/{appKey}/mass-messages/{requestId}/recipients
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+|値|	タイプ|	説明|
+|---|---|---|
+| appKey |	String |	固有のアプリキー |
+| requestId |	String |	リクエストID |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+|値|	タイプ|	説明|
+|---|---|---|
+| X-Secret-Key |	String|	固有のシークレットキー |
+
+
+|値|	タイプ| 最大長さ |	必須|	説明|
+|---|---|---|---|---|
+| requestId | String | - | O | リクエストID |
+| startRequestDate | String | - | X | 送信日の開始 |
+| endRequestDate | String | - | X | 送信日の終了 |
+| startCreateDate |	String| - |	X |	登録日の開始 |
+| endCreateDate |	String| - |	X |	登録日の終了 |
+| pageNum | optional, Integer | - | X | ページ番号 |
+| pageSize | optional, Integer | 1000 | X | 検索数 |
+
+<a id="curl-2"></a>
+
+#### cURL
+```
+curl -X GET \
+https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appKey}/'"${APP_KEY}"'/mass-messages/recipients?requestId='"${REQUEST_ID}" \
+-H 'Content-Type: application/json;charset=UTF-8' \
+-H 'X-Secret-Key:{secretkey}'
+```
+
+<a id="response-10"></a>
+
+#### レスポンス
+```
+{
+    "header": {
+      "resultCode" :  Integer,
+      "resultMessage" :  String,
+      "isSuccessful" :  boolean
+    },
+    "body": {
+        "recipients": [
+            {
+                "requestId": String,
+                "recipientSeq": Integer,
+                "recipientNo": String,
+                "requestDate": String,
+                "receiveDate": String,
+                "messageStatus": String,
+                "resultCode": String,
+                "resultCodeName": String
+            }
+        ],
+        "totalCount": Integer
+    }
+}
+```
+
+|値|	タイプ|	説明|
+|---|---|---|
+| header | Object |	ヘッダ領域 |
+| - resultCode |	Integer |	結果コード |
+| - resultMessage |	String | 結果メッセージ |
+| - isSuccessful |	Boolean | 成否 |
+| body | Object | 本文領域 |
+| - messages | Object | メッセージリスト |
+| -- requestId | String | リクエストID |
+| -- recipientSeq | String | 受信者シーケンス番号 |
+| -- recipientNo | String | 受信番号 |
+| -- requestDate | String | リクエスト日 |
+| -- receiveDate | String | 受信日 |
+| -- messageStatus | String | メッセージ状態 |
+| -- resultCode | String | 結果コード |
+| -- resultCodeName | String | 結果コード内容 |
+| - totalCount | Integer | 総数 |
+
+<a id="get-a-mass-delivery-recipient"></a>
+
+### 大量送信大量送信受信者照会
+
+<a id="request-10"></a>
+
+#### リクエスト
+[URL]
+```
+GET /alimtalk/v2.3/appkeys/{appKey}/mass-messages/{requestId}/recipients/{recipientSeq}
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+|値|	タイプ|	説明|
+|---|---|---|
+| appKey |	String | 固有のアプリキー |
+| requestId |	String | リクエストID |
+| recipientSeq | String | 受信者の順序 |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+|値|	タイプ|	説明|
+|---|---|---|
+|X-Secret-Key|	String|	固有のシークレットキー |
+
+
+|値|	タイプ| 最大長さ |	必須|	説明|
+|---|---|---|---|---|
+| requestId | String | - | O | リクエストID |
+| startRequestDate | String | - | X | 送信日の開始 |
+| endRequestDate | String | - | X | 送信日の終了 |
+| startCreateDate |	String| - |	X |	登録日の開始 |
+| endCreateDate |	String| - |	X |	登録日の終了 |
+| pageNum | optional, Integer | - | X | ページ番号 |
+| pageSize | optional, Integer | 1000 | X | 検索数 |
+
+<a id="curl-3"></a>
+
+#### cURL
+```
+curl -X GET \
+https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appKey}/'"${APP_KEY}"'/mass-messages/recipients/1?requestId='"${REQUEST_ID}" \
+-H 'Content-Type: application/json;charset=UTF-8' \
+-H 'X-Secret-Key:{secretkey}'
+```
+
+<a id="response-11"></a>
+
+#### レスポンス
+```
+{
+    "header": {
+      "resultCode" :  Integer,
+      "resultMessage" :  String,
+      "isSuccessful" :  boolean
+    },
+    "body": {
+        "requestId": String,
+        "recipientSeq": Integer,
+        "plusFriendId": String,
+        "senderKey": String,
+        "templateCode": String,
+        "recipientNo": String,
+        "content": String,
+        "templateTitle": String,
+        "templateSubtitle": String,
+        "templateExtra": String,
+        "templateAd": String,
+        "requestDate": String,
+        "receiveDate": String,
+        "createDate": String,
+        "resendStatus": String,
+        "resendStatusName": String,
+        "resendResultCode": String,
+        "resendRequestId": String,
+        "messageStatus": String,
+        "resultCode": String,
+        "resultCodeName": String,
+        "createUser": String,
+        "buttons": [
+            {
+                "ordering": Integer,
+                "type": String,
+                "name": String,
+                "linkMo": String,
+                "linkPc": String,
+                "schemeIos": String,
+                "schemeAndroid": String,
+                "chatExtra": String,
+                "chatEvent": String
+                "target": String
+	      "pluginId": String,
+	      "telNumber": String                
+            }
+        ],
+        "messageOption": {
+          "price": Integer,
+          "currencyType": String
+        }
+    }
+}
+```
+
+|値|	タイプ|	説明|
+|---|---|---|
+| header | Object |	ヘッダ領域 |
+| - resultCode |	Integer |	結果コード |
+| - resultMessage |	String | 結果メッセージ |
+| - isSuccessful |	Boolean | 成否 |
+| body | Object | 本文領域 |
+| - requestId | String | リクエストID |
+| - recipientSeq | String | 受信者シーケンス番号 |
+| - plusFriendId | String | プラスフレンドID |
+| - senderKey | String | 送信者ID |
+| - templateCode |	String | テンプレートコード(最大20文字) |
+| - recipientNo | String | 受信番号 |
+| - content | String | 内容 |
+| - tempalteTitle| String | テンプレートタイトル(最大50文字、Android：2行、23文字以上省略処理、IOS：2行、27文字以上省略処理) |
+| - templateSubtitle| String | テンプレート補助文言(最大50文字、Android：18文字以上省略処理、IOS：21文字以上省略処理) |
+| - templateExtra | String | テンプレート付加情報(テンプレートメッセージタイプが[付加情報型/複合型]の場合は必須) |
+| - templateAd | String | テンプレート内の受信同意リクエストまたは簡単な広告文言 |
+| - requestDate | String | リクエスト日 |
+| - receiveDate | String | 受信日 |
+| - createDate | String | 作成日 |
+| - resendStatus | String | 代替送信ステータスコード(RSC01, RSC02, RSC03, RSC04, RSC05)<br>([[以下の代替送信ステータス表](http://docs.toast.com/ko/Notification/KakaoTalk%20Bizmessage/ko/alimtalk-api-guide/#smslms)]参考) |
+| - resendStatusName | String | 代替送信ステータス名 |
+| - resendResultCode | String | 代替送信結果コード[SMS結果コード](https://docs.toast.com/ko/Notification/SMS/ko/error-code/#api) |
+| - resendRequestId | String | 代替送信リクエストID |
+| - messageStatus | String | 大量受信者送信ステータスコード(READY, COMPLETED, FAILED, CANCEL) |
+| - resultCode | String | 結果ステータスコード |
+| - resultCodeName | String | 結果状態名 |
+| - createUser | String | 作成ユーザーID |
+| - buttons | List | ボタンリスト |
+| -- ordering | String | ボタンの順序 |
+| -- type | String | ボタンの種類<br/> - WL：Webリンク<br/> - AL：アプリリンク<br/> - DS：配送照会<br/> - BK：Botキーワード<br/> - MD：メッセージ配信<br/> - BC：相談トーク切り替え<br/> - BT：Bot切り替え<br/> - AC：チャンネル追加[広告追加/複合型のみ], TN:電話発信) |
+| -- name | String | ボタン名 |
+| -- linkMo | String | モバイルWebリンク(WLタイプの場合は必須フィールド) |
+| -- linkPc | String | PC Webリンク(WLタイプの場合は任意フィールド)|
+| -- schemeIos | String | IOSアプリリンク(ALタイプの場合は必須フィールド) |
+| -- schemeAndroid | String | Androidアプリリンク(ALタイプの場合は必須フィールド) |
+| -- chatExtra | String | BC：相談トークに切り替える時に伝達するメタ情報<br/> BT：Botに切り替える時に伝達するメタ情報 |
+| -- chatEvent | String | BT：Botに切り替える時に接続するBotイベント名 |
+| -- target|	String|	Webリンクボタンの場合、"target"："out"プロパティを追加時アウトリンク<br>基本アプリ内リンクで送信 |
+| - messageOption | Boolean | メッセージオプション |
+|-- price | Integer |	message(ユーザーに伝達されるメッセージ)内に含まれる価格/金額/決済金額(モーメント広告に該当) |
+|-- currencyType | String |	message(ユーザーに伝達されるメッセージ)内に含まれる価格/金額/決済金額の通貨単位KRW、USD、EURなどの国際通貨コードを使用(モーメント広告に該当) |
+
+
+<a id="templates"></a>
+
+## テンプレート
+
+<a id="list-template-categories"></a>
+
+### テンプレートカテゴリー照会
+<a id="request-11"></a>
+
+#### リクエスト
+[URL]
+
+```
+GET  /alimtalk/v2.3/appkeys/{appkey}/template/categories
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 値    | タイプ | 説明 |
+| ------------ | ------ | -------- |
+| appkey       | String | 固有のアプリキー |
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| 値    | タイプ | 必須 | 説明                               |
+|---|---|---|---|
+| X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+<a id="response-12"></a>
+
+#### レスポンス
+```
+
+{
+  "header" : {
+      "resultCode" :  Integer,
+      "resultMessage" :  String,
+      "isSuccessful" :  boolean
+  },
+  "categories": [
+    {
+      "name": String,
+      "subCategories": [
+        {
+          "code": String,
+          "name": String,
+          "groupName": String,
+          "inclusion": String,
+          "exclusion": String
+        }
+      ]
+    }
+  ]
+}
+```
+
+| 値       | タイプ | 説明 |
+| --------------- | ------- | ------ |
+| header          | Object  | ヘッダ領域 |
+| - resultCode    | Integer | 結果コード |
+| - resultMessage | String  | 結果メッセージ |
+| - isSuccessful  | Boolean | 成否 |
+|categories|	List|	カテゴリー一覧 |
+|- name | String | カテゴリー名 |
+|- subCategories | List |	サブカテゴリーのリスト |
+|-- code | String | カテゴリーコード(テンプレートの登録/変更する際、使用) |
+|-- name | String |	カテゴリー名 |
+|-- groupName | String |	カテゴリーグループ名 |
+|-- inclusion | String |	カテゴリー対象テンプレートの説明 |
+|-- exclusion| String| カテゴリの除外対象のテンプレートの説明 |
+
+<a id="register-templates"></a>
+
+### テンプレートの登録
+<a id="request-12"></a>
+
+#### リクエスト
+[URL]
+
+```
+POST  /alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 値    | タイプ | 説明 |
+| ------------ | ------ | -------- |
+| appkey       | String | 固有のアプリキー |
+| senderKey | String | 発信キー |
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| 値    | タイプ | 必須 | 説明                               |
+| ------------ | ------ | ---- | ---------------------------------------- |
+| X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+[Request body]
+
+```
+{
+  "templateCode" : String,
+  "templateName" : String,
+  "templateContent" : String,
+  "templateMessageType": String,
+  "templateEmphasizeType" : String,
+  "templateExtra": String,
+  "templateTitle" : String,
+  "templateSubtitle" : String,
+  "templateImageName" : String,
+  "templateImageUrl" : String,
+  "securityFlag": Boolean,
+  "categoryCode": String,
+  "buttons" : [
+    {
+      "ordering" : Integer,
+      "type" : String,
+      "name" : String,
+      "linkMo" : String,
+      "linkPc" : String,
+      "schemeIos" : String,
+      "schemeAndroid" : String
+    }
+  ]
+}
+```
+
+| 値       | タイプ | 必須 | 説明                               |
+| --------------- | ------- | ---- | ---------------------------------------- |
+| templateCode    | String  | O    | テンプレートコード(最大20文字)                           |
+| templateName    | String  | O    | テンプレート名(最大150文字)                             |
+| templateContent | String  | O    | テンプレート本文(最大1300文字)                         |
+| templateMessageType| String | X  | テンプレートメッセージタイプ(BA:基本型、EX:付加情報型、AD:広告追加型、MI:複合型)<br>EX：templateExtraフィールド必須<br>MI：templateExtraフィールド必須」 |
+|templateEmphasizeType| String| X  | テンプレートハイライトタイプ（NONE：基本、TEXT：ハイライト、ITEM_LIST:アイテムリスト型, default：NONE）<br>TEXT：templateTitle、templateSubtitleフィールド必須<br>ITEM_LIST: 画像、ヘッダ、アイテムハイライトアイテムリストのうち1つ以上必須 |
+| templateExtra     | String  | X  | テンプレート付加情報 |
+|tempalteTitle      | String  | X  | テンプレートのタイトル(最大50字、Android:2行、23字以上のコマ処理、iOS:2行、27字以上のコマ処理) |
+|templateSubtitle   | String  | X  | テンプレートの補助フレーズ(最大50文字、Android:18字以上のコマを省く、iOS:21字以上のコマを省く) |
+|templateImageName  | String  |	X  | 画像名（アップロードされたファイル名） |
+|templateImageUrl   | String  |	X  | 画像のURL |
+|securityFlag| Boolean | X| セキュリティテンプレートかどうか<br>OTPなどのセキュリティメッセージの場合、設定<br>発信当時のメインデバイスを除くすべてのデバイスにメッセージテキストミノチュル(default: false) |
+|categoryCode| String | X | テンプレートのカテゴリコード(テンプレートカテゴリー照会API参考, default: 999999)<br>カテゴリーを入力し、テンプレートを優先審査 |
+| buttons         | List    | X    | ボタンリスト(最大5個)                             |
+| -ordering       | Integer | X    | ボタン順序(1～5)                               |
+| -type           | String  | X    | ボタンタイプ(WL：Webリンク、AL：アプリリンク、DS：配送照会、BK：Botキーワード、MD：メッセージ伝達、BC：相談トーク転換、BT：Bot転換、AC：チャンネル追加) |[広告追加/複合型のみ]) |
+| -name           | String  | X    | ボタン名(ボタンがある場合は必須、最大14文字)              |
+| -linkMo         | String  | X    | モバイルWebリンク(WLタイプの場合は必須フィールド、最大500文字)       |
+| -linkPc         | String  | X    | PC Webリンク(WLタイプの場合は任意フィールド、最大500文字)        |
+| -schemeIos      | String  | X    | iOSアプリリンク(ALタイプの場合は必須フィールド、最大500文字)       |
+| -schemeAndroid  | String  | X    | Androidアプリリンク(ALタイプの場合は必須フィールド、最大500文字)   |
+
+<a id="response-13"></a>
+
+#### レスポンス
+```
+{
+  "header" : {
+    "resultCode" :  Integer,
+    "resultMessage" :  String,
+    "isSuccessful" :  boolean
+  }
+}
+```
+
+| 値       | タイプ | 説明 |
+| --------------- | ------- | ------ |
+| header          | Object  | ヘッダ領域 |
+| - resultCode    | Integer | 結果コード |
+| - resultMessage | String  | 結果メッセージ |
+| - isSuccessful  | Boolean | 成否 |
+
+<a id="modify-templates"></a>
+
+### テンプレートの修正
+<a id="request-13"></a>
+
+#### リクエスト
+[URL]
+
+```
+PUT  /alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 値    | タイプ | 説明 |
+| ------------ | ------ | -------- |
+| appkey       | String | 固有のアプリキー |
+| senderKey | String | 発信キー |
+| templateCode | String | テンプレートコード |
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| 値    | タイプ | 必須 | 説明                               |
+| ------------ | ------ | ---- | ---------------------------------------- |
+| X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+[Request body]
+
+```
+{
+  "templateName" : String,
+  "templateContent" : String,
+  "templateMessageType": String,
+  "templateEmphasizeType" : String,
+  "templateExtra": String,
+  "templateTitle" : String,
+  "templateSubtitle" : String,
+  "templateImageName" : String,
+  "templateImageUrl" : String,
+  "securityFlag": Boolean,
+  "categoryCode": String,
+  "buttons" : [
+    {
+      "ordering" : Integer,
+      "type" : String,
+      "name" : String,
+      "linkMo" : String,
+      "linkPc" : String,
+      "schemeIos" : String,
+      "schemeAndroid" : String
+    }
+  ]
+}
+```
+
+| 値       | タイプ | 必須 | 説明                               |
+| --------------- | ------- | ---- | ---------------------------------------- |
+| templateName    | String  | O    | テンプレート名(最大150文字)                             |
+| templateContent | String  | O    | テンプレート本文(最大1300文字)                         |
+| templateMessageType| String | X  | テンプレートメッセージタイプ(BA:基本型、EX:付加情報型、AD:広告追加型、MI:複合型)<br>EX：templateExtraフィールド必須<br>MI：templateExtraフィールド必須」 |
+| templateEmphasizeType| String| X  | テンプレートハイライトタイプ（NONE：基本、TEXT：ハイライト、default：NONE）<br>TEXT：templateTitle、templateSubtitleフィールド必須 |
+| templateExtra   | String  | X    |テンプレート付加情報 |
+| tempalteTitle| String | X| テンプレートのタイトル(最大50字、Android:2行、23字以上のコマ処理、iOS:2行、27字以上のコマ処理) |
+| templateSubtitle| String | X| テンプレートの補助フレーズ(最大50文字、Android:18字以上のコマを省く、iOS:21字以上のコマを省く) |
+| templateImageName  | String  |	X  | 画像名（アップロードされたファイル名） |
+| templateImageUrl   | String  |	X  | 画像のURL |
+|securityFlag| Boolean | X| セキュリティテンプレートかどうか<br>OTPなどのセキュリティメッセージの場合、設定<br>発信当時のメインデバイスを除くすべてのデバイスにメッセージテキストミノチュル(default: false) |
+|categoryCode| String | X | テンプレートのカテゴリコード(テンプレートカテゴリー照会API参考, default: 999999)<br>カテゴリーを入力し、テンプレートを優先審査 |
+| buttons         | List    | X    | ボタンリスト(最大5個)                             |
+| -ordering       | Integer | X    | ボタン順序(1～5)                               |
+| -type           | String  | X    | ボタンタイプ(WL：Webリンク、AL：アプリリンク、DS：配送照会、BK：Botキーワード、MD：メッセージ伝達、BC：相談トーク転換、BT：Bot転換、AC：チャンネル追加) |[広告追加/複合型のみ]) |
+| -name           | String  | X    | ボタン名(ボタンがある場合は必須、最大14文字)              |
+| -linkMo         | String  | X    | モバイルWebリンク(WLタイプの場合は必須フィールド、最大500文字)       |
+| -linkPc         | String  | X    | PC Webリンク(WLタイプの場合は任意フィールド、最大500文字)        |
+| -schemeIos      | String  | X    | iOSアプリリンク(ALタイプの場合は必須フィールド、最大500文字)       |
+| -schemeAndroid  | String  | X    | Androidアプリリンク(ALタイプの場合は必須フィールド、最大500文字)   |
+
+<a id="response-14"></a>
+
+#### レスポンス
+```
+{
+  "header" : {
+    "resultCode" :  Integer,
+    "resultMessage" :  String,
+    "isSuccessful" :  boolean
+  }
+}
+```
+
+| 値       | タイプ | 説明 |
+| --------------- | ------- | ------ |
+| header          | Object  | ヘッダ領域 |
+| - resultCode    | Integer | 結果コード |
+| - resultMessage | String  | 結果メッセージ |
+| - isSuccessful  | Boolean | 成否 |
+
+<a id="delete-templates"></a>
+
+### テンプレートの削除
+<a id="request-14"></a>
+
+#### リクエスト
+[URL]
+
+```
+DELETE  /alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 値    | タイプ | 説明 |
+| ------------ | ------ | -------- |
+| appkey       | String | 固有のアプリキー |
+| plusFriendId | String | 発信キー |
+| templateCode | String | テンプレートコード |
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+<a id="response-15"></a>
+
+#### レスポンス
+```
+{
+  "header" : {
+    "resultCode" :  Integer,
+    "resultMessage" :  String,
+    "isSuccessful" :  boolean
+  }
+}
+```
+
+| 値       | タイプ | 説明 |
+| --------------- | ------- | ------ |
+| header          | Object  | ヘッダ領域 |
+| - resultCode    | Integer | 結果コード |
+| - resultMessage | String  | 結果メッセージ |
+| - isSuccessful  | Boolean | 成否 |
+
+* 承認されたテンプレートを削除する時、NHN Cloud内でのみ削除されます。(3日間未送信のテンプレートのみ削除可能)
+* 承認されたテンプレートの場合、カカオトークBizメッセージの制約のため、カカオ内部データは削除できません。
+* カカオに残っているテンプレートは1年間使っていないと休眠処理され、休眠状態が1年間続くと削除処理されます。(カカオでテンプレートが休眠に切り替わるときや、削除されるときは担当者に通知が送信されます。)
+
+
+<a id="inquire-of-templates"></a>
+
+### テンプレートの問い合わせをする
+<a id="request-15"></a>
+
+#### リクエスト
+[URL]
+
+```
+POST  /alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}/comments
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 値    | タイプ | 説明 |
+| ------------ | ------ | -------- |
+| appkey       | String | 固有のアプリキー |
+| plusFriendId | String | 発信キー |
+| templateCode | String | テンプレートコード |
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| 値    | タイプ | 必須 | 説明                               |
+| ------------ | ------ | ---- | ---------------------------------------- |
+| X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+[Request body]
+
+```
+{
+  "comment" : String
+}
+```
+
+| 値 | タイプ | 必須 | 説明 |
+| ------- | ------ | ---- | ----- |
+| comment | String | O    | お問い合わせ内容 |
+
+* REJステータスのテンプレートにコメントを付けると、REQステータスに変更されます。
+
+<a id="response-16"></a>
+
+#### レスポンス
+```
+{
+  "header" : {
+    "resultCode" :  Integer,
+    "resultMessage" :  String,
+    "isSuccessful" :  boolean
+  }
+}
+```
+
+| 値       | タイプ | 説明 |
+| --------------- | ------- | ------ |
+| header          | Object  | ヘッダ領域 |
+| - resultCode    | Integer | 結果コード |
+| - resultMessage | String  | 結果メッセージ |
+| - isSuccessful  | Boolean | 成否 |
+
+<a id="send-inquiry-on-templates-with-file-attachment"></a>
+
+### ファイルを添付してテンプレートお問い合わせ
+<a id="request-16"></a>
+
+#### リクエスト
+[URL]
+
+```
+POST  /alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}/comments_file
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+|値|	タイプ|	説明|
+|---|---|---|
+|appkey|	String|	固有のAppkey|
+|plusFriendId|	String|	発信キー |
+|templateCode|	String|	テンプレートコード |
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+|値|	タイプ|	必須|	説明|
+|---|---|---|---|
+|X-Secret-Key|	String| O | コンソールで作成できます。 |
+
+[Request Body]
+
+```
+{
+  "comment" : String,
+  "attachments" : File
+}
+```
+
+|値|	タイプ|	必須| 	説明                                                                                                                                      |
+|---|---|---|------------------------------------------------------------------------------------------------------------------------------------------|
+|comment|	String |	O | お問い合わせ内容                                                                                                                                 |
+|attachments| List<File> | X | 添付ファイルリスト(最大10個)<br>- 対応拡張子 ( .png, .jpg, .jpeg, .gif, .pdf, .hwp, .doc, .docx )<br>- 各個別ファイルの最大サイズ 50mb<br>- アップロード可能なファイルの総最大サイズ 100mb |
+
+* REJステータスのテンプレートにコメントを付けると、REQステータスに変更されます。
+
+<a id="response-17"></a>
+
+#### レスポンス
+```
+{
+  "header" : {
+    "resultCode" :  Integer,
+    "resultMessage" :  String,
+    "isSuccessful" :  boolean
+  }
+}
+```
+
+|値|	タイプ|	説明|
+|---|---|---|
+|header|	Object|	ヘッダ領域|
+|- resultCode|	Integer|	結果コード|
+|- resultMessage|	String| 結果メッセージ|
+|- isSuccessful|	Boolean| 成否|
+
+<a id="single-query-for-template"></a>
+
+### テンプレート個別照会
+
+<a id="request-18"></a>
+
+#### リクエスト
+
+[URL]
+
+```
+GET  /alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 名前          | 	タイプ    | 	説明    |
+|--------------|---------|---------|
+| appkey       | 	String | 	固有のアプリキー |
+| senderKey    | 	String | 	発信キー  |
+| templateCode | String  | テンプレートコード |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前          | 	タイプ    | 	必須 | 	説明             |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | コンソールで作成できます。 |
+
+| テンプレートステータスコード | 説明  |
+|-----------|------|
+| TSC01     | 申請   |
+| TSC02     | 審査中 |
+| TSC03     | 承認  |
+| TSC04     | 却下   |
+
+[例]
+
+```
+curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}"
+```
+
+<a id="response-19"></a>
+
+#### レスポンス
+
+```
+{
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
+  },
+  "templates": {
+      "plusFriendId": String,
+      "senderKey": String,
+      "plusFriendType": String,
+      "templateCode": String,
+      "kakaoTemplateCode": String,
+      "templateName": String,
+      "templateMessageType": String,
+      "templateEmphasizeType": String,
+      "templateContent": String,
+      "templateExtra": String,
+      "templateAd": String,
+      "templateTitle": String,
+      "templateSubtitle": String,
+      "templateHeader": String,
+      "templateItem": {
+        "list": [{
+          "title": String,
+          "description": String
+        }],
+        "summary": {
+          "title": String,
+          "description": String
+        }
+      },
+      "templateItemHighlight": {
+        "title": String,
+        "description": String,
+        "imageUrl": String
+      },
+      "templateRepresentLink": {
+        "linkMo": String,
+        "linkPc": String,
+        "schemeIos": String,
+        "schemeAndroid": String,
+      },
+      "templateImageName": String,
+      "templateImageUrl": String,
+      "buttons": [
+        {
+            "ordering": Integer,
+            "type": String,
+            "name": String,
+            "linkMo": String,
+            "linkPc": String,
+            "schemeIos": String,
+            "schemeAndroid": String,
+            "bizFormId": Integer,
+            "pluginId": String,
+            "telNumber": String
+        }
+      ],
+      "quickReplies": [
+        {
+            "ordering": Integer,
+            "type": String,
+            "name": String,
+            "linkMo": String,
+            "linkPc": String,
+            "schemeIos": String,
+            "schemeAndroid": String,
+            "bizFormId": Integer
+        }
+      ],
+      "comments": [
+          {
+              "id": Integer,
+              "content": String,
+              "userName": String,
+              "createdAt": String,
+              "attachment": [{
+                "originalFileName": String,
+                "filePath": String
+              }],
+              "status": String
+          }  
+      ],
+      "status": String,
+      "statusName": String,
+      "securityFlag": Boolean,
+      "categoryCode": String,
+      "block": Boolean,
+      "dormant": Boolean,
+      "createDate": String,
+      "updateDate": String
+  }
+}
+```
+
+---
+
+| 名前                     | タイプ     | Not Null | 説明                                                                                                                                                                              |
+|-------------------------|---------|:--------:|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| header                  | Object  |    O     | ヘッダ領域                                                                                                                                                                           |
+| - resultCode            | Integer |    O     | 結果コード                                                                                                                                                                           |
+| - resultMessage         | String  |    O     | 結果メッセージ                                                                                                                                                                          |
+| - isSuccessful          | Boolean |    O     | 成否                                                                                                                                                                           |
+| templates               | Object    |    X     | テンプレートリスト                                                                                                                                                                         |
+| - plusFriendId          | String  |    O     | カカオトークチャンネル検索用IDまたは発信プロフィールグループ名                                                                                                                                                 |
+| - senderKey             | String  |    O     | 発信キー                                                                                                                                                                            |
+| - plusFriendType        | String  |    O     | プラスフレンドタイプ(NORMAL, GROUP)                                                                                                                                                          |
+| - templateCode          | String  |    O     | テンプレートコード                                                                                                                                                                          |
+| - kakaoTemplateCode     | String  |    O     | オリジナルテンプレートコード                                                                                                                                                                        |
+| - templateName          | String  |    O     | テンプレート名                                                                                                                                                                            |
+| - templateMessageType   | String  |    X     | テンプレートメッセージタイプ(BA:基本型, EX: 付加情報型, AD:チャンネル追加型, MI:複合型)                                                                                                                             |
+| - templateEmphasizeType | String  |    X     | テンプレート強調表示タイプ(NONE:基本、 TEXT:強調 表示、IMAGE:画像型、 ITEM_LIST:アイテムリスト型)                                                                                                             |
+| - templateContent       | String  |    X     | テンプレート本文                                                                                                                                                                          |
+| - templateExtra         | String  |    X     | テンプレート付加情報                                                                                                                                                                          |
+| - templateAd            | String  |    X     | テンプレート内の受信同意リクエストまたは簡単な広告文言                                                                                                                                                        |
+| - tempalteTitle         | String  |    X     | テンプレートタイトル                                                                                                                                                                          |
+| - templateSubtitle      | String  |    X     | テンプレート補助文言                                                                                                                                                                            |
+| - templateHeader        | String  |    X     | テンプレートヘッダ(最大16文字)                                                                                                                                                                   |
+| - templateItem          | Object  |    X     | アイテム                                                                                                                                                                             |
+| -- list                 | List    |    X     | アイテムリスト(最小2個、最大10個)                                                                                                                                                           |
+| --- title               | String  |    X     | タイトル(最大6文字)                                                                                                                                                                       |
+| --- description         | String  |    X     | 説明(最大23文字)                                                                                                                                                                    |
+| -- summary              | Object  |    X     | アイテム要約情報                                                                                                                                                                       |
+| --- title               | String  |    X     | タイトル(最大6文字)                                                                                                                                                                       |
+| --- description         | String  |    X     | 説明(変数及び通貨単位、数字、カンマ、ピリオドのみ使用可能、最大14文字)                                                                                                                                    |
+| - templateItemHighlight | Object  |    X     | アイテムハイライト                                                                                                                                                                       |
+| -- title                | String  |    X     | タイトル(最大30文字、サムネイル画像がある場合は21文字)                                                                                                                                                   |
+| -- description          | String  |    X     | 説明(最大19文字、サムネイル画像がある場合は13文字)                                                                                                                                                    |
+| -- imageUrl             | String  |    X     | サムネイル画像アドレス                                                                                                                                                                      |
+| - templateRepresentLink | Object  |    X     | 代表リンク                                                                                                                                                                           |
+| -- linkMo               | String  |    X     | モバイルWebリンク(最大500文字)                                                                                                                                                                |
+| -- linkPc               | String  |    X     | PC Webリンク(最大500文字)                                                                                                                                                                 |
+| -- schemeIos            | String  |    X     | iOSアプリリンク(最大500文字)                                                                                                                                                                |
+| -- schemeAndroid        | String  |    X     | Androidアプリリンク(最大500文字)                                                                                                                                                              |
+| - templateImageName     | String  |    X     | 画像名(アップロードしたファイル名)                                                                                                                                                                   |
+| - templateImageUrl      | String  |    X     | 画像URL                                                                                                                                                                            |
+| - buttons               | List    |    X     | ボタンリスト                                                                                                                                                                          |
+| -- ordering             | Integer |    X     | ボタン順序(1～5)                                                                                                                                                                       |
+| -- type                 | String  |    X     | ボタンタイプ(WL: Webリンク, AL: アプリリンク, DS: 配送照会, BK: ボットキーワード, MD: メッセージ転送, BC: 相談トーク切替, BT: ボット切替, AC: チャンネル追加, BF: ビジネスフォーム, P1: 画像セキュリティ転送プラグインID, P2: 個人情報利用プラグインID, P3: ワンクリック決済プラグインID, TN: 電話発信) |
+| -- name                 | String  |    X     | ボタン名                                                                                                                                                                           |
+| -- linkMo               | String  |    X     | モバイルWebリンク(WLタイプの場合は必須フィールド)                                                                                                                                                        |
+| -- linkPc               | String  |    X     | PC Webリンク(WLタイプの場合は任意フィールド)                                                                                                                                                         |
+| -- schemeIos            | String  |    X     | iOSアプリリンク(ALタイプの場合は必須フィールド)                                                                                                                                                        |
+| -- schemeAndroid        | String  |    X     | Androidアプリリンク(ALタイプの場合は必須フィールド)                                                                                                                                                      |
+| -- bizFormId            | Integer |    X     | ビジネスフォーム ID(BFタイプの場合は必須)                                                                                                                                                           |
+| -- pluginId             | String  |    X     | プラグインID(最大24文字)                                                                                                                                                                  |
+| -- telNumber            | 	String  | 	X  | TN(電話発信)タイプボタンの場合、伝達する電話番号                                                                                                                                                       |
+| - quickReplies          | List    |    X     | クイックリプライリスト(最大5個)                                                                                                                                                                  |
+| -- ordering             | Integer |    X     | クイックリプライ順序(クイックリプライがある場合は必須)                                                                                                                                                            |
+| -- type                 | String  |    X     | クイックリプライタイプ(WL: Webリンク, AL: アプリリンク, BK: ボットキーワード, BC: 相談トーク切替, BT: ボット切替, BF: ビジネスフォーム)                                                                                                          |
+| -- name                 | String  |    X     | クイックリプライ名(クイックリプライがある場合は必須、最大14文字)                                                                                                                                                    |
+| -- linkMo               | String  |    X     | モバイルWebリンク(WLタイプの場合は必須フィールド、最大500文字)                                                                                                                                               |
+| -- linkPc               | String  |    X     | PC Webリンク(WLタイプの場合は任意フィールド、最大500文字)                                                                                                                                                  |
+| -- schemeIos            | String  |    X     | iOSアプリリンク(ALタイプの場合は必須フィールド、最大500文字)                                                                                                                                               |
+| -- schemeAndroid        | String  |    X     | Androidアプリリンク(ALタイプの場合は必須フィールド、最大500文字)                                                                                                                                             |
+| -- bizFormId            | Integer |    X     | ビジネスフォーム ID(BFタイプの場合は必須)                                                                                                                                                           |
+| - comments              | List    |    X     | 審査結果                                                                                                                                                                                    |
+| -- id                   | Integer |    X     | お問い合わせID                                                                                                                                                                           |
+| -- content              | String  |    X     | お問い合わせ内容                                                                                                                                                                           |
+| -- userName             | String  |    X     | 作成者                                                                                                                                                                             |
+| -- createAt             | String  |    O     | 登録日                                                                                                                                                                           |
+| -- attachment           | List    |    X     | 添付ファイル                                                                                                                                                                           |
+| --- originalFileName    | String  |    X     | 添付ファイル名                                                                                                                                                                          |
+| --- filePath            | String  |    X     | 添付ファイルパス                                                                                                                                                                        |
+| -- status               | String  |    X     | コメントステータス(INQ: 問い合わせ, APR: 承認, REJ: 却下, REP: 回答, REQ: 審査中)                                                                                                                             |
+| - status                | String  |    O     | テンプレートステータス                                                                                                                                                                           |
+| - statusName            | String  |    X     | テンプレートステータス名                                                                                                                                                                          |
+| - securityFlag          | Boolean |    X     | セキュリティテンプレート区分                                                                                                                                                                        |
+| - categoryCode          | String  |    X     | テンプレートカテゴリーコード                                                                                                                                                                     |
+| - block                 | Boolean |    X     | ブロック可否                                                                                                                                                                              |
+| - dormant               | Boolean |    X     | 休止可否                                                                                                                                                                            |
+| - createDate            | String  |    O     | 作成日                                                                                                                                                                           |
+| - updateDate            | String  |    X     | 修正日                                                                                                                                                                           |
+
+
+<a id="list-templates"></a>
+
+### テンプレートリストの照会
+
+<a id="request-19"></a>
+
+#### リクエスト
+
+[URL]
+
+```
+GET  /alimtalk/v2.3/appkeys/{appkey}/templates
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 値 | タイプ | 説明 |
+| ------ | ------ | ------ |
+| appkey | String | 固有のアプリキー |
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| 値    | タイプ | 必須 | 説明                               |
+| ------------ | ------ | ---- | ---------------------------------------- |
+| X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+[Query parameter]
+
+| 値      | タイプ | 必須 | 説明    |
+| -------------- | ------- | ---- | ------------- |
+| plusFriendId   | String  | X    | 発信キー      |
+| templateCode   | String  | X    | テンプレートコード |
+| templateName   | String  | X    | テンプレート名 |
+| templateStatus | String  | X    | テンプレートステータスコード |
+| pageNum        | Integer | X    | ページ番号(基本：1) |
+| pageSize       | Integer | X    | 照会件数(基本：15、最大: 1000) |
+
+| テンプレートステータスコード | 説明 |
+| --------- | ---- |
+| TSC01     | リクエスト |
+| TSC02     | 検収中 |
+| TSC03     | 承認 |
+| TSC04     | 差し戻し |
+
+[例]
+```
+curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/templates?plusFriendId={発信キー}&templateStatus={テンプレートステータスコード}"
+```
+
+<a id="response-20"></a>
+
+#### レスポンス
+```
+
+{
+  "header" : {
+      "resultCode" :  Integer,
+      "resultMessage" :  String,
+      "isSuccessful" :  boolean
+  },
+  "templateListResponse": {
+      "templates": [
+          {
+              "plusFriendId": String,
+              "plusFriendType": String,
+              "templateCode": String,
+              "templateName": String,
+              "templateContent": String,
+              "templateEmphasizeType": String,
+              "templateTitle" : String,
+              "templateSubtitle" : String,
+              "templateImageName" : String,
+              "templateImageUrl" : String,
+              "templateMessageType" : String,
+              "templateExtra" : String,
+              "templateAd" : String,
+              "buttons": [
+                {
+                    "ordering":Integer,
+                    "type": String,
+                    "name": String,
+                    "linkMo": String,
+                    "linkPc": String,
+                    "schemeIos": String,
+                    "schemeAndroid": String
+                }
+                ],
+                "comments": [
+                  {
+                      "id": Integer,
+                      "content": String,
+                      "userName": String,
+                      "createdAt": String,
+                      "attachment": [{
+                        "originalFileName": String,
+                        "filePath": String
+                      }],
+                      "status": String
+                    }  
+                ],
+                "status": String,
+                "statusName": String,
+                "createDate": String
+            }
+        ],
+        "totalCount": Integer
+    }
+}
+```
+
+| 値            | タイプ | 説明                                                                                                     |
+| -------------------- | ------- |--------------------------------------------------------------------------------------------------------|
+| header               | Object  | ヘッダ領域                                                                                                  |
+| - resultCode         | Integer | 結果コード                                                                                                  |
+| - resultMessage      | String  | 結果メッセージ                                                                                                |
+| - isSuccessful       | Boolean | 成否                                                                                                     |
+| templateListResponse | Object  | 本文領域                                                                                                   |
+| - templates          | List    | テンプレートリスト                                                                                              |
+| -- plusFriendId      | String  | プラスフレンドID                                                                                              |
+| -- plusFriendType    | String  | プラスフレンドタイプ(NORMAL、GROUP)                                                                               |
+| -- templateCode      | String  | テンプレートコード                                                                                              |
+| -- templateName      | String  | テンプレート名                                                                                                |
+| -- templateContent   | String  | テンプレート本文                                                                                               |
+| -- templateEmphasizeType| String| テンプレートハイライトタイプ（NONE：基本、TEXT：ハイライト、default：NONE）<br>TEXT：templateTitle、templateSubtitleフィールド必須          |
+| -- tempalteTitle     | String  | テンプレートのタイトル(最大50字、Android:2行、23字以上のコマ処理、iOS:2行、27字以上のコマ処理)                                             |
+| -- templateSubtitle  | String  | テンプレートの補助フレーズ(最大50文字、Android:18字以上のコマを省く、iOS:21字以上のコマを省く)                                              |
+| -- templateImageName | String  | 画像名（アップロードされたファイル名）                                                                                    |
+| -- templateImageUrl  | String  | 画像のURL                                                                                                 |
+| -- templateMessageType| String  | テンプレートメッセージタイプ(BA:基本型、EX:付加情報型、AD:広告追加型、MI:複合型)<br>EX：templateExtraフィールド必須<br>MI：templateExtraフィールド必須」 |
+| -- templateExtra     | String  | テンプレート付加情報                                                                                             |
+| -- templateAd        | String  | テンプレート内の受信同意または簡単な広告文句                                                                                 |
+| -- buttons           | List    | ボタンリスト                                                                                                 |
+| --- ordering         | Integer | ボタン順序(1～5)                                                                                             |
+| --- type             | String  | ボタンタイプ(WL：Webリンク、AL：アプリリンク、DS：配送照会、BK：Botキーワード、MD：メッセージ伝達、BC：相談トーク転換、BT：Bot転換、AC：チャンネル追加)              |
+| --- name             | String  | ボタン名                                                                                                   |
+| --- linkMo           | String  | モバイルWebリンク(WLタイプの場合は必須フィールド)                                                                           |
+| --- linkPc           | String  | PC Webリンク(WLタイプの場合は任意フィールド)                                                                            |
+| --- schemeIos        | String  | iOSアプリリンク(ALタイプの場合は必須フィールド)                                                                            |
+| --- schemeAndroid    | String  | Androidアプリリンク(ALタイプの場合は必須フィールド)                                                                        |
+| -- comments          | List    | 検収結果                                                                                                   |
+| --- id               | Integer | お問い合わせID                                                                                               |
+| --- content          | String  | お問い合わせ内容                                                                                               |
+| --- userName          | String  | 作成者                                                                                                    |
+| --- createAt          | String  | 登録日                                                                                                    |
+| --- attachment        | List | 添付ファイル                                                                                                 |
+| ---- originalFileName | String | 添付ファイル名                                                                                                |
+| ---- filePath         | String | 添付ファイルへのパス                                                                                             |
+| --- status            | String  | 応答状態(INQ：お問い合わせ、APR：承認、REJ：差し戻し、REP：返信, REQ : 検査中)                                                     |
+| -- status            | String  | テンプレートのステータス                                                                                           |
+| -- statusName        | String  | テンプレートのステータス名                                                                                          |
+| -- createDate        | String  | 作成日時                                                                                                   |
+| - totalCount         | Integer | 総個数                                                                                                    |
+
+<a id="change-template-to-channel-add-type"></a>
+
+### テンプレートチャンネル追加型に変更
+
+<a id="request-17"></a>
+
+#### リクエスト
+[URL]
+```
+PUT  /alimtalk/v2.3/appkeys/{appKey}/senders/{senderKey}/templates/{templateCode}/convert-add-channel
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 名前 |	タイプ|	説明|
+|---|---|---|
+|appkey|	String|	固有のアプリキー|
+|senderKey|	String|	発信キー |
+|templateCode|	String|	テンプレートコード |
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| 名前 |	タイプ|	必須|	説明|
+|---|---|---|---|
+|X-Secret-Key|	String| O | コンソールで作成できます。  |
+
+* グループプロフィールに登録されたテンプレートは、チャンネルタイプに変換することはできません
+
+<a id="response-18"></a>
+
+#### レスポンス
+```
+{
+  "header" : {
+    "resultCode" :  Integer,
+    "resultMessage" :  String,
+    "isSuccessful" :  boolean
+  }
+}
+```
+
+| 名前 |	タイプ|	説明|
+|---|---|---|
+|header|	Object|	ヘッダ領域|
+|- resultCode|	Integer|	結果コード|
+|- resultMessage|	String| 結果メッセージ|
+|- isSuccessful|	Boolean| 成否|
+
+<a id="list-template-modifications"></a>
+
+### テンプレートの修正リスト照会
+
+<a id="request-20"></a>
+
+#### リクエスト
+
+[URL]
+
+```
+GET  /alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}/modifications
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 値 | タイプ | 説明 |
+|---|---|---|
+| appkey       | String | 固有のアプリキー |
+| plusFriendId | String | プラスフレンドID |
+| templateCode | String | テンプレートコード |
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| 値    | タイプ | 必須 | 説明                               |
+|---|---|---|---|
+| X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+[例]
+```
+curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}/modifications"
+```
+
+<a id="response-21"></a>
+
+#### レスポンス
+```
+
+{
+  "header" : {
+      "resultCode" :  Integer,
+      "resultMessage" :  String,
+      "isSuccessful" :  boolean
+  },
+  "templateModificationsResponse": {
+      "templates": [
+          {
+              "plusFriendId": String,
+              "plusFriendType": String,
+              "templateCode": String,
+              "templateName": String,
+              "templateContent": String,
+              "templateEmphasizeType": String,
+              "templateTitle" : String,
+              "templateSubtitle" : String,
+              "templateImageName" : String,
+              "templateImageUrl" : String,
+              "templateMessageType" : String,
+              "templateExtra" : String,
+              "templateAd" : String,
+              "buttons": [
+                {
+                    "ordering":Integer,
+                    "type": String,
+                    "name": String,
+                    "linkMo": String,
+                    "linkPc": String,
+                    "schemeIos": String,
+                    "schemeAndroid": String
+                }
+                ],
+                "comments": [
+                  {
+                      "id": Integer,
+                      "content": String,
+                      "userName": String,
+                      "createdAt": String,
+                      "attachment": [{
+                        "originalFileName": String,
+                        "filePath": String
+                      }],
+                      "status": String
+                    }  
+                ],
+                "status": String,
+                "statusName": String,
+                "activated": boolean,
+                "createDate": String
+            }
+        ],
+        "totalCount": Integer
+    }
+}
+```
+
+| 値            | タイプ | 説明                               |
+| -------------------- | ------- | ---------------------------------------- |
+| header               | Object  | ヘッダ領域                            |
+| - resultCode         | Integer | 結果コード                            |
+| - resultMessage      | String  | 結果メッセージ                           |
+| - isSuccessful       | Boolean | 成否                             |
+| templateModificationsResponse | Object  | 本文領域                            |
+| - templates          | List    | テンプレートリスト                          |
+| -- plusFriendId      | String  | プラスフレンドID                                 |
+| -- plusFriendType    | String  | プラスフレンドタイプ(NORMAL、GROUP)                  |
+| -- templateCode      | String  | テンプレートコード                           |
+| -- templateName      | String  | テンプレート名                             |
+| -- templateContent   | String  | テンプレート本文                           |
+| -- templateEmphasizeType| String| テンプレートハイライトタイプ（NONE：基本、TEXT：ハイライト、default：NONE）<br>TEXT：templateTitle、templateSubtitleフィールド必須 |
+| -- tempalteTitle     | String  | テンプレートのタイトル(最大50字、Android:2行、23字以上のコマ処理、iOS:2行、27字以上のコマ処理) |
+| -- templateSubtitle  | String  | テンプレートの補助フレーズ(最大50文字、Android:18字以上のコマを省く、iOS:21字以上のコマを省く) |
+| -- templateImageName | String  | 画像名（アップロードされたファイル名） |
+| -- templateImageUrl  | String  | 画像のURL |
+| -- templateMessageType| String  | テンプレートメッセージタイプ(BA:基本型、EX:付加情報型、AD:広告追加型、MI:複合型)<br>EX：templateExtraフィールド必須<br>MI：templateExtraフィールド必須」 |
+| -- templateExtra     | String  | テンプレート付加情報 |
+| -- templateAd        | String  | テンプレート内の受信同意または簡単な広告文句 |
+| -- buttons           | List    | ボタンリスト                            |
+| --- ordering         | Integer | ボタン順序(1～5)                               |
+| --- type             | String  | ボタンタイプ(WL：Webリンク、AL：アプリリンク、DS：配送照会、BK：Botキーワード、MD：メッセージ伝達、BC：相談トーク転換、BT：Bot転換、AC：チャンネル追加) |
+| --- name             | String  | ボタン名                            |
+| --- linkMo           | String  | モバイルWebリンク(WLタイプの場合は必須フィールド)                |
+| --- linkPc           | String  | PC Webリンク(WLタイプの場合は任意フィールド)                 |
+| --- schemeIos        | String  | iOSアプリリンク(ALタイプの場合は必須フィールド)                |
+| --- schemeAndroid    | String  | Androidアプリリンク(ALタイプの場合は必須フィールド)            |
+| -- comments          | List    | 検収結果                            |
+| --- id               | Integer | お問い合わせID                                   |
+| --- content          | String  | お問い合わせ内容                            |
+| ---userName          | String  | 作成者                               |
+| ---createAt          | String  | 登録日                            |
+| --- attachment        | List | 添付ファイル                           |
+| ---- originalFileName | String | 添付ファイル名                        |
+| ---- filePath         | String | 添付ファイルへのパス                   |
+| ---status            | String  | 応答状態(INQ：お問い合わせ、APR：承認、REJ：差し戻し、REP：返信, REQ : 検査中) |
+| -- status            | String  | テンプレートのステータス                           |
+| -- statusName        | String  | テンプレートのステータス名                           |
+| -- activated         | Boolean  | 有効かどうか                            |
+| -- createDate        | String  | 作成日時                            |
+| - totalCount         | Integer | 総個数                              |
+
+<a id="register-template-image"></a>
+
+### テンプレート画像の登録
+<a id="request-21"></a>
+
+#### リクエスト
+[URL]
+
+```
+POST  /alimtalk/v2.3/appkeys/{appkey}/template-image
+Content-Type: multipart/form-data
+```
+
+[Path parameter]
+
+| 値 | タイプ | 説明 |
+|---|---|---|
+| appkey       | String | 固有のアプリキー |
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+| 値    | タイプ | 必須 | 説明                               |
+|---|---|---|---|
+| X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+[Request parameter]
+
+|値|	タイプ|	必須|	説明|
+|---|---|---|---|
+|file|	File|	O |	画像ファイル |
+
+[例]
+```
+curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/template-image" -F "file=@alimtalk-template-image.jpeg"
+```
+
+<a id="response-22"></a>
+
+#### レスポンス
+```
+{
+  "header" : {
+    "resultCode" :  Integer,
+    "resultMessage" :  String,
+    "isSuccessful" :  boolean
+  },
+  "templateImage" {
+    "templateImageName": String,
+    "templateImageUrl": String
+  }
+}
+```
+
+| 値            | タイプ | 説明                               |
+| -------------------- | ------- | ---------------------------------------- |
+| header               | Object  | ヘッダ領域                            |
+| - resultCode         | Integer | 結果コード                            |
+| - resultMessage      | String  | 結果メッセージ                           |
+| - isSuccessful       | Boolean | 成否                             |
+| templateImage         |	Object |	本文領域|
+|- templateImageName    | String |	画像名（アップロードされたファイル名） |
+|- templateImageUrl     | String |	画像のURL |
+
+<a id="register-template-item-highlight-images"></a>
+
+### テンプレートアイテムハイライト画像登録
+
+<!-- TODO: translate body -->
+
+<a id="request-22"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="response-23"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="register-template-plugin"></a>
+
+### テンプレートプラグイン登録
+
+<!-- TODO: translate body -->
+
+<a id="request-23"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="response-24"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="modify-template-plugin"></a>
+
+### テンプレートプラグイン修正
+
+<!-- TODO: translate body -->
+
+<a id="request-24"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="response-25"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="modify-template-plugin-2"></a>
+
+### テンプレートプラグイン削除
+
+<!-- TODO: translate body -->
+
+<a id="request-25"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="response-26"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="retrieve-template-plugin"></a>
+
+### テンプレートプラグイン照会
+
+<!-- TODO: translate body -->
+
+<a id="request-26"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="response-27"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="manage-alternative-delivery"></a>
+
+## 代替送信管理
+<a id="register-an-sms-appkey"></a>
+
+### SMS AppKey登録
+
+[URL]
+
+```
+POST  /alimtalk/v2.3/appkeys/{appkey}/failback/appkey
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 値    | タイプ | 説明 |
+| ------------ | ------ | -------- |
+| appkey       | String | 固有のアプリキー |
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 値    | タイプ | 必須 | 説明                               |
+| ------------ | ------ | ---- | ---------------------------------------- |
+| X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+
+[Request body]
+
+```
+{
+    "resendAppKey": String
+}
+```
+
+| 値    | タイプ | 必須 | 説明                               |
+|---|---|---|---|
+|resendAppKey|	String|	O | 代替発送に設定するSMS AppKey |
+
+[例]
+```
+curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
+```
+
+<a id="response-28"></a>
+
+#### レスポンス
+```
+
+{
+  "header" : {
+      "resultCode" :  Integer,
+      "resultMessage" :  String,
+      "isSuccessful" :  boolean
+  }
+}
+```
+
+<a id="register-alternative-delivery-settings"></a>
+
+### 代替送信設定登録
+
+[URL]
+
+```
+POST  /alimtalk/v2.3/appkeys/{appkey}/failback
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 値    | タイプ | 説明 |
+| ------------ | ------ | -------- |
+| appkey       | String | 固有のアプリキー |
+
+[Header]
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 値    | タイプ | 必須 | 説明                               |
+| ------------ | ------ | ---- | ---------------------------------------- |
+| X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+[Request body]
+
+```
+{  
+   "plusFriendId": String,
+   "isResend": Boolean,
+   "resendSendNo": String
+}
+```
+
+| 値               | タイプ | 必須 | 説明                                |
+| ---------------------- | ------- | ---- | ---------------------------------------- |
+| plusFriendId           | String  | O    | プラスフレンドID(最大30文字)                         |
+| isResend             | boolean | O    | 送信失敗時、代替送信するかどうか<br>コンソールで送信失敗設定をした時、デフォルト設定は再送信になっています。 |
+| resendSendNo         | String  | O    | 代替送信発信番号(最大13桁)<br><span style="color:red">(SMSサービスに登録された発信番号ではない場合、代替送信が失敗することがあります。)</span> |
+
+[例]
+```
+curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/failback/appkey -d '{"plusFriendId": "@プラスフレンド","isResend": true,"resendSendNo": "01012341234" }
+```
+
+<a id="response-29"></a>
+
+#### レスポンス
+```
+
+{
+  "header" : {
+      "resultCode" :  Integer,
+      "resultMessage" :  String,
+      "isSuccessful" :  boolean
+  }
+}
+```

--- a/ja/alimtalk-api-guide.md
+++ b/ja/alimtalk-api-guide.md
@@ -1,6 +1,10 @@
 ## Notification > KakaoTalk Bizmessage > お知らせトーク > API v2.3 Guide
 
+<a id="alimtalk"></a>
+
 ## お知らせトーク
+
+<a id="api-domain"></a>
 
 #### [APIドメイン]
 
@@ -17,13 +21,19 @@
 </tbody>
 </table>
 
+<a id="overview-of-v23-api"></a>
+
 ## v2.3 API紹介
 1. お知らせトーク大量送信照会、統計照会APIが追加されました。
 2. 置換メッセージ送信時、buttonsフィールドが追加されました。
 3. 専門メッセージ送信時、buttonsフィールドにchatExtra、chatEvent、targetフィールドが追加されました。
 4. メッセージ照会時、buttonsフィールドにchatExtra、chatEvent、targetフィールドが追加されました。
 
+<a id="general-messages"></a>
+
 ## 一般メッセージ
+
+<a id="request-of-sending-replaced-messages"></a>
 
 ### メッセージ置換送信リクエスト
 
@@ -143,6 +153,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","templateParameter":{"{日本語識別子フィールド}":"{置換データ}"}}]}'
 ```
 
+<a id="response"></a>
+
 #### レスポンス
 
 ```
@@ -183,6 +195,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultCode           | Integer | 送信リクエスト結果コード |
 | -- resultMessage        | String  | 送信リクエスト結果メッセージ |
 | -- recipientGroupingKey | String  | 受信者グルーピングキー |
+
+<a id="request-of-sending-full-text"></a>
 
 ### メッセージ全文送信リクエスト
 
@@ -346,6 +360,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/raw-messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","content":"{内容}","buttons":[{"ordering":"{ボタン順序}","type":"{ボタンタイプ}","name":"{ボタン名}","linkMo":"{モバイルWebリンク}"}]}]}'
 ```
 
+<a id="response-2"></a>
+
 #### レスポンス
 
 ```
@@ -387,7 +403,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultMessage        | String  | 送信リクエスト結果メッセージ |
 | -- recipientGroupingKey | String  | 受信者グルーピングキー |
 
+<a id="list-messages"></a>
+
 ### メッセージリストの照会
+
+<a id="request"></a>
 
 #### リクエスト
 
@@ -436,6 +456,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 90日以上前の送信リクエストデータは照会されません。
 * 送信リクエスト日時の範囲は最大30日です。
+
+<a id="response-3"></a>
 
 #### レスポンス
 ```
@@ -518,7 +540,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
-#### SMS/LMS再送信ステータス
+**SMS/LMS再送信ステータス**
 | 値 | 説明                      |
 | ----- | ------------------------------- |
 | RSC01 | 再送信の対象ではない                 |
@@ -527,7 +549,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | RSC04 | 再送信成功                  |
 | RSC05 | 再送信失敗                  |
 
+<a id="get-messages"></a>
+
 ### メッセージ単件照会
+
+<a id="request-2"></a>
 
 #### リクエスト
 
@@ -560,6 +586,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-4"></a>
 
 #### レスポンス
 ```
@@ -738,6 +766,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - senderGroupingKey    | String  | 発信グルーピングキー                            |
 | - recipientGroupingKey | String  | 受信者グルーピングキー                           |
 
+<a id="authentication-messages"></a>
+
 ## 認証メッセージ
 
 <span id="precautions-authword"></span>
@@ -750,6 +780,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 - 例1)認証メッセージAPI送信リクエストした時、全文(テンプレート日本語識別子含む)に認証文言が含まれていない場合は、送信に失敗します。
 - 例2)認証文言が英文の場合、大文字/小文字の区別なしで有効性チェックが行われます。
 
+
+<a id="request-of-sending-replaced-messages-2"></a>
 
 ### メッセージ置換送信リクエスト
 
@@ -853,7 +885,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","templateParameter":{"{日本語識別子フィールド}":"{置換データ}"}}]}'
 ```
 
-#### レスポンス
+**レスポンス**
 
 ```
 {
@@ -896,6 +928,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultCode           | Integer | 送信リクエスト結果コード |
 | -- resultMessage        | String  | 送信リクエスト結果メッセージ |
 | -- recipientGroupingKey | String  | 受信者グルーピングキー |
+
+<a id="request-of-sending-full-text-2"></a>
 
 ### メッセージ全文送信リクエスト
 
@@ -1011,7 +1045,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/raw-messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","content":"{内容}","buttons":[{"ordering":"{ボタン順序}","type":"{ボタンタイプ}","name":"{ボタン名}","linkMo":"{モバイルWebリンク}"}]}]}'
 ```
 
-#### レスポンス
+**レスポンス**
 
 ```
 {
@@ -1058,7 +1092,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultMessage        | String  | 送信リクエスト結果メッセージ |
 | -- recipientGroupingKey | String  | 受信者グルーピングキー |
 
+<a id="list-messages-2"></a>
+
 ### メッセージリストの照会
+
+<a id="request-3"></a>
 
 #### リクエスト
 
@@ -1108,7 +1146,7 @@ Content-Type: application/json;charset=UTF-8
 * 90日以上前の送信リクエストデータは照会されません。
 * 送信リクエスト日時の範囲は最大30日です。
 
-#### レスポンス
+**レスポンス**
 ```
 {
   "header" : {
@@ -1202,7 +1240,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<a id="get-messages-2"></a>
+
 ### メッセージ結果アップデート件数の照会
+
+<a id="request-4"></a>
 
 #### リクエスト
 
@@ -1239,6 +1281,8 @@ Content-Type: application/json;charset=UTF-8
 | endUpdateDate       | 	String  | O   | 	結果アップデート照会終了時間(yyyy-MM-dd HH:mm) |
 | alimtalkMessageType | 	String  | X   | 	お知らせトークのメッセージタイプ(NORMAL, AUTH)           |
 
+<a id="response-5"></a>
+
 #### レスポンス
 
 ```
@@ -1266,7 +1310,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/message-results/count?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
-#### SMS/LMS再送信ステータス
+### SMS/LMS再送信ステータス
 | 値 | 説明                      |
 | ----- | ------------------------------- |
 | RSC01 | 再送信の対象ではない                 |
@@ -1381,8 +1425,14 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - senderGroupingKey    | String  | 発信グルーピングキー                            |
 | - recipientGroupingKey | String  | 受信者グルーピングキー                           |
 
+<a id="message"></a>
+
 ## メッセージ
+<a id="cancel-sending-messages"></a>
+
 ### メッセージ送信取消
+
+<a id="request-5"></a>
 
 #### リクエスト
 
@@ -1418,6 +1468,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 一般/認証メッセージは同じAPIでキャンセルできます。
 
+<a id="response-6"></a>
+
 #### レスポンス
 ```
 {
@@ -1441,7 +1493,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
 ```
 
+<a id="query-updates-of-message-result"></a>
+
 ### メッセージ結果アップデートの照会
+
+<a id="request-6"></a>
 
 #### リクエスト
 
@@ -1477,6 +1533,8 @@ Content-Type: application/json;charset=UTF-8
 | alimtalkMessageType | String  | X    | お知らせトークメッセージタイプ(NORMAL、AUTH)           |
 | pageNum             | Integer | X    | ページ番号(基本：1)                      |
 | pageSize            | Integer | X    | 照会件数(基本：15、最大: 1000)          |
+
+<a id="response-7"></a>
 
 #### レスポンス
 ```
@@ -1530,8 +1588,14 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/message-results?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
+<a id="mass-delivery"></a>
+
 ## 大量送信
+<a id="list-mass-delivery-requests"></a>
+
 ### 大量送信リクエストリスト照会
+
+<a id="request-8"></a>
 
 #### リクエスト
 [URL]
@@ -1571,6 +1635,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum | optional, Integer | - | X | ページ番号 |
 | pageSize | optional, Integer | 1000 | X | 検索数 |
 
+<a id="curl"></a>
+
 #### cURL
 ```
 curl -X GET \
@@ -1578,6 +1644,8 @@ https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appK
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-9"></a>
 
 #### レスポンス
 ```
@@ -1667,7 +1735,11 @@ https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appK
 | - totalCount | Integer | 総数
 
 
+<a id="list-mass-delivery-recipients"></a>
+
 ### 大量送信大量送信受信者リスト照会
+
+<a id="request-9"></a>
 
 #### リクエスト
 [URL]
@@ -1706,6 +1778,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum | optional, Integer | - | X | ページ番号 |
 | pageSize | optional, Integer | 1000 | X | 検索数 |
 
+<a id="curl-2"></a>
+
 #### cURL
 ```
 curl -X GET \
@@ -1713,6 +1787,8 @@ https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appK
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-10"></a>
 
 #### レスポンス
 ```
@@ -1758,7 +1834,11 @@ https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appK
 | -- resultCodeName | String | 結果コード内容 |
 | - totalCount | Integer | 総数 |
 
+<a id="get-a-mass-delivery-recipient"></a>
+
 ### 大量送信大量送信受信者照会
+
+<a id="request-10"></a>
 
 #### リクエスト
 [URL]
@@ -1798,6 +1878,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum | optional, Integer | - | X | ページ番号 |
 | pageSize | optional, Integer | 1000 | X | 検索数 |
 
+<a id="curl-3"></a>
+
 #### cURL
 ```
 curl -X GET \
@@ -1805,6 +1887,8 @@ https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appK
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-11"></a>
 
 #### レスポンス
 ```
@@ -1906,9 +1990,15 @@ https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appK
 |-- currencyType | String |	message(ユーザーに伝達されるメッセージ)内に含まれる価格/金額/決済金額の通貨単位KRW、USD、EURなどの国際通貨コードを使用(モーメント広告に該当) |
 
 
+<a id="templates"></a>
+
 ## テンプレート
 
+<a id="list-template-categories"></a>
+
 ### テンプレートカテゴリー照会
+<a id="request-11"></a>
+
 #### リクエスト
 [URL]
 
@@ -1932,6 +2022,8 @@ Content-Type: application/json;charset=UTF-8
 | 値    | タイプ | 必須 | 説明                               |
 |---|---|---|---|
 | X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+<a id="response-12"></a>
 
 #### レスポンス
 ```
@@ -1974,7 +2066,11 @@ Content-Type: application/json;charset=UTF-8
 |-- inclusion | String |	カテゴリー対象テンプレートの説明 |
 |-- exclusion| String| カテゴリの除外対象のテンプレートの説明 |
 
+<a id="register-templates"></a>
+
 ### テンプレートの登録
+<a id="request-12"></a>
+
 #### リクエスト
 [URL]
 
@@ -2053,6 +2149,8 @@ Content-Type: application/json;charset=UTF-8
 | -schemeIos      | String  | X    | iOSアプリリンク(ALタイプの場合は必須フィールド、最大500文字)       |
 | -schemeAndroid  | String  | X    | Androidアプリリンク(ALタイプの場合は必須フィールド、最大500文字)   |
 
+<a id="response-13"></a>
+
 #### レスポンス
 ```
 {
@@ -2071,7 +2169,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | 結果メッセージ |
 | - isSuccessful  | Boolean | 成否 |
 
+<a id="modify-templates"></a>
+
 ### テンプレートの修正
+<a id="request-13"></a>
+
 #### リクエスト
 [URL]
 
@@ -2149,6 +2251,8 @@ Content-Type: application/json;charset=UTF-8
 | -schemeIos      | String  | X    | iOSアプリリンク(ALタイプの場合は必須フィールド、最大500文字)       |
 | -schemeAndroid  | String  | X    | Androidアプリリンク(ALタイプの場合は必須フィールド、最大500文字)   |
 
+<a id="response-14"></a>
+
 #### レスポンス
 ```
 {
@@ -2167,7 +2271,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | 結果メッセージ |
 | - isSuccessful  | Boolean | 成否 |
 
+<a id="delete-templates"></a>
+
 ### テンプレートの削除
+<a id="request-14"></a>
+
 #### リクエスト
 [URL]
 
@@ -2190,6 +2298,8 @@ Content-Type: application/json;charset=UTF-8
   "X-Secret-Key": String
 }
 ```
+
+<a id="response-15"></a>
 
 #### レスポンス
 ```
@@ -2214,7 +2324,11 @@ Content-Type: application/json;charset=UTF-8
 * カカオに残っているテンプレートは1年間使っていないと休眠処理され、休眠状態が1年間続くと削除処理されます。(カカオでテンプレートが休眠に切り替わるときや、削除されるときは担当者に通知が送信されます。)
 
 
+<a id="inquire-of-templates"></a>
+
 ### テンプレートの問い合わせをする
+<a id="request-15"></a>
+
 #### リクエスト
 [URL]
 
@@ -2255,6 +2369,8 @@ Content-Type: application/json;charset=UTF-8
 
 * REJステータスのテンプレートにコメントを付けると、REQステータスに変更されます。
 
+<a id="response-16"></a>
+
 #### レスポンス
 ```
 {
@@ -2273,7 +2389,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | 結果メッセージ |
 | - isSuccessful  | Boolean | 成否 |
 
+<a id="send-inquiry-on-templates-with-file-attachment"></a>
+
 ### ファイルを添付してテンプレートお問い合わせ
+<a id="request-16"></a>
+
 #### リクエスト
 [URL]
 
@@ -2316,6 +2436,8 @@ Content-Type: application/json;charset=UTF-8
 
 * REJステータスのテンプレートにコメントを付けると、REQステータスに変更されます。
 
+<a id="response-17"></a>
+
 #### レスポンス
 ```
 {
@@ -2334,7 +2456,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 結果メッセージ|
 |- isSuccessful|	Boolean| 成否|
 
+<a id="change-template-to-channel-add-type"></a>
+
 ### テンプレート個別照会
+
+<a id="request-17"></a>
 
 #### リクエスト
 
@@ -2377,6 +2503,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}"
 ```
+
+<a id="response-18"></a>
 
 #### レスポンス
 
@@ -2556,7 +2684,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - updateDate            | String  |    X     | 修正日                                                                                                                                                                           |
 
 
+<a id="single-query-for-template"></a>
+
 ### テンプレートリストの照会
+
+<a id="request-18"></a>
 
 #### リクエスト
 
@@ -2605,6 +2737,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/templates?plusFriendId={発信キー}&templateStatus={テンプレートステータスコード}"
 ```
+
+<a id="response-19"></a>
 
 #### レスポンス
 ```
@@ -2708,7 +2842,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- createDate        | String  | 作成日時                                                                                                   |
 | - totalCount         | Integer | 総個数                                                                                                    |
 
+<a id="list-templates"></a>
+
 ### テンプレートチャンネル追加型に変更
+
+<a id="request-19"></a>
 
 #### リクエスト
 [URL]
@@ -2737,6 +2875,8 @@ Content-Type: application/json;charset=UTF-8
 
 * グループプロフィールに登録されたテンプレートは、チャンネルタイプに変換することはできません
 
+<a id="response-20"></a>
+
 #### レスポンス
 ```
 {
@@ -2755,7 +2895,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 結果メッセージ|
 |- isSuccessful|	Boolean| 成否|
 
+<a id="list-template-modifications"></a>
+
 ### テンプレートの修正リスト照会
+
+<a id="request-20"></a>
 
 #### リクエスト
 
@@ -2788,6 +2932,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}/modifications"
 ```
+
+<a id="response-21"></a>
 
 #### レスポンス
 ```
@@ -2893,7 +3039,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- createDate        | String  | 作成日時                            |
 | - totalCount         | Integer | 総個数                              |
 
+<a id="register-template-image"></a>
+
 ### テンプレート画像の登録
+<a id="request-21"></a>
+
 #### リクエスト
 [URL]
 
@@ -2929,6 +3079,8 @@ Content-Type: multipart/form-data
 curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/template-image" -F "file=@alimtalk-template-image.jpeg"
 ```
 
+<a id="response-22"></a>
+
 #### レスポンス
 ```
 {
@@ -2954,7 +3106,101 @@ curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}
 |- templateImageName    | String |	画像名（アップロードされたファイル名） |
 |- templateImageUrl     | String |	画像のURL |
 
+<a id="register-template-item-highlight-images"></a>
+
+### テンプレートアイテムハイライト画像登録
+
+<!-- TODO: translate body -->
+
+<a id="request-22"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="response-23"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="register-template-plugin"></a>
+
+### テンプレートプラグイン登録
+
+<!-- TODO: translate body -->
+
+<a id="request-23"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="response-24"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="modify-template-plugin"></a>
+
+### テンプレートプラグイン修正
+
+<!-- TODO: translate body -->
+
+<a id="request-24"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="response-25"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="modify-template-plugin-2"></a>
+
+### テンプレートプラグイン削除
+
+<!-- TODO: translate body -->
+
+<a id="request-25"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="response-26"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="retrieve-template-plugin"></a>
+
+### テンプレートプラグイン照会
+
+<!-- TODO: translate body -->
+
+<a id="request-26"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="response-27"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="manage-alternative-delivery"></a>
+
 ## 代替送信管理
+<a id="register-an-sms-appkey"></a>
+
 ### SMS AppKey登録
 
 [URL]
@@ -2999,6 +3245,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
 ```
 
+<a id="response-28"></a>
+
 #### レスポンス
 ```
 
@@ -3010,6 +3258,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
   }
 }
 ```
+
+<a id="register-alternative-delivery-settings"></a>
 
 ### 代替送信設定登録
 
@@ -3057,6 +3307,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/failback/appkey -d '{"plusFriendId": "@プラスフレンド","isResend": true,"resendSendNo": "01012341234" }
 ```
+
+<a id="response-29"></a>
 
 #### レスポンス
 ```

--- a/ko/alimtalk-api-guide.md
+++ b/ko/alimtalk-api-guide.md
@@ -1,6 +1,10 @@
 ## Notification > KakaoTalk Bizmessage > 알림톡 > API v2.3 Guide
 
+<a id="alimtalk"></a>
+
 ## 알림톡
+
+<a id="api-domain"></a>
 
 #### [API Domain]
 
@@ -17,6 +21,8 @@
 </tbody>
 </table>
 
+<a id="overview-of-v23-api"></a>
+
 ## Overview of v2.3 API
 
 1. 알림톡 바로 연결, 아이템리스트, 톡 비즈 플러그인, 대표 링크, 비즈니스폼 버튼 기능이 추가되었습니다.
@@ -24,7 +30,11 @@
 3. 알림톡 플러그인 등록/수정/삭제/조회 API가 추가되었습니다.
 4. 메시지 리스트 조회 API에서 buttons 필드가 삭제되었습니다.
 
+<a id="general-messages"></a>
+
 ## 일반 메시지
+
+<a id="request-of-sending-replaced-messages"></a>
 
 ### 메시지 치환 발송 요청
 
@@ -154,6 +164,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages -d '{"senderKey":"{발신 키}","templateCode":"{템플릿 코드}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{수신번호}","templateParameter":{"{치환자 필드}":"{치환 데이터}"}}]}'
 ```
 
+<a id="response"></a>
+
 #### 응답
 
 ```
@@ -194,6 +206,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultCode           | Integer |    O     | 발송 요청 결과 코드  |
 | -- resultMessage        | String  |    O     | 발송 요청 결과 메시지 |
 | -- recipientGroupingKey | String  |    X     | 수신자 그룹핑 키    |
+
+<a id="request-of-sending-full-text"></a>
 
 ### 메시지 전문 발송 요청
 
@@ -393,6 +407,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/raw-messages -d '{"senderKey":"{발신 키}","templateCode":"{템플릿 코드}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{수신번호}","content":"{내용}","buttons":[{"ordering":"{버튼 순서}","type":"{버튼 타입}","name":"{버튼 이름}","linkMo":"{모바일 웹 링크}"}]}]}'
 ```
 
+<a id="response-2"></a>
+
 #### 응답
 
 ```
@@ -434,7 +450,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultMessage        | String  |    O     | 발송 요청 결과 메시지 |
 | -- recipientGroupingKey | String  |    X     | 수신자 그룹핑 키    |
 
+<a id="list-messages"></a>
+
 ### 메시지 리스트 조회
+
+<a id="request"></a>
 
 #### 요청
 
@@ -485,6 +505,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 90일 이전 발송 요청 데이터는 조회되지 않습니다.
 * 발송 요청 일시의 범위는 최대 30일입니다.
+
+<a id="response-3"></a>
 
 #### 응답
 
@@ -557,7 +579,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<a id="get-messages"></a>
+
 ### 메시지 단건 조회
+
+<a id="request-2"></a>
 
 #### 요청
 
@@ -593,6 +619,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-4"></a>
 
 #### 응답
 
@@ -774,6 +802,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - senderGroupingKey     | String  |    X     | 발신 그룹핑 키                                                                                                                                                               |
 | - recipientGroupingKey  | String  |    X     | 수신자 그룹핑 키                                                                                                                                                              |
 
+<a id="authentication-messages"></a>
+
 ## 인증 메시지
 
 <span id="precautions-authword"></span>
@@ -786,6 +816,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 
 - 예시 1-1) 인증 메시지 API 요청시 전문(템플릿 치환자 포함)에 인증 문구가 포함되어 있지 않은 경우 발송 실패됩니다.
 - 예시 1-2) 인증 문구가 영문인 경우 대소문자 구분 없이 유효성 검사가 진행됩니다.
+
+<a id="request-of-sending-replaced-messages-2"></a>
 
 ### 메시지 치환 발송 요청
 
@@ -818,6 +850,8 @@ Content-Type: application/json;charset=UTF-8
 [Request body]
 [위와 동일](./alimtalk-api-guide/#_3)
 
+<a id="request-of-sending-full-text-2"></a>
+
 ### 메시지 전문 발송 요청
 
 [URL]
@@ -849,7 +883,11 @@ Content-Type: application/json;charset=UTF-8
 [Request Body]
 [위와 동일](./alimtalk-api-guide/#_5)
 
+<a id="list-messages-2"></a>
+
 ### 메시지 리스트 조회
+
+<a id="request-3"></a>
 
 #### 요청
 
@@ -881,7 +919,11 @@ Content-Type: application/json;charset=UTF-8
 [Query parameter]
 [위와 동일](./alimtalk-api-guide/#_7)
 
+<a id="get-messages-2"></a>
+
 ### 메시지 단건 조회
+
+<a id="request-4"></a>
 
 #### 요청
 
@@ -918,13 +960,21 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/messages/{requestId}/{recipientSeq}"
 ```
 
+<a id="response-5"></a>
+
 #### 응답
 
 [위와 동일](./alimtalk-api-guide/#_9)
 
+<a id="message"></a>
+
 ## 메시지
 
+<a id="cancel-sending-messages"></a>
+
 ### 메시지 발송 취소
+
+<a id="request-5"></a>
 
 #### 요청
 
@@ -962,6 +1012,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 일반/인증 메시지 모두 동일한 API로 취소할 수 있습니다.
 
+<a id="response-6"></a>
+
 #### 응답
 
 ```
@@ -987,7 +1039,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
 ```
 
+<a id="query-updates-of-message-result"></a>
+
 ### 메시지 결과 업데이트 조회
+
+<a id="request-6"></a>
 
 #### 요청
 
@@ -1025,6 +1081,8 @@ Content-Type: application/json;charset=UTF-8
 | alimtalkMessageType | 	String  | X   | 	알림톡 메시지 타입(NORMAL, AUTH)           |
 | pageNum             | 	Integer | 	X  | 	페이지 번호(기본: 1)                      |
 | pageSize            | 	Integer | 	X  | 	조회 건수(Default: 15, Max: 1000)      |
+
+<a id="response-7"></a>
 
 #### 응답
 
@@ -1080,7 +1138,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/message-results?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
+<a id="query-the-number-of-message-result-updates"></a>
+
 ### 메시지 결과 업데이트 건수 조회
+
+<a id="request-7"></a>
 
 #### 요청
 
@@ -1117,6 +1179,8 @@ Content-Type: application/json;charset=UTF-8
 | endUpdateDate       | 	String  | O   | 	결과 업데이트 조회 종료 시간(yyyy-MM-dd HH:mm) |
 | alimtalkMessageType | 	String  | X   | 	알림톡 메시지 타입(NORMAL, AUTH)           |
 
+<a id="response-8"></a>
+
 #### 응답
 
 ```
@@ -1144,6 +1208,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/message-results/count?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
+<a id="status-code-of-smslms-resending"></a>
+
 ### SMS/LMS 대체 발송 상태 코드
 
 | 이름    | 	설명                                  |
@@ -1154,9 +1220,15 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | RSC04 | 	대체 발송 성공                            |
 | RSC05 | 	대체 발송 실패                            |
 
+<a id="mass-delivery"></a>
+
 ## 대량 발송
 
+<a id="list-mass-delivery-requests"></a>
+
 ### 대량 발송 요청 목록 조회
+
+<a id="request-8"></a>
 
 #### 요청
 
@@ -1199,6 +1271,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum          | optional, Integer | -     | X   | 페이지 번호    |
 | pageSize         | optional, Integer | 1000  | X   | 검색 수      |
 
+<a id="curl"></a>
+
 #### cURL
 
 ```
@@ -1207,6 +1281,8 @@ curl -X GET \
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-9"></a>
 
 #### 응답
 
@@ -1261,7 +1337,11 @@ curl -X GET \
 | -- createUser       | String  |    X     | 생성 사용자(콘솔에서 발송 시 사용자 UUID로 저장)                                                 |
 | - totalCount        | Integer |    X     | 총개수                                                                            |
 
+<a id="list-mass-delivery-recipients"></a>
+
 ### 대량 발송 수신자 목록 조회
+
+<a id="request-9"></a>
 
 #### 요청
 
@@ -1301,6 +1381,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum          | optional, Integer | -     | X   | 페이지 번호    |
 | pageSize         | optional, Integer | 1000  | X   | 검색 수      |
 
+<a id="curl-2"></a>
+
 #### cURL
 
 ```
@@ -1309,6 +1391,8 @@ curl -X GET \
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-10"></a>
 
 #### 응답
 
@@ -1355,7 +1439,11 @@ curl -X GET \
 | -- resultCodeName | String  |    X     | 결과 코드 내용   |
 | - totalCount      | Integer |    X     | 총개수        |
 
+<a id="get-a-mass-delivery-recipient"></a>
+
 ### 대량 발송 수신자 조회
+
+<a id="request-10"></a>
 
 #### 요청
 
@@ -1396,6 +1484,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum          | optional, Integer | -     | X   | 페이지 번호    |
 | pageSize         | optional, Integer | 1000  | X   | 검색 수      |
 
+<a id="curl-3"></a>
+
 #### cURL
 
 ```
@@ -1404,6 +1494,8 @@ curl -X GET \
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-11"></a>
 
 #### 응답
 
@@ -1572,9 +1664,15 @@ curl -X GET \
 | -- pluginId             | String  |    X     | 플러그인 ID(최대 24자)                                                                                                                                                        |
 | -- target               | String  |    X     | 웹 링크 타입일 경우, "target":"out" 속성 추가 시 아웃 링크\<br\>기본 인앱 링크로 발송                                                                                                            |
 
+<a id="templates"></a>
+
 ## 템플릿
 
+<a id="list-template-categories"></a>
+
 ### 템플릿 카테고리 조회
+
+<a id="request-11"></a>
 
 #### 요청
 
@@ -1602,6 +1700,8 @@ Content-Type: application/json;charset=UTF-8
 | 이름           | 	타입     | 	필수 | 	설명              |
 |--------------|---------|-----|------------------|
 | X-Secret-Key | 	String | O   | 콘솔에서 생성할 수 있습니다. |
+
+<a id="response-12"></a>
 
 #### 응답
 
@@ -1645,7 +1745,11 @@ Content-Type: application/json;charset=UTF-8
 | -- inclusion    | String  |    X     | 카테고리 적용 대상 템플릿 설명        |
 | -- exclusion    | String  |    X     | 카테고리 제외 대상 템플릿 설명        |
 
+<a id="register-templates"></a>
+
 ### 템플릿 등록
+
+<a id="request-12"></a>
 
 #### 요청
 
@@ -1798,6 +1902,8 @@ Content-Type: application/json;charset=UTF-8
 * 채널 추가형(AD) 또는 복합형(MI) 메시지 유형 템플릿 등록 시 채널 추가(AC) 버튼이 첫 번째 순서에 위치해야 합니다.
 * 채널 추가(AC) 버튼의 버튼명은 "채널 추가"로 고정하여 등록해야 합니다.
 
+<a id="response-13"></a>
+
 #### 응답
 
 ```
@@ -1817,7 +1923,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
 
+<a id="modify-templates"></a>
+
 ### 템플릿 수정
+
+<a id="request-13"></a>
 
 #### 요청
 
@@ -1969,6 +2079,8 @@ Content-Type: application/json;charset=UTF-8
 * 채널 추가형(AD)과 복합형(MI) 메시지 유형 템플릿 수정 시, 채널 추가(AC) 버튼이 첫 번째 순서에 위치해야 합니다.
 * 채널 추가(AC) 버튼의 버튼명은 "채널 추가"로 고정하여, 수정해야 합니다.
 
+<a id="response-14"></a>
+
 #### 응답
 
 ```
@@ -1988,7 +2100,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
 
+<a id="delete-templates"></a>
+
 ### 템플릿 삭제
+
+<a id="request-14"></a>
 
 #### 요청
 
@@ -2019,6 +2135,8 @@ Content-Type: application/json;charset=UTF-8
 * 승인된 템플릿의 경우, 카카오톡 비즈메시지의 제약 때문에 카카오 내부 데이터는 삭제할 수 없습니다.
 * 카카오에 남아 있는 템플릿은 1년 미사용 시 휴면 처리되고, 휴면 상태가 1년간 지속되면 삭제 처리됩니다.(카카오에서 템플릿이 휴면 전환되거나 삭제되면 담당자에게 알림이 발송됩니다.)
 
+<a id="response-15"></a>
+
 #### 응답
 
 ```
@@ -2038,7 +2156,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
 
+<a id="inquire-of-templates"></a>
+
 ### 템플릿 문의하기
+
+<a id="request-15"></a>
 
 #### 요청
 
@@ -2083,6 +2205,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 반려 상태의 템플릿에 문의를 남길 경우, 검수 중(REQ) 상태로 변경됩니다.
 
+<a id="response-16"></a>
+
 #### 응답
 
 ```
@@ -2102,7 +2226,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
 
+<a id="send-inquiry-on-templates-with-file-attachment"></a>
+
 ### 파일 첨부하여 템플릿 문의하기
+
+<a id="request-16"></a>
 
 #### 요청
 
@@ -2149,6 +2277,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 반려 상태의 템플릿에 문의를 남길 경우, 검수 중(REQ) 상태로 변경됩니다.
 
+<a id="response-17"></a>
+
 #### 응답
 
 ```
@@ -2168,7 +2298,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
 
+<a id="change-template-to-channel-add-type"></a>
+
 ### 템플릿 채널 추가형으로 변경
+
+<a id="request-17"></a>
 
 #### 요청
 
@@ -2201,6 +2335,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 그룹 발신 프로필에 등록된 템플릿은 채널 추가형으로 전환할 수 없습니다.
 
+<a id="response-18"></a>
+
 #### 응답
 
 ```
@@ -2220,7 +2356,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
 
+<a id="single-query-for-template"></a>
+
 ### 템플릿 단건 조회
+
+<a id="request-18"></a>
 
 #### 요청
 
@@ -2263,6 +2403,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}"
 ```
+
+<a id="response-19"></a>
 
 #### 응답
 
@@ -2443,7 +2585,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - updateDate            | String  |    X     | 수정일자                                                                                                                                                                             |
 
 
+<a id="list-templates"></a>
+
 ### 템플릿 리스트 조회
+
+<a id="request-19"></a>
 
 #### 요청
 
@@ -2495,6 +2641,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates?templateStatus={템플릿 상태 코드}"
 ```
+
+<a id="response-20"></a>
 
 #### 응답
 
@@ -2677,7 +2825,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- updateDate            | String  |    X     | 수정일자                                                                                                                                                                   |
 | - totalCount             | Integer |    X     | 총개수                                                                                                                                                                    |
 
+<a id="list-template-modifications"></a>
+
 ### 템플릿 수정 리스트 조회
+
+<a id="request-20"></a>
 
 #### 요청
 
@@ -2713,6 +2865,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}/modifications"
 ```
+
+<a id="response-21"></a>
 
 #### 응답
 
@@ -2891,7 +3045,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- updateDate                 | String  |    X     | 수정일자                                                                                                                                                                   |
 | - totalCount                  | Integer |    X     | 총개수                                                                                                                                                                    |
 
+<a id="register-template-image"></a>
+
 ### 템플릿 이미지 등록
+
+<a id="request-21"></a>
 
 #### 요청
 
@@ -2932,6 +3090,8 @@ Content-Type: multipart/form-data
 curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/template-image" -F "file=@alimtalk-template-image.jpeg"
 ```
 
+<a id="response-22"></a>
+
 #### 응답
 
 ```
@@ -2958,7 +3118,11 @@ curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}
 | - templateImageName | String  |    X     | 이미지명(업로드한 파일명) |
 | - templateImageUrl  | String  |    X     | 이미지 URL        |
 
+<a id="register-template-item-highlight-images"></a>
+
 ### 템플릿 아이템 하이라이트 이미지 등록
+
+<a id="request-22"></a>
 
 #### 요청
 
@@ -2999,6 +3163,8 @@ Content-Type: multipart/form-data
 curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/template-image/item-highlight" -F "file=@alimtalk-template-image.jpeg"
 ```
 
+<a id="response-23"></a>
+
 #### 응답
 
 ```
@@ -3025,7 +3191,11 @@ curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}
 | - templateImageName | String  |    X     | 이미지명(업로드한 파일명) |
 | - templateImageUrl  | String  |    X     | 이미지 URL        |
 
+<a id="register-template-plugin"></a>
+
 ### 템플릿 플러그인 등록
+
+<a id="request-23"></a>
 
 #### 요청
 
@@ -3071,6 +3241,8 @@ Content-Type: application/json;charset=UTF-8
 | pluginId    | 	String | 	O  | 플러그인 아이디                                                   |
 | callbackUrl | 	String | 	O  | 플러그인 버튼 클릭 시, 수신받을 콜백 URL                                  |
 
+<a id="response-24"></a>
+
 #### 응답
 
 ```
@@ -3090,7 +3262,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
 
+<a id="modify-template-plugin"></a>
+
 ### 템플릿 플러그인 수정
+
+<a id="request-24"></a>
 
 #### 요청
 
@@ -3135,6 +3311,8 @@ Content-Type: application/json;charset=UTF-8
 | pluginType  | 	String | 	O  | 플러그인 타입(SECURE_IMAGE: 보안 이미지 전송, ONE_TIME_PROFILE: 개인정보 이용) |
 | callbackUrl | 	String | 	O  | 플러그인 버튼 클릭 시, 수신받을 콜백 URL                                  |
 
+<a id="response-25"></a>
+
 #### 응답
 
 ```
@@ -3154,7 +3332,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
 
+<a id="modify-template-plugin-2"></a>
+
 ### 템플릿 플러그인 삭제
+
+<a id="request-25"></a>
 
 #### 요청
 
@@ -3185,6 +3367,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|---------|-----|------------------|
 | X-Secret-Key | 	String | O   | 콘솔에서 생성할 수 있습니다. |
 
+<a id="response-26"></a>
+
 #### 응답
 
 ```
@@ -3204,7 +3388,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
 
+<a id="retrieve-template-plugin"></a>
+
 ### 템플릿 플러그인 조회
+
+<a id="request-26"></a>
 
 #### 요청
 
@@ -3233,6 +3421,8 @@ Content-Type: application/json;charset=UTF-8
 | 이름           | 	타입     | 	필수 | 	설명              |
 |--------------|---------|-----|------------------|
 | X-Secret-Key | 	String | O   | 콘솔에서 생성할 수 있습니다. |
+
+<a id="response-27"></a>
 
 #### 응답
 
@@ -3271,7 +3461,11 @@ Content-Type: application/json;charset=UTF-8
 | - modifiable     | Boolean |    X     | 수정 가능 여부                                                   |
 | - deletable      | Boolean |    X     | 삭제 가능 여부                                                   |
 
+<a id="manage-alternative-delivery"></a>
+
 ## 대체 발송 관리
+
+<a id="register-an-sms-appkey"></a>
 
 ### SMS AppKey 등록
 
@@ -3318,6 +3512,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
 ```
 
+<a id="response-28"></a>
+
 #### 응답
 
 ```
@@ -3337,6 +3533,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | - resultCode    | Integer |    O     | 결과 코드  |
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
+
+<a id="register-alternative-delivery-settings"></a>
 
 ### 대체 발송 설정 등록
 
@@ -3386,6 +3584,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/failback/appkey -d '{"senderKey": "0be23c29de88d6888798aeda57062516354d74ba","isResend": true,"resendSendNo": "01012341234" }
 ```
+
+<a id="response-29"></a>
 
 #### 응답
 


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Body text is never modified.** The model only sees heading outlines; edits apply to heading lines (and `<!-- TODO: translate body -->` stubs for missing sections) only.

## Analysis

| | |
| --- | --- |
| Engine | `claude-code (CLI)` |
| Model | `claude-haiku-4-5` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `alpha` |
| Scope | 1 doc(s) scanned · 4 file(s) changed |
| Self-verify | ⚠️ 22 mismatch(es) remain |
| Jenkins build | http://testlab.cloud.toastoven.net:8080/job/user-guide-agent/job/align-heading/job/260521/72/ |
| Generated | 2026-06-15T07:54:44 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`alpha`): [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FAlimtalk%2Fblob%2Falpha%2Fko%2Falimtalk-api-guide.md&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FAlimtalk%2Fpull%2F220&source=ko&langs=en%2Cja)

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra demoted | extra removed | verify |
| --- | --: | --: | --: | --: | --: | --: | --: | :--: |
| `ko/alimtalk-api-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/alimtalk-api-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/alimtalk-api-guide.md` | 1 | 15 | 0 | 0 | 0 | 4 | 0 | ⚠️ 8 |
| `ja/alimtalk-api-guide-align-v2.md` | 0 | 0 | 0 | 16 | 0 | 0 | 0 | ⚠️ 14 |

<details><summary>남은 불일치 (검토 필요)</summary>

- `ja/alimtalk-api-guide.md`:
  - extra_in_target (ko#None/ja#24)
  - extra_in_target (ko#None/ja#25)
  - extra_in_target (ko#None/ja#26)
  - extra_in_target (ko#None/ja#27)
  - missing_in_target (ko#31/ja#None)
  - missing_in_target (ko#32/ja#None)
  - missing_in_target (ko#33/ja#None)
  - missing_in_target (ko#34/ja#None)
- `ja/alimtalk-api-guide-align-v2.md`:
  - extra_in_target (ko#None/ja#21)
  - extra_in_target (ko#None/ja#22)
  - extra_in_target (ko#None/ja#23)
  - extra_in_target (ko#None/ja#24)
  - missing_in_target (ko#31/ja#None)
  - missing_in_target (ko#32/ja#None)
  - missing_in_target (ko#33/ja#None)
  - missing_in_target (ko#34/ja#None)
  - missing_in_target (ko#67/ja#None)
  - missing_in_target (ko#68/ja#None)
  - missing_in_target (ko#69/ja#None)
  - extra_in_target (ko#None/ja#73)
  - extra_in_target (ko#None/ja#74)
  - extra_in_target (ko#None/ja#75)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/Alimtalk`