### PR TITLE
chore(pre-align): align heading structure (32 docs) with ko

### DIFF
--- a/en/alimtalk-api-guide-v2.0.md
+++ b/en/alimtalk-api-guide-v2.0.md
@@ -1,6 +1,12 @@
+<!-- pre-align:aligned sig=4ea84933972e -->
+
 ## Notification > KakaoTalk Bizmessage > AlimTalk > API v2.0 Guide
 
+<a id="alimtalk"></a>
+
 ## AlimTalk
+
+<a id="api-domain"></a>
 
 #### [API Domain]
 
@@ -17,6 +23,8 @@
 </tbody>
 </table>
 
+<a id="overview-of-v20-api"></a>
+
 ## Overview of v2.0 API
 1. It has been changed to allow emphasized template for Register Template API(for a full-text delivery, the title value can be configured.)
 2. Expanded the template type. Ad or additional information can be added.
@@ -25,7 +33,11 @@
 5. Added Attach Files to Send Inquiry on Templates API.
 
 
+<a id="general-messages"></a>
+
 ## General Messages
+
+<a id="request-of-sending-replaced-messages"></a>
 
 ### Request of Sending Replaced Messages
 
@@ -119,6 +131,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages -d '{"senderkey":"{Sender key}","templateCode":"{template code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{recipient number}","templateParameter":{"{replaced field}":"{replacement data}"}}]}'
 ```
 
+<a id="response"></a>
+
 #### Response
 
 ```
@@ -159,6 +173,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultCode           | Integer | Result code of delivery request    |
 | -- resultMessage        | String  | Result message of delivery request |
 | -- recipientGroupingKey | String  | Recipient's grouping key           |
+
+<a id="request-of-sending-full-text"></a>
 
 ### Request of Sending Full Text
 
@@ -270,6 +286,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/raw-messages -d '{"senderKey":"{Sender key}","templateCode":"{template code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{recipient number}","content":"{body}","buttons":[{"ordering":"{button sequence}","type":"{button type}","name":"{button name}","linkMo":"{mobile web link}"}]}]}'
 ```
 
+<a id="response-2"></a>
+
 #### Response
 
 ```
@@ -311,7 +329,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultMessage        | String  | Result message of delivery request |
 | -- recipientGroupingKey | String  | Recipient's grouping key           |
 
+<a id="list-messages"></a>
+
 ### List Messages
+
+<a id="request"></a>
 
 #### Request
 
@@ -361,6 +383,8 @@ Content-Type: application/json;charset=UTF-8
 
 * Cannot query data requested for delivery which are dated before 90 days.
 * The maximum available days for delivery request is 30 days.
+
+<a id="response-3"></a>
 
 #### Response
 ```
@@ -450,7 +474,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
-#### Status of Sending SMS/LMS
+**Status of Sending SMS/LMS**
 | Value | Description                                      |
 | ----- | ------------------------------------------------ |
 | RSC01 | No target of resending                           |
@@ -459,7 +483,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | RSC04 | Resending successful                             |
 | RSC05 | Resending failed                                 |
 
+<a id="get-messages"></a>
+
 ### Get Messages
+
+<a id="request-2"></a>
 
 #### Request
 
@@ -492,6 +520,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-4"></a>
 
 #### Response
 ```
@@ -585,6 +615,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - senderGroupingKey    | String  | Sender's grouping key                                        |
 | - recipientGroupingKey | String  | Recipient grouping key                                       |
 
+<a id="authentication-messages"></a>
+
 ## Authentication Messages
 
 <span id="precautions-authword"></span>
@@ -597,6 +629,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 - Example 1) Delivery shall fail if the full text(including template replacement) does not include authentication words, in the request of Authentication Messages API(for emergency)
 - Example 2) Validity for English words shall be checked regardless of small or capital letters
 
+
+<a id="request-of-sending-replaced-messages-2"></a>
 
 ### Request of Sending Replaced Messages
 
@@ -682,6 +716,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/auth/messages -d '{"senderKey":"{Sender Key}","templateCode":"{template code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{recipient number}","templateParameter":{"{replaced field}":"{replacement data}"}}]}'
 ```
 
+<a id="response-5"></a>
+
 #### Response
 
 ```
@@ -722,6 +758,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultCode           | Integer | Result code of delivery request    |
 | -- resultMessage        | String  | Result message of delivery request |
 | -- recipientGroupingKey | String  | Recipient's grouping key           |
+
+<a id="request-of-sending-full-text-2"></a>
 
 ### Request of Sending Full Text
 
@@ -827,6 +865,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/auth/raw-messages -d '{"senderKey":"{Sender Key}","templateCode":"{template code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{recipient number}","content":"{body message}","buttons":[{"ordering":"{button sequence}","type":"{button type}","name":"{button name}","linkMo":"{mobile web link}"}]}]}'
 ```
 
+<a id="response-6"></a>
+
 #### Response
 
 ```
@@ -868,7 +908,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultMessage        | String  | Result message of delivery request |
 | -- recipientGroupingKey | String  | Recipient's grouping key           |
 
+<a id="list-messages-2"></a>
+
 ### List Messages
+
+<a id="request-3"></a>
 
 #### Request
 
@@ -917,6 +961,8 @@ Content-Type: application/json;charset=UTF-8
 
 * Delivery request data before 90 days cannot be queried.
 * Delivery can be requested within 30 days to the maximum.   
+
+<a id="response-7"></a>
 
 #### Response
 ```
@@ -1006,7 +1052,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/auth/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
-#### Status of Resending SMS/LMS
+**Status of Resending SMS/LMS**
 | Value | Description                                     |
 | ----- | ----------------------------------------------- |
 | RSC01 | No target of resending                          |
@@ -1015,7 +1061,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | RSC04 | Resending successful                            |
 | RSC05 | Resending failed                                |
 
+<a id="get-messages-2"></a>
+
 ### Get Messages
+
+<a id="request-4"></a>
 
 #### Request
 
@@ -1048,6 +1098,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/auth/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-8"></a>
 
 #### Response
 ```
@@ -1144,8 +1196,14 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - senderGroupingKey    | String  | Sender's grouping key                                        |
 | - recipientGroupingKey | String  | Recipient's grouping key                                     |
 
+<a id="messages"></a>
+
 ## Messages
+<a id="cancel-sending-messages"></a>
+
 ### Cancel Sending Messages
+
+<a id="request-5"></a>
 
 #### Request
 
@@ -1181,6 +1239,8 @@ Content-Type: application/json;charset=UTF-8
 
 * Both general and authentication messages can be canceled by same API.
 
+<a id="response-9"></a>
+
 #### Response
 ```
 {
@@ -1204,7 +1264,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
 ```
 
+<a id="query-updates-of-message-result"></a>
+
 ### Query Updates of Message Result
+
+<a id="request-6"></a>
 
 #### Request
 
@@ -1240,6 +1304,8 @@ Content-Type: application/json;charset=UTF-8
 | alimtalkMessageType | String  | X        | AlimTalk message type(NORMAL, AUTH)                     |
 | pageNum             | Integer | X        | Page number(default: 1)                                 |
 | pageSize            | Integer | X        | Number of queries(default: 15, Max: 1000)              |
+
+<a id="response-10"></a>
 
 #### Response
 ```
@@ -1294,9 +1360,21 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/message-results?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
+<a id="smslms-alternative-delivery-status-code"></a>
+
+### SMS/LMS Alternative Delivery Status Code
+
+<!-- TODO: translate body -->
+
+<a id="templates"></a>
+
 ## Templates
 
+<a id="list-template-categories"></a>
+
 ### List Template Categories
+<a id="request-7"></a>
+
 #### Request
 [URL]
 
@@ -1320,6 +1398,8 @@ Content-Type: application/json;charset=UTF-8
 | Value        | Type   | Required | Description                                                  |
 | ------------ | ------ | -------- | ------------------------------------------------------------ |
 | X-Secret-Key | String | O        | Can be created on console.  |
+
+<a id="response-11"></a>
 
 #### Response
 ```
@@ -1362,7 +1442,11 @@ Content-Type: application/json;charset=UTF-8
 | -- inclusion    | String  |	Description of templates to which the category applies |
 | -- exclusion    | String  | Description of templates to which the category does not apply |
 
+<a id="register-templates"></a>
+
 ### Register Templates
+
+<a id="request-8"></a>
 
 #### Request
 
@@ -1439,6 +1523,8 @@ Content-Type: application/json;charset=UTF-8
 | -schemeIos      | String  | X        | iOS app link(required for the AL type, up to 500 characters) |
 | -schemeAndroid  | String  | X        | Android app link(required for the AL type, up to 500 characters) |
 
+<a id="response-12"></a>
+
 #### Response
 
 ```
@@ -1458,7 +1544,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | Result message    |
 | - isSuccessful  | Boolean | Successful or not |
 
+<a id="modify-templates"></a>
+
 ### Modify Templates
+
+<a id="request-9"></a>
 
 #### Request
 
@@ -1534,6 +1624,8 @@ Content-Type: application/json;charset=UTF-8
 | -schemeIos      | String  | X        | iOS app link(required for the AL type, up to 500 characters) |
 | -schemeAndroid  | String  | X        | Android app link(required for the AL type, up to 500 characters) |
 
+<a id="response-13"></a>
+
 #### Response
 
 ```
@@ -1553,7 +1645,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | Result message    |
 | - isSuccessful  | Boolean | Successful or not |
 
+<a id="delete-templates"></a>
+
 ### Delete Templates
+
+<a id="request-10"></a>
 
 #### Request
 
@@ -1579,6 +1675,8 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
+<a id="response-14"></a>
+
 #### Response
 ```
 {
@@ -1597,7 +1695,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | Result message    |
 | - isSuccessful  | Boolean | Successful or not |
 
+<a id="inquire-of-templates"></a>
+
 ### Inquire of Templates
+
+<a id="request-11"></a>
 
 #### Request
 
@@ -1638,6 +1740,8 @@ Content-Type: application/json;charset=UTF-8
 | ------- | ------ | -------- | ----------- |
 | comment | String | O        | Inquiries   |
 
+<a id="response-15"></a>
+
 #### Response
 ```
 {
@@ -1656,7 +1760,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | Result message    |
 | - isSuccessful  | Boolean | Successful or not |
 
+<a id="attach-files-to-send-inquiry-on-templates"></a>
+
 ### Attach files to send inquiry on templates
+<a id="request-12"></a>
+
 #### Request
 [URL]
 
@@ -1697,6 +1805,8 @@ Content-Type: application/json;charset=UTF-8
 |comment|	String |	O | Content of Inquiry          |
 |attachments| List<File> | X | List of Attachment(Up to 10) |
 
+<a id="response-16"></a>
+
 #### Response
 ```
 {
@@ -1715,7 +1825,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result Message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="list-templates"></a>
+
 ### List Templates
+
+<a id="request-13"></a>
 
 #### Request
 
@@ -1765,6 +1879,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/templates?templateStatus={template status code}"
 ```
+
+<a id="response-17"></a>
 
 #### Response
 ```
@@ -1866,7 +1982,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- createDate        | String  | Date and time of creation                                    |
 | - totalCount         | Integer | Total count                                                  |
 
+<a id="list-template-modifications"></a>
+
 ### List Template modifications
+
+<a id="request-14"></a>
 
 #### Request
 
@@ -1899,6 +2019,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}/modifications"
 ```
+
+<a id="response-18"></a>
 
 #### Response
 ```
@@ -2001,3 +2123,33 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- activated         | Boolean | activated or not                                             |
 | -- createDate        | String  | Date and time of creation                                    |
 | - totalCount         | Integer | Total count                                                  |
+<a id="alternative-delivery-management"></a>
+
+## Alternative Delivery Management
+
+<!-- TODO: translate body -->
+
+<a id="sms-appkey-registration"></a>
+
+### SMS AppKey Registration
+
+<!-- TODO: translate body -->
+
+<a id="response-19"></a>
+
+#### Response
+
+<!-- TODO: translate body -->
+
+<a id="alternative-delivery-settings-registration"></a>
+
+### Alternative Delivery Settings Registration
+
+<!-- TODO: translate body -->
+
+<a id="response-20"></a>
+
+#### Response
+
+<!-- TODO: translate body -->
+

--- a/en/alimtalk-api-guide.md
+++ b/en/alimtalk-api-guide.md
@@ -1,6 +1,10 @@
 ## Notification > KakaoTalk Bizmessage > AlimTalk > API v2.3 Guide
 
+<a id="alimtalk"></a>
+
 ## AlimTalk
+
+<a id="api-domain"></a>
 
 #### [API Domain]
 
@@ -17,6 +21,8 @@
 </tbody>
 </table>
 
+<a id="overview-of-v23-api"></a>
+
 ## Overview of v2.3 API
 1. Added Quick Reply, Item List, Talk Biz plugin, Main Link, and Business Form button.
 
@@ -24,7 +30,11 @@
 3. Added APIs to register, modify, delete, and retrieve AlimTalk plugins.
 4. Removed the buttons field from the API to retrieve message list.
 
+<a id="general-messages"></a>
+
 ## General Messages
+
+<a id="request-of-sending-replaced-messages"></a>
 
 ### Request of Sending Replaced Messages
 
@@ -151,6 +161,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages -d '{"senderKey":"{outgoing key}","templateCode":"{template code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{incoming number}","templateParameter":{"{replacer field}":"{replacement data}"}}]}'
 ```
 
+<a id="response"></a>
+
 #### Response
 
 ```
@@ -191,6 +203,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 |-- resultCode | Integer | Result code of delivery request |
 |-- resultMessage | String | Result message of delivery request |
 |-- recipientGroupingKey | String | Recipient's grouping key |
+
+<a id="request-of-sending-full-text"></a>
 
 ### Request of Sending Full Text
 
@@ -384,6 +398,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/raw-messages -d '{"senderKey":"{outgoing key}","templateCode":"{template code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{incoming number}","content":"{content}","buttons":[{"ordering":"{button sequence}","type":"{button type}","name":"{button name}","linkMo":"{mobile web link}"}]}]}'
 ```
 
+<a id="response-2"></a>
+
 #### Response
 
 ```
@@ -425,7 +441,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 |-- resultMessage | String | Result message of delivery request |
 |-- recipientGroupingKey | String | Recipient's grouping key |
 
+<a id="list-messages"></a>
+
 ### List Messages
+
+<a id="request"></a>
 
 #### Request
 
@@ -474,6 +494,8 @@ Content-Type: application/json;charset=UTF-8
 
 * Cannot query data requested for delivery which are dated before 90 days.
 * The maximum available days for delivery request is 30 days.
+
+<a id="response-3"></a>
 
 #### Response
 ```
@@ -544,7 +566,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<a id="get-messages"></a>
+
 ### Get Messages
+
+<a id="request-2"></a>
 
 #### Request
 
@@ -577,6 +603,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-4"></a>
 
 #### Response
 ```
@@ -755,6 +783,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |- senderGroupingKey | String | Sender's grouping key                                                                                                                                                                                              |
 |- recipientGroupingKey | String | 	Recipient's grouping key                                                                                                                                                                                          |
 
+<a id="authentication-messages"></a>
+
 ## Authentication Messages
 
 <span id="precautions-authword"></span>
@@ -767,6 +797,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 - Example 1-1) Delivery shall fail if the full text(including template replacement) does not include authentication words, in the request of Authentication Messages API(for emergency)
 - Example 1-2) Validity for English words shall be checked regardless of small or capital letters
 
+
+<a id="request-of-sending-replaced-messages-2"></a>
 
 ### Request of Sending Replaced Messages
 
@@ -797,6 +829,8 @@ Content-Type: application/json;charset=UTF-8
 [Request body]
 [Same as the above](./alimtalk-api-guide/#request-of-sending-replaced-messages)
 
+<a id="request-of-sending-full-text-2"></a>
+
 ### Request of Sending Full Text
 
 [URL]
@@ -826,7 +860,11 @@ Content-Type: application/json;charset=UTF-8
 [Request Body]
 [Same as the above](./alimtalk-api-guide/#request-of-sending-full-text)
 
+<a id="list-messages-2"></a>
+
 ### List Messages
+
+<a id="request-3"></a>
 
 #### Request
 
@@ -856,7 +894,11 @@ Content-Type: application/json;charset=UTF-8
 [Query parameter]
 [Same as the above](./alimtalk-api-guide/#list-messages)
 
+<a id="get-messages-2"></a>
+
 ### Get Messages
+
+<a id="request-4"></a>
 
 #### Request
 
@@ -890,11 +932,19 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/messages/{requestId}/{recipientSeq}"
 ```
 
+<a id="response-5"></a>
+
 #### Response
 [Same as the above](./alimtalk-api-guide/#get-messages)
 
+<a id="message"></a>
+
 ## Message
+<a id="cancel-sending-messages"></a>
+
 ### Cancel Sending Messages
+
+<a id="request-5"></a>
 
 #### Request
 
@@ -930,6 +980,8 @@ Content-Type: application/json;charset=UTF-8
 
 * Both general and authentication messages can be canceled by the same API.
 
+<a id="response-6"></a>
+
 #### Response
 ```
 {
@@ -953,7 +1005,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
 ```
 
+<a id="query-updates-of-message-result"></a>
+
 ### Query Updates of Message Result
+
+<a id="request-6"></a>
 
 #### Request
 
@@ -989,6 +1045,8 @@ Content-Type: application/json;charset=UTF-8
 |alimtalkMessageType|	String| X |	AlimTalk message type(NORMAL, AUTH) |
 |pageNum|	Integer|	X|	Page number(default: 1)|
 |pageSize|	Integer|	X|	Number of queries(default: 15, Max: 1000)|
+
+<a id="response-7"></a>
 
 #### Response
 ```
@@ -1042,7 +1100,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/message-results?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
+<a id="query-the-number-of-message-result-updates"></a>
+
 ### Query the Number of Message Result Updates
+
+<a id="request-7"></a>
 
 #### Request
 
@@ -1079,6 +1141,8 @@ Content-Type: application/json;charset=UTF-8
 | endUpdateDate       | 	String  | O   | 	Result update query end time (yyyy-MM-dd HH:mm) |
 | alimtalkMessageType | 	String  | X   | 	AlimTalk message type (NORMAL, AUTH)           |
 
+<a id="response-8"></a>
+
 #### Response
 
 ```
@@ -1106,6 +1170,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/message-results/count?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
+<a id="status-code-of-smslms-resending"></a>
+
 ### Status Code of SMS/LMS Resending
 | Name |	Description|
 |---|---|
@@ -1115,8 +1181,14 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |RSC04|	Resending successful|
 |RSC05|	Resending failed|
 
+<a id="mass-delivery"></a>
+
 ## Mass Delivery
+<a id="list-mass-delivery-requests"></a>
+
 ### List Mass Delivery Requests
+
+<a id="request-8"></a>
 
 #### Request
 [URL]
@@ -1156,6 +1228,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum | optional, Integer | - | X | Page number |
 | pageSize | optional, Integer | 1000 | X | Search count |
 
+<a id="curl"></a>
+
 #### cURL
 ```
 curl -X GET \
@@ -1163,6 +1237,8 @@ curl -X GET \
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-9"></a>
 
 #### Response
 ```
@@ -1219,7 +1295,11 @@ curl -X GET \
 | - totalCount | Integer | Total count |
 
 
+<a id="list-mass-delivery-recipients"></a>
+
 ### List Mass Delivery Recipients
+
+<a id="request-9"></a>
 
 #### Request
 [URL]
@@ -1258,6 +1338,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum | optional, Integer | - | X | Page number |
 | pageSize | optional, Integer | 1000 | X | Search count |
 
+<a id="curl-2"></a>
+
 #### cURL
 ```
 curl -X GET \
@@ -1265,6 +1347,8 @@ curl -X GET \
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-10"></a>
 
 #### Response
 ```
@@ -1310,7 +1394,11 @@ curl -X GET \
 | -- resultCodeName | String | Result code content |
 | - totalCount | Integer | Total count |
 
+<a id="get-a-mass-delivery-recipient"></a>
+
 ### Get a Mass Delivery Recipient
+
+<a id="request-10"></a>
 
 #### Request
 [URL]
@@ -1350,6 +1438,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum | optional, Integer | - | X | Page number |
 | pageSize | optional, Integer | 1000 | X | Search count |
 
+<a id="curl-3"></a>
+
 #### cURL
 ```
 curl -X GET \
@@ -1357,6 +1447,8 @@ curl -X GET \
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-11"></a>
 
 #### Response
 ```
@@ -1524,9 +1616,15 @@ curl -X GET \
 | -- bizFormId|	String| 	Plugin ID(up to 24 characters) |
 | -- target|	String| 	In the case of a web link type, out link used when adding "target":"out" attribute<br>Send with the default in-app link |
 
+<a id="templates"></a>
+
 ## Templates
 
+<a id="list-template-categories"></a>
+
 ### List Template Categories
+<a id="request-11"></a>
+
 #### Request
 [URL]
 
@@ -1550,6 +1648,8 @@ Content-Type: application/json;charset=UTF-8
 | Name |	Type|	Required|	Description|
 |---|---|---|---|
 |X-Secret-Key|	String| O | Can be created on console.   |
+
+<a id="response-12"></a>
 
 #### Response
 ```
@@ -1592,7 +1692,11 @@ Content-Type: application/json;charset=UTF-8
 |-- inclusion | String |	Description of templates to which the category applies |
 |-- exclusion| String| Description of templates to which the category does not apply |
 
+<a id="register-templates"></a>
+
 ### Register Templates
+<a id="request-12"></a>
+
 #### Request
 [URL]
 
@@ -1744,6 +1848,8 @@ Content-Type: application/json;charset=UTF-8
 * The Add Channel(AC) button must be registered with a fixed button name of "Add Channel".
 
 
+<a id="response-13"></a>
+
 #### Response
 ```
 {
@@ -1762,7 +1868,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="modify-templates"></a>
+
 ### Modify Templates
+<a id="request-13"></a>
+
 #### Request
 [URL]
 
@@ -1909,6 +2019,8 @@ Content-Type: application/json;charset=UTF-8
 * The Add Chanel button must be in the first when modifying the AD included(AD) or Mixed Purposes(MI) message type template.
 * The Add Channel(AC) button must be modified with a fixed button name of "Add Channel".
 
+<a id="response-14"></a>
+
 #### Response
 ```
 {
@@ -1927,7 +2039,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="delete-templates"></a>
+
 ### Delete Templates
+<a id="request-14"></a>
+
 #### Request
 [URL]
 
@@ -1955,6 +2071,8 @@ Content-Type: application/json;charset=UTF-8
 * A template remaining in Kakao becomes dormant if it is not used for 1 year, and gets deleted if it remains dormant for 1 year.(If a template becomes dormant or gets deleted on Kakao, the person in charge will be notified.)
 
 
+<a id="response-15"></a>
+
 #### Response
 ```
 {
@@ -1973,7 +2091,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="inquire-of-templates"></a>
+
 ### Inquire of Templates
+<a id="request-15"></a>
+
 #### Request
 [URL]
 
@@ -2014,6 +2136,8 @@ Content-Type: application/json;charset=UTF-8
 
 * When commenting a template in the REJ status, it will be changed to the REQ status.
 
+<a id="response-16"></a>
+
 #### Response
 ```
 {
@@ -2032,7 +2156,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="send-inquiry-on-templates-with-file-attachment"></a>
+
 ### Send Inquiry on Templates with File Attachment
+<a id="request-16"></a>
+
 #### Request
 [URL]
 
@@ -2075,6 +2203,8 @@ Content-Type: application/json;charset=UTF-8
 
 * When commenting a template in the REJ status, it will be changed to the REQ status.
 
+<a id="response-17"></a>
+
 #### Response
 ```
 {
@@ -2093,7 +2223,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="change-template-to-channel-add-type"></a>
+
 ### Change Template to Channel-Add Type
+
+<a id="request-17"></a>
 
 #### Request
 [URL]
@@ -2122,6 +2256,8 @@ Content-Type: application/json;charset=UTF-8
 
 * The template registered in sender group cannot be converted to a add-channel type.
 
+<a id="response-18"></a>
+
 #### Response
 ```
 {
@@ -2140,7 +2276,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="single-query-for-template"></a>
+
 ### Single Query for Template
+
+<a id="request-18"></a>
 
 #### Request
 
@@ -2183,6 +2323,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}"
 ```
+
+<a id="response-19"></a>
 
 #### Response
 
@@ -2362,7 +2504,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - createDate | String | O | Created at |
 | - updateDate | String | X | Modified at |
 
+<a id="list-templates"></a>
+
 ### List Templates
+
+<a id="request-19"></a>
 
 #### Request
 
@@ -2411,6 +2557,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates?templateStatus={template status code}"
 ```
+
+<a id="response-20"></a>
 
 #### Response
 ```
@@ -2587,7 +2735,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- updateDate            | String | Date of modification                                                                                                                                                                                                                                                                                   |
 | - totalCount             | Integer | Total count                                                                                                                                                                                                                                                                                            |
 
+<a id="list-template-modifications"></a>
+
 ### List Template modifications
+
+<a id="request-20"></a>
 
 #### Request
 
@@ -2620,6 +2772,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}/modifications"
 ```
+
+<a id="response-21"></a>
 
 #### Response
 ```
@@ -2772,7 +2926,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |-- updateDate | String | Date of modification |
 |- totalCount | Integer | Total count |
 
+<a id="register-template-image"></a>
+
 ### Register Template Image
+<a id="request-21"></a>
+
 #### Request
 [URL]
 
@@ -2808,6 +2966,8 @@ Content-Type: multipart/form-data
 curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/template-image" -F "file=@alimtalk-template-image.jpeg"
 ```
 
+<a id="response-22"></a>
+
 #### Response
 ```
 {
@@ -2833,7 +2993,11 @@ curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}
 |- templateImageName | String |	Image name(name of uploaded file) |
 |- templateImageUrl | String |	Image URL |
 
+<a id="register-template-item-highlight-images"></a>
+
 ### Register Template Item Highlight Images
+<a id="request-22"></a>
+
 #### Request
 [URL]
 
@@ -2869,6 +3033,8 @@ Content-Type: multipart/form-data
 curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/template-image/item-highlight" -F "file=@alimtalk-template-image.jpeg"
 ```
 
+<a id="response-23"></a>
+
 #### Response
 ```
 {
@@ -2894,7 +3060,11 @@ curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}
 |- templateImageName | String |	Image name(name of uploaded file) |
 |- templateImageUrl | String |	Image URL |
 
+<a id="register-template-plugin"></a>
+
 ### Register Template Plugin
+<a id="request-23"></a>
+
 #### Request
 [URL]
 
@@ -2936,6 +3106,8 @@ Content-Type: application/json;charset=UTF-8
 |pluginId|	String |	O | Plugin ID |
 |callbackUrl|	String |	O | The callback URL to receive when the plugin button is clicked |
 
+<a id="response-24"></a>
+
 #### Response
 ```
 {
@@ -2954,7 +3126,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="modify-template-plugin"></a>
+
 ### Modify Template Plugin
+<a id="request-24"></a>
+
 #### Request
 [URL]
 
@@ -2995,6 +3171,8 @@ Content-Type: application/json;charset=UTF-8
 |pluginType|	String |	O | Plugin type(SECURE_IMAGE: secure image transmission, ONE_TIME_PROFILE: personal information use) |
 |callbackUrl|	String |	O | The callback URL to receive when the plugin button is clicked |
 
+<a id="response-25"></a>
+
 #### Response
 ```
 {
@@ -3013,7 +3191,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="modify-template-plugin-2"></a>
+
 ### Modify Template Plugin
+<a id="request-25"></a>
+
 #### Request
 [URL]
 
@@ -3040,6 +3222,8 @@ Content-Type: application/json;charset=UTF-8
 |---|---|---|---|
 |X-Secret-Key|	String| O | Can be created on console.   |
 
+<a id="response-26"></a>
+
 #### Response
 ```
 {
@@ -3058,7 +3242,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="retrieve-template-plugin"></a>
+
 ### Retrieve Template Plugin
+<a id="request-26"></a>
+
 #### Request
 [URL]
 
@@ -3083,6 +3271,8 @@ Content-Type: application/json;charset=UTF-8
 | Name |	Type|	Required|	Description|
 |---|---|---|---|
 |X-Secret-Key|	String| O | Can be created on console.   |
+
+<a id="response-27"></a>
 
 #### Response
 ```
@@ -3120,7 +3310,11 @@ Content-Type: application/json;charset=UTF-8
 |- modifiable|	Boolean| Modifiable |
 |- deletable|	Boolean| Deletable |
 
+<a id="manage-alternative-delivery"></a>
+
 ## Manage Alternative Delivery
+<a id="register-an-sms-appkey"></a>
+
 ### Register an SMS AppKey
 
 [URL]
@@ -3164,6 +3358,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
 ```
 
+<a id="response-28"></a>
+
 #### Response
 ```
 
@@ -3175,6 +3371,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
   }
 }
 ```
+
+<a id="register-alternative-delivery-settings"></a>
 
 ### Register Alternative Delivery Settings
 
@@ -3222,6 +3420,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/failback/appkey -d '{"senderKey": "0be23c29de88d6888798aeda57062516354d74ba","isResend": true,"resendSendNo": "01012341234" }
 ```
+
+<a id="response-29"></a>
 
 #### Response
 ```

--- a/en/friendtalkupgrade-api-guide.md
+++ b/en/friendtalkupgrade-api-guide.md
@@ -1,6 +1,10 @@
 ## Notification > KakaoTalk Bizmessage > Brand Message > API v1.0 Guide
 
+<a id="brand-message"></a>
+
 ## Brand Message
+
+<a id="api-domain"></a>
 
 #### \[API Domain]
 
@@ -8,7 +12,11 @@
 |----------|
 | [https://kakaotalk-bizmessage.api.nhncloudservice.com](https://kakaotalk-bizmessage.api.nhncloudservice.com)|
 
+<a id="introduce-v10-api"></a>
+
 ## Introduce v1.0 API
+
+<a id="manage-non-friend-message-sending-targeting-m-n"></a>
 
 ## Manage non-friend message sending (targeting M, N)
 
@@ -20,7 +28,11 @@ Non-friend message sending (targeting M, N) can be sent if all the conditions be
 - 50,000 or more channel friends
 - Successfully send notification messages within the past three months
 
+<a id="upload-marketing-consent-evidence"></a>
+
 ### Upload marketing consent evidence
+
+<a id="requested"></a>
 
 #### Requested
 
@@ -56,6 +68,8 @@ Content-Type: multipart/form-data
 |----------|----------|----------|----------|
 | file| File| O| Marketing consent evidence|
 
+<a id="response"></a>
+
 #### Response
 
 ```
@@ -75,7 +89,11 @@ Content-Type: multipart/form-data
 | \- resultMessage| String| O| Result message|
 | \- isSuccessful| boolean| O| Success status|
 
+<a id="apply-for-using-non-friend-message-sending-targeting-m-n"></a>
+
 ### Apply for using non-friend message sending (targeting M, N)
+
+<a id="requested-2"></a>
 
 #### Requested
 
@@ -105,6 +123,8 @@ Content-Type: application/json;charset=UTF-8
 |----------|----------|----------|----------|
 | X-Secret-Key| String| O| Available to create from the console.|
 
+<a id="response-2"></a>
+
 #### Response
 
 ```
@@ -123,6 +143,8 @@ Content-Type: application/json;charset=UTF-8
 | \- resultCode| Integer| O| Result code|
 | \- resultMessage| String| O| Result message|
 | \- isSuccessful| boolean| O| Success status|
+
+<a id="request-to-send-a-free-form-message"></a>
 
 ## Request to send a free-form message
 
@@ -145,6 +167,8 @@ Content-Type: application/json;charset=UTF-8
 * Fallback can be set via resendParameter for each recipient.
   * When using fallback, you need to register the SMS Appkey and set its sending through the fallback management API.
   * **Nighttime delivery restrictions(8:50 PM - 8:00 AM the next day)**
+
+<a id="requested-3"></a>
 
 #### Requested
 
@@ -172,6 +196,8 @@ Content-Type: application/json;charset=UTF-8
 | Name| Type| Required| Description|
 |----------|----------|----------|----------|
 | X-Secret-Key| String| O| Available to create from the console.|
+
+<a id="request-text-type-sending"></a>
 
 #### Request text-type sending
 
@@ -276,6 +302,8 @@ Content-Type: application/json;charset=UTF-8
 | resellerCode| String| X| Reseller code (used by resellers when sending)|
 | createUser| String| X| Registrant (stored as user UUID when sent from console)|
 | statsId| String| X| Statistics ID (not included in the outgoing search conditions. Up 8 characters)|
+
+<a id="request-image-type-sending"></a>
 
 #### Request image-type sending
 
@@ -388,6 +416,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser| String| X| Registrant (stored as user UUID when sent from console)|
 | statsId| String| X| Statistics ID (not included in the outgoing search conditions. Up 8 characters)|
 
+<a id="request-wide-image-type-sending"></a>
+
 #### Request wide image-type sending
 
 \[Request body]
@@ -498,6 +528,8 @@ Content-Type: application/json;charset=UTF-8
 | resellerCode| String| X| Reseller code (used by resellers when sending)|
 | createUser| String| X| Registrant (stored as user UUID when sent from console)|
 | statsId| String| X| Statistics ID (not included in the outgoing search conditions. Up 8 characters)|
+
+<a id="request-to-send-wide-item-list-type"></a>
 
 #### Request to send wide item list type
 
@@ -639,6 +671,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser| String| X| Registrant (stored as user UUID when sent from console)|
 | statsId| String| X| Statistics ID (not included in the outgoing search conditions. Up 8 characters)|
 
+<a id="request-to-send-premium-video-type"></a>
+
 #### Request to send premium video type
 
 \[Request body]
@@ -751,6 +785,8 @@ Content-Type: application/json;charset=UTF-8
 | resellerCode| String| X| Reseller code (used by resellers when sending)|
 | createUser| String| X| Registrant (stored as user UUID when sent from console)|
 | statsId| String| X| Statistics ID (not included in the outgoing search conditions. Up 8 characters)|
+
+<a id="request-to-send-commerce"></a>
 
 #### Request to send commerce
 
@@ -875,6 +911,8 @@ Content-Type: application/json;charset=UTF-8
 | resellerCode| String| X| Reseller code (used by resellers when sending)|
 | createUser| String| X| Registrant (stored as user UUID when sent from console)|
 | statsId| String| X| Statistics ID (not included in the outgoing search conditions. Up 8 characters)|
+
+<a id="request-to-send-carousel-feed-type"></a>
 
 #### Request to send carousel feed type
 ##### Carousel fixed placeholders (path-based template parameter)
@@ -1052,6 +1090,8 @@ Allow unique placeholder values for each item in a carousel-type template.
 | createUser| String| X        | Registrant (stored as user UUID when sent from console)|
 | statsId| String| X        | Statistics ID (not included in the outgoing search conditions. Up 8 characters)|
 
+<a id="request-to-send-carousel-commerce-type"></a>
+
 #### Request to send carousel commerce type
 
 \[Request body]
@@ -1208,6 +1248,8 @@ Allow unique placeholder values for each item in a carousel-type template.
 | createUser| String| X        | Registrant (stored as user UUID when sent from console)|
 | statsId| String| X        | Statistics ID (not included in the outgoing search conditions, up to 8 characters)|
 
+<a id="response-3"></a>
+
 #### Response
 
 ```
@@ -1245,6 +1287,8 @@ Allow unique placeholder values for each item in a carousel-type template.
 | \-- resultCode| Integer| O| Recipient-specific sending result code (success and various failure codes may exist)|
 | \-- resultMessage| String| O| Recipient-specific sending result message ("success" or a related message on success, detailed message on failure, cause on failure)|
 
+<a id="request-to-send-basic-message"></a>
+
 ## Request to send basic message
 
 * A sending using a template.
@@ -1260,6 +1304,8 @@ Allow unique placeholder values for each item in a carousel-type template.
 * Fallback can be set via resendParameter for each recipient.
   * When using fallback, you need to register the SMS Appkey and set its send through the fallback management API.
 * **Nighttime delivery restrictions(8:50 PM - 8:00 AM the next day)**
+
+<a id="cautions-for-use"></a>
 
 ### Cautions for use
 
@@ -1292,6 +1338,8 @@ Content-Type: application/json;charset=UTF-8
 | Name| Type| Required| Description|
 |----------|----------|----------|----------|
 | X-Secret-Key| String| O| Available to create from the console.|
+
+<a id="requested-4"></a>
 
 #### Requested
 
@@ -1359,6 +1407,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser| String| X| Registrant (stored as user UUID when sent from console)|
 | statsId| String| X| Statistics ID (not included in the outgoing search conditions, up to 8 characters)|
 
+<a id="response-4"></a>
+
 #### Response
 
 ```
@@ -1396,7 +1446,11 @@ Content-Type: application/json;charset=UTF-8
 | \-- resultCode| Integer| O| Recipient-specific sending result code (success and various failure codes may exist)|
 | \-- resultMessage| String| O| Recipient-specific sending result message ("success" or a related message on success, detailed message on failure, cause on failure)|
 
+<a id="view-sending-list"></a>
+
 ## View sending list
+
+<a id="requested-5"></a>
 
 #### Requested
 
@@ -1441,6 +1495,8 @@ Content-Type: application/json;charset=UTF-8
 | recipientGroupingKey| String| X| Recipient grouping key|
 | pageNum| String| X| Page number (default: 1\)|
 | pageSize| String| X| Number of views (default: 15, Max: 1,000)|
+
+<a id="response-5"></a>
 
 #### Response
 
@@ -1517,7 +1573,11 @@ Content-Type: application/json;charset=UTF-8
 | \-- recipientGroupingKey| String| X| Recipient grouping key|
 | \- totalCount| Integer| O| Total|
 
+<a id="view-single-sending"></a>
+
 ## View single sending
+
+<a id="requested-6"></a>
 
 #### Requested
 
@@ -1547,6 +1607,8 @@ Content-Type: application/json;charset=UTF-8
 | Name| Type| Required| Description|
 |----------|----------|----------|----------|
 | X-Secret-Key| String| O| Available to create from the console.|
+
+<a id="response-6"></a>
 
 #### Response
 
@@ -1808,7 +1870,11 @@ Content-Type: application/json;charset=UTF-8
 | \- senderGroupingKey| String| X| Outgoing grouping key|
 | \- recipientGroupingKey| String| X| Recipient grouping key|
 
+<a id="cancel-message-sending"></a>
+
 ## Cancel message sending
+
+<a id="requested-7"></a>
 
 #### Requested
 
@@ -1844,6 +1910,8 @@ Content-Type: application/json;charset=UTF-8
 |----------|----------|----------|----------|
 | recipientSeq| String| X| Recipient sequence number<br>(If you do not enter any information, all requests for that request ID will be canceled)|
 
+<a id="response-7"></a>
+
 #### Response
 
 ```
@@ -1869,9 +1937,15 @@ Content-Type: application/json;charset=UTF-8
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
 ```
 
+<a id="manage-templates"></a>
+
 ## Manage Templates
 
+<a id="view-template-list"></a>
+
 ### View template list
+
+<a id="requested-8"></a>
 
 #### Requested
 
@@ -1910,6 +1984,8 @@ Content-Type: application/json;charset=UTF-8
 | status| String| X| Template status code|
 | pageNum| Integer| X| Page number (Default: 1\)|
 | pageSize| Integer| X| Number of views (default: 15, Max: 1,000)|
+
+<a id="response-8"></a>
 
 #### Response
 
@@ -2138,6 +2214,8 @@ Content-Type: application/json;charset=UTF-8
 | \--- updateDate| String| X| Modified on|
 | \- totalCount| Integer| O| Total|
 
+<a id="view-single-template"></a>
+
 ### View single template
 
 \[URL]
@@ -2167,6 +2245,8 @@ Content-Type: application/json;charset=UTF-8
 |----------|----------|----------|----------|
 | X-Secret-Key| String| O| Available to create from the console.|
 | X-NC-API-IDEMPOTENCY-KEY | String | X | Key used as the basis for duplicate message delivery request detection<br>If a request is made with the same key within 10 minutes, the request will be treated as failed. |
+
+<a id="response-9"></a>
 
 #### Response
 
@@ -2389,7 +2469,11 @@ Content-Type: application/json;charset=UTF-8
 | \- createDate| String| O| Registered on|
 | \- updateDate| String| X| Modified on|
 
+<a id="register-template"></a>
+
 ### Register Template
+
+<a id="requested-9"></a>
 
 #### Requested
 
@@ -2419,6 +2503,8 @@ Content-Type: application/json;charset=UTF-8
 |----------|----------|----------|----------|
 | X-Secret-Key| String| O| Available to create from the console.|
 
+<a id="note"></a>
+
 #### Note
 
 * If applying placeholders to coupon titles, you must use the following fixed placeholders:
@@ -2437,6 +2523,8 @@ Content-Type: application/json;charset=UTF-8
   * discountPrice -> #{discount price}
   * discountRate -> #{discount rate}
   * discountFixed -> #{fixed discount price}
+
+<a id="request-to-register-text-type-template"></a>
 
 #### Request to register text type template
 
@@ -2491,6 +2579,8 @@ Content-Type: application/json;charset=UTF-8
 | \- linkPc| String| X| PC web link (optional for WL type), limited to 500 characters|
 | \- schemeAndroid| String| X| Android app link (required for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
 | \- schemeIos| String| X| iOS app link (required field for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
+
+<a id="request-to-register-image-type-template"></a>
 
 #### Request to register image type template
 
@@ -2553,6 +2643,8 @@ Content-Type: application/json;charset=UTF-8
 | \- schemeAndroid| String| X        | Android app link (required for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
 | \- schemeIos| String| X        | iOS app link (required field for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
 
+<a id="request-to-register-wide-image-type-template"></a>
+
 #### Request to register wide image type template
 
 \[Request body]
@@ -2613,6 +2705,8 @@ Content-Type: application/json;charset=UTF-8
 | \- linkPc| String| X        | PC web link (optional for WL type), limited to 500 characters|
 | \- schemeAndroid| String| X        | Android app link (required for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
 | \- schemeIos| String| X        | iOS app link (required field for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
+
+<a id="request-to-register-wide-item-list-type-template"></a>
 
 #### Request to register wide item list type template
 
@@ -2704,6 +2798,8 @@ Content-Type: application/json;charset=UTF-8
 | \- schemeAndroid| String| X| Android app link (required for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
 | \- schemeIos| String| X| iOS app link (required field for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
 
+<a id="request-to-register-premium-video-type-template"></a>
+
 #### Request to register premium video type template
 
 \[Request body]
@@ -2766,6 +2862,8 @@ Content-Type: application/json;charset=UTF-8
 | \- linkPc| String| X| PC web link (optional for WL type), limited to 500 characters|
 | \- schemeAndroid| String| X| Android app link (required for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
 | \- schemeIos| String| X| iOS app link (required field for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
+
+<a id="request-to-register-commerce-type-template"></a>
 
 #### Request to register commerce type template
 
@@ -2841,6 +2939,8 @@ Content-Type: application/json;charset=UTF-8
 | \- linkPc| String| X        | PC web link (optional for WL type), limited to 500 characters|
 | \- schemeAndroid| String| X        | Android app link (required for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
 | \- schemeIos| String| X        | iOS app link (required field for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
+
+<a id="request-to-register-carousel-feed-type-template"></a>
 
 #### Request to register carousel feed type template
 
@@ -2952,6 +3052,8 @@ Content-Type: application/json;charset=UTF-8
 | \- recipientNo| String| O        | Incoming number|
 | createUser| String| X        | Registrant (stored as user UUID when sent from console)|
 
+<a id="request-to-register-carousel-commerce-type-template"></a>
+
 #### Request to register carousel commerce type template
 
 \[Request body]
@@ -3060,6 +3162,8 @@ Content-Type: application/json;charset=UTF-8
 | \-- schemeAndroid| String| X        | Android app link, limited to 500 characters<br>No placeholders available|
 | \-- schemeIos| String| X        | iOS app link, limited to 500 characters<br>No placeholders available|
 
+<a id="response-10"></a>
+
 #### Response
 
 ```
@@ -3084,7 +3188,11 @@ Content-Type: application/json;charset=UTF-8
 | template| Object| X| Template Info|
 | \- templateCode| String| O| Template Code|
 
+<a id="modify-template"></a>
+
 ### Modify Template
+
+<a id="requested-10"></a>
 
 #### Requested
 
@@ -3119,6 +3227,8 @@ Content-Type: application/json;charset=UTF-8
 
 * Same specifications as template registration
 
+<a id="response-11"></a>
+
 #### Response
 
 ```
@@ -3138,7 +3248,11 @@ Content-Type: application/json;charset=UTF-8
 | \- resultMessage| String| O| Result message|
 | \- isSuccessful| boolean| O| Success status|
 
+<a id="delete-template"></a>
+
 ### Delete Template
+
+<a id="requested-11"></a>
 
 #### Requested
 
@@ -3169,6 +3283,8 @@ Content-Type: application/json;charset=UTF-8
 |----------|----------|----------|----------|
 | X-Secret-Key| String| O| Available to create from the console.|
 
+<a id="response-12"></a>
+
 #### Response
 
 ```
@@ -3188,9 +3304,15 @@ Content-Type: application/json;charset=UTF-8
 | \- resultMessage| String| O| Result message|
 | \- isSuccessful| boolean| O| Success status|
 
+<a id="manage-image"></a>
+
 ## Manage Image
 
+<a id="upload-image"></a>
+
 ### Upload image
+
+<a id="requested-12"></a>
 
 #### Requested
 
@@ -3226,6 +3348,8 @@ Content-Type: multipart/form-data
 | image| File| O| Image|
 | imageType| String| O| Image type <br>(IMAGE, WIDE_IMAGE,MAIN_WIDE_ITEMLIST_IMAGE,NORMAL_WIDE_ITEMLIST_IMAGE,CAROUSEL_FEED_IMAGE,CAROUSEL_COMMERCE_IMAGE)|
 
+<a id="response-13"></a>
+
 #### Response
 
 ```
@@ -3254,6 +3378,8 @@ Content-Type: multipart/form-data
 | \- imageUrl| String| O| Image URL|
 | \- imageName| String| X| Image Name|
 
+<a id="upload-image-specifications"></a>
+
 #### Upload Image Specifications
 | Image Type                 | Usage                                                                   | Upload Image Specifications                                                                                                                                                      |
 | :------------------------- | :---------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -3266,7 +3392,11 @@ Content-Type: multipart/form-data
 
 * If all templates referencing an uploaded image are deleted or changed to a different image, the image will be removed from the Kakao CDN, making the URL invalid. While image information is retained in the Image Retrieval API, the actual image cannot be accessed. It is recommended to store the original file separately on your own server.
 
+<a id="view-image"></a>
+
 ### View image
+
+<a id="requested-13"></a>
 
 #### Requested
 
@@ -3303,6 +3433,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum| String| X| Page number (default: 1\)|
 | pageSize| String| X| Number of views (default: 15\)|
 
+<a id="response-14"></a>
+
 #### Response
 
 ```
@@ -3331,7 +3463,11 @@ Content-Type: application/json;charset=UTF-8
 | \- imageUrl| String| O| Image URL|
 | \- imageName| String| X| Image Name|
 
+<a id="delete-image"></a>
+
 ### Delete Image
+
+<a id="requested-14"></a>
 
 #### Requested
 
@@ -3366,6 +3502,8 @@ Content-Type: application/json;charset=UTF-8
 |----------|----------|----------|----------|
 | imageSeq| String| O| Image number|
 
+<a id="response-15"></a>
+
 #### Response
 
 ```
@@ -3385,9 +3523,15 @@ Content-Type: application/json;charset=UTF-8
 | \- resultMessage| String| O| Result message|
 | \- isSuccessful| boolean| O| Success status|
 
+<a id="upload"></a>
+
 ## Upload
 
+<a id="upload-bizform-key"></a>
+
 ### Upload Bizform key
+
+<a id="requested-15"></a>
 
 #### Requested
 
@@ -3417,6 +3561,8 @@ Content-Type: application/json;charset=UTF-8
 |----------|----------|----------|----------|
 | X-Secret-Key| String| O| Available to create from the console.|
 
+<a id="response-16"></a>
+
 #### Response
 
 ```
@@ -3436,9 +3582,15 @@ Content-Type: application/json;charset=UTF-8
 | \- resultMessage| String| O| Result message|
 | \- isSuccessful| boolean| O| Success status|
 
+<a id="manage-outgoing-profiles"></a>
+
 ## Manage Outgoing Profiles
 
+<a id="view-outgoing-profile"></a>
+
 ### View outgoing profile
+
+<a id="requested-16"></a>
 
 #### Requested
 
@@ -3467,6 +3619,8 @@ Content-Type: application/json;charset=UTF-8
 | Name| Type| Required| Description|
 |----------|----------|----------|----------|
 | X-Secret-Key| String| O| Available to create from the console.|
+
+<a id="response-17"></a>
 
 #### Response
 
@@ -3537,7 +3691,11 @@ Content-Type: application/json;charset=UTF-8
 | \- createDate| String| X| Registered Date|
 | \- initialUserRestriction| boolean| O| First-time user restriction status|
 
+<a id="modify-outgoing-profile-080-opt-out-number"></a>
+
 ### Modify outgoing profile 080 opt-out number
+
+<a id="requested-17"></a>
 
 #### Requested
 
@@ -3581,6 +3739,8 @@ Content-Type: application/json;charset=UTF-8
 | unsubscribeNo| String| O| 080 toll-free opt-out phone number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx|
 | unsubscribeAuthNo| String| X| 080 toll-free opt-out verification number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>unsubscribeAuthNo cannot be entered without unsubscribeNo<br>ex) 1234|
 
+<a id="response-18"></a>
+
 #### Response
 
 ```
@@ -3600,7 +3760,11 @@ Content-Type: application/json;charset=UTF-8
 | \- resultMessage| String| O| Result message|
 | \- isSuccessful| boolean| O| Success status|
 
+<a id="manage-fallback"></a>
+
 ## Manage Fallback
+
+<a id="register-sms-appkey"></a>
 
 ### Register SMS AppKey
 
@@ -3647,6 +3811,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
 ```
 
+<a id="response-19"></a>
+
 #### Response
 
 ```
@@ -3659,6 +3825,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
   }
 }
 ```
+
+<a id="register-fallback-settings"></a>
 
 ### Register fallback settings
 
@@ -3710,6 +3878,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/failback/appkey -d '{"senderKey": "0be23c29de88d6888798aeda57062516354d74ba","isResend": true,"resendSendNo": "01012341234" }
 ```
+
+<a id="response-20"></a>
 
 #### Response
 

--- a/ja/alimtalk-api-guide-v2.0.md
+++ b/ja/alimtalk-api-guide-v2.0.md
@@ -1,6 +1,12 @@
+<!-- pre-align:aligned sig=4ea84933972e -->
+
 ## Notification > KakaoTalk Bizmessage > お知らせトーク > API v2.0 Guide
 
+<a id="alimtalk"></a>
+
 ## お知らせトーク
+
+<a id="api-domain"></a>
 
 #### [APIドメイン]
 
@@ -17,11 +23,17 @@
 </tbody>
 </table>
 
+<a id="overview-of-v20-api"></a>
+
 ## v2.0 API紹介
 1. カカオチャンネル追加時、発行されたsenderKeyフィールドでAPI呼び出しが行われるように変更しました。
 2. カカオチャンネルグループ機能が追加されました。
 
+<a id="general-messages"></a>
+
 ## 一般メッセージ
+
+<a id="request-of-sending-replaced-messages"></a>
 
 ### メッセージ置換送信リクエスト
 
@@ -115,6 +127,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","templateParameter":{"{日本語識別子フィールド}":"{置換データ}"}}]}'
 ```
 
+<a id="response"></a>
+
 #### レスポンス
 
 ```
@@ -155,6 +169,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultCode           | Integer | 送信リクエスト結果コード |
 | -- resultMessage        | String  | 送信リクエスト結果メッセージ |
 | -- recipientGroupingKey | String  | 受信者グルーピングキー |
+
+<a id="request-of-sending-full-text"></a>
 
 ### メッセージ全文送信リクエスト
 
@@ -265,6 +281,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/raw-messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","content":"{内容}","buttons":[{"ordering":"{ボタン順序}","type":"{ボタンタイプ}","name":"{ボタン名}","linkMo":"{モバイルWebリンク}"}]}]}'
 ```
 
+<a id="response-2"></a>
+
 #### レスポンス
 
 ```
@@ -306,7 +324,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultMessage        | String  | 送信リクエスト結果メッセージ |
 | -- recipientGroupingKey | String  | 受信者グルーピングキー |
 
+<a id="list-messages"></a>
+
 ### メッセージリストの照会
+
+<a id="request"></a>
 
 #### リクエスト
 
@@ -355,6 +377,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 90日以上前の送信リクエストデータは照会されません。
 * 送信リクエスト日時の範囲は最大30日です。
+
+<a id="response-3"></a>
 
 #### レスポンス
 ```
@@ -444,7 +468,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
-#### SMS/LMS再送信ステータス
+**SMS/LMS再送信ステータス**
 | 値 | 説明                      |
 | ----- | ------------------------------- |
 | RSC01 | 再送信の対象ではない                 |
@@ -453,7 +477,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | RSC04 | 再送信成功                  |
 | RSC05 | 再送信失敗                  |
 
+<a id="get-messages"></a>
+
 ### メッセージ単件照会
+
+<a id="request-2"></a>
 
 #### リクエスト
 
@@ -486,6 +514,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-4"></a>
 
 #### レスポンス
 ```
@@ -579,6 +609,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - senderGroupingKey    | String  | 発信グルーピングキー                            |
 | - recipientGroupingKey | String  | 受信者グルーピングキー                           |
 
+<a id="authentication-messages"></a>
+
 ## 認証メッセージ
 
 <span id="precautions-authword"></span>
@@ -591,6 +623,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 - 例1)認証メッセージAPI送信リクエストした時、全文(テンプレート日本語識別子含む)に認証文言が含まれていない場合は、送信に失敗します。
 - 例2)認証文言が英文の場合、大文字/小文字の区別なしで有効性チェックが行われます。
 
+
+<a id="request-of-sending-replaced-messages-2"></a>
 
 ### メッセージ置換送信リクエスト
 
@@ -680,6 +714,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/auth/messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","templateParameter":{"{日本語識別子フィールド}":"{置換データ}"}}]}'
 ```
 
+<a id="response-5"></a>
+
 #### レスポンス
 
 ```
@@ -720,6 +756,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultCode           | Integer | 送信リクエスト結果コード |
 | -- resultMessage        | String  | 送信リクエスト結果メッセージ |
 | -- recipientGroupingKey | String  | 受信者グルーピングキー |
+
+<a id="request-of-sending-full-text-2"></a>
 
 ### メッセージ全文送信リクエスト
 
@@ -827,6 +865,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/auth/raw-messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","content":"{内容}","buttons":[{"ordering":"{ボタン順序}","type":"{ボタンタイプ}","name":"{ボタン名}","linkMo":"{モバイルWebリンク}"}]}]}'
 ```
 
+<a id="response-6"></a>
+
 #### レスポンス
 
 ```
@@ -868,7 +908,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultMessage        | String  | 送信リクエスト結果メッセージ |
 | -- recipientGroupingKey | String  | 受信者グルーピングキー |
 
+<a id="list-messages-2"></a>
+
 ### メッセージリストの照会
+
+<a id="request-3"></a>
 
 #### リクエスト
 
@@ -917,6 +961,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 90日以上前の送信リクエストデータは照会されません。
 * 送信リクエスト日時の範囲は最大30日です。
+
+<a id="response-7"></a>
 
 #### レスポンス
 ```
@@ -1006,7 +1052,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/auth/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
-#### SMS/LMS再送信ステータス
+**SMS/LMS再送信ステータス**
 | 値 | 説明                      |
 | ----- | ------------------------------- |
 | RSC01 | 再送信の対象ではない                 |
@@ -1015,7 +1061,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | RSC04 | 再送信成功                  |
 | RSC05 | 再送信失敗                  |
 
+<a id="get-messages-2"></a>
+
 ### メッセージ単件照会
+
+<a id="request-4"></a>
 
 #### リクエスト
 
@@ -1048,6 +1098,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/auth/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-8"></a>
 
 #### レスポンス
 ```
@@ -1144,8 +1196,14 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - senderGroupingKey    | String  | 発信グルーピングキー                            |
 | - recipientGroupingKey | String  | 受信者グルーピングキー                           |
 
+<a id="messages"></a>
+
 ## メッセージ
+<a id="cancel-sending-messages"></a>
+
 ### メッセージ送信取消
+
+<a id="request-5"></a>
 
 #### リクエスト
 
@@ -1181,6 +1239,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 一般/認証メッセージは同じAPIでキャンセルできます。
 
+<a id="response-9"></a>
+
 #### レスポンス
 ```
 {
@@ -1204,7 +1264,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
 ```
 
+<a id="query-updates-of-message-result"></a>
+
 ### メッセージ結果アップデートの照会
+
+<a id="request-6"></a>
 
 #### リクエスト
 
@@ -1240,6 +1304,8 @@ Content-Type: application/json;charset=UTF-8
 | alimtalkMessageType | String  | X    | お知らせトークメッセージタイプ(NORMAL、AUTH)           |
 | pageNum             | Integer | X    | ページ番号(基本：1)                      |
 | pageSize            | Integer | X    | 照会件数(基本：15、最大: 1000)          |
+
+<a id="response-10"></a>
 
 #### レスポンス
 ```
@@ -1294,9 +1360,21 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/message-results?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
+<a id="smslms-alternative-delivery-status-code"></a>
+
+### SMS/LMS代替送信ステータスコード
+
+<!-- TODO: translate body -->
+
+<a id="templates"></a>
+
 ## テンプレート
 
+<a id="list-template-categories"></a>
+
 ### テンプレートカテゴリー照会
+<a id="request-7"></a>
+
 #### リクエスト
 [URL]
 
@@ -1320,6 +1398,8 @@ Content-Type: application/json;charset=UTF-8
 | 値    | タイプ | 必須 | 説明                               |
 |---|---|---|---|
 | X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+<a id="response-11"></a>
 
 #### レスポンス
 ```
@@ -1362,7 +1442,11 @@ Content-Type: application/json;charset=UTF-8
 |-- inclusion | String |	カテゴリー対象テンプレートの説明 |
 |-- exclusion| String| カテゴリの除外対象のテンプレートの説明 |
 
+<a id="register-templates"></a>
+
 ### テンプレートの登録
+<a id="request-8"></a>
+
 #### リクエスト
 [URL]
 
@@ -1438,6 +1522,8 @@ Content-Type: application/json;charset=UTF-8
 | -schemeIos      | String  | X    | iOSアプリリンク(ALタイプの場合は必須フィールド、最大500文字)       |
 | -schemeAndroid  | String  | X    | Androidアプリリンク(ALタイプの場合は必須フィールド、最大500文字)   |
 
+<a id="response-12"></a>
+
 #### レスポンス
 ```
 {
@@ -1456,7 +1542,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | 結果メッセージ |
 | - isSuccessful  | Boolean | 成否 |
 
+<a id="modify-templates"></a>
+
 ### テンプレートの修正
+<a id="request-9"></a>
+
 #### リクエスト
 [URL]
 
@@ -1530,6 +1620,8 @@ Content-Type: application/json;charset=UTF-8
 | -schemeIos      | String  | X    | iOSアプリリンク(ALタイプの場合は必須フィールド、最大500文字)       |
 | -schemeAndroid  | String  | X    | Androidアプリリンク(ALタイプの場合は必須フィールド、最大500文字)   |
 
+<a id="response-13"></a>
+
 #### レスポンス
 ```
 {
@@ -1548,7 +1640,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | 結果メッセージ |
 | - isSuccessful  | Boolean | 成否 |
 
+<a id="delete-templates"></a>
+
 ### テンプレートの削除
+<a id="request-10"></a>
+
 #### リクエスト
 [URL]
 
@@ -1572,6 +1668,8 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
+<a id="response-14"></a>
+
 #### レスポンス
 ```
 {
@@ -1590,7 +1688,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | 結果メッセージ |
 | - isSuccessful  | Boolean | 成否 |
 
+<a id="inquire-of-templates"></a>
+
 ### テンプレートの問い合わせをする
+<a id="request-11"></a>
+
 #### リクエスト
 [URL]
 
@@ -1629,6 +1731,8 @@ Content-Type: application/json;charset=UTF-8
 | ------- | ------ | ---- | ----- |
 | comment | String | O    | お問い合わせ内容 |
 
+<a id="response-15"></a>
+
 #### レスポンス
 ```
 {
@@ -1647,7 +1751,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | 結果メッセージ |
 | - isSuccessful  | Boolean | 成否 |
 
+<a id="attach-files-to-send-inquiry-on-templates"></a>
+
 ### ファイルを添付してテンプレートお問い合わせ
+<a id="request-12"></a>
+
 #### リクエスト
 [URL]
 
@@ -1688,6 +1796,8 @@ Content-Type: application/json;charset=UTF-8
 |comment|	String |	O | お問い合わせ内容         |
 |attachments| List<File> | X | 添付ファイルリスト(最大10個) |
 
+<a id="response-16"></a>
+
 #### レスポンス
 ```
 {
@@ -1706,7 +1816,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 結果メッセージ|
 |- isSuccessful|	Boolean| 成否|
 
+<a id="list-templates"></a>
+
 ### テンプレートリストの照会
+
+<a id="request-13"></a>
 
 #### リクエスト
 
@@ -1755,6 +1869,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/templates?plusFriendId={発信キー}&templateStatus={テンプレートステータスコード}"
 ```
+
+<a id="response-17"></a>
 
 #### レスポンス
 ```
@@ -1854,7 +1970,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- createDate        | String  | 作成日時                            |
 | - totalCount         | Integer | 総個数                              |
 
+<a id="list-template-modifications"></a>
+
 ### テンプレートの修正リスト照会
+
+<a id="request-14"></a>
 
 #### リクエスト
 
@@ -1887,6 +2007,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/plus-friends/{plusFriendId}/templates/{templateCode}/modifications"
 ```
+
+<a id="response-18"></a>
 
 #### レスポンス
 ```
@@ -1992,7 +2114,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |-- updateDate | String | 修正日                                                                                            |
 |- totalCount | Integer | 総数                                                                                            |
 
+<a id="alternative-delivery-management"></a>
+
 ## 代替送信管理
+<a id="sms-appkey-registration"></a>
+
 ### SMS AppKey登録
 
 [URL]
@@ -2037,6 +2163,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
 ```
 
+<a id="response-19"></a>
+
 #### レスポンス
 ```
 
@@ -2048,6 +2176,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
   }
 }
 ```
+
+<a id="alternative-delivery-settings-registration"></a>
 
 ### 代替送信設定登録
 
@@ -2096,6 +2226,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/failback/appkey -d '{"plusFriendId": "@プラスフレンド","isResend": true,"resendSendNo": "01012341234" }
 ```
+
+<a id="response-20"></a>
 
 #### レスポンス
 ```

--- a/ja/alimtalk-api-guide.md
+++ b/ja/alimtalk-api-guide.md
@@ -1,6 +1,10 @@
 ## Notification > KakaoTalk Bizmessage > お知らせトーク > API v2.3 Guide
 
+<a id="alimtalk"></a>
+
 ## お知らせトーク
+
+<a id="api-domain"></a>
 
 #### [APIドメイン]
 
@@ -17,13 +21,19 @@
 </tbody>
 </table>
 
+<a id="overview-of-v23-api"></a>
+
 ## v2.3 API紹介
 1. お知らせトーク大量送信照会、統計照会APIが追加されました。
 2. 置換メッセージ送信時、buttonsフィールドが追加されました。
 3. 専門メッセージ送信時、buttonsフィールドにchatExtra、chatEvent、targetフィールドが追加されました。
 4. メッセージ照会時、buttonsフィールドにchatExtra、chatEvent、targetフィールドが追加されました。
 
+<a id="general-messages"></a>
+
 ## 一般メッセージ
+
+<a id="request-of-sending-replaced-messages"></a>
 
 ### メッセージ置換送信リクエスト
 
@@ -143,6 +153,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","templateParameter":{"{日本語識別子フィールド}":"{置換データ}"}}]}'
 ```
 
+<a id="response"></a>
+
 #### レスポンス
 
 ```
@@ -183,6 +195,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultCode           | Integer | 送信リクエスト結果コード |
 | -- resultMessage        | String  | 送信リクエスト結果メッセージ |
 | -- recipientGroupingKey | String  | 受信者グルーピングキー |
+
+<a id="request-of-sending-full-text"></a>
 
 ### メッセージ全文送信リクエスト
 
@@ -346,6 +360,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/raw-messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","content":"{内容}","buttons":[{"ordering":"{ボタン順序}","type":"{ボタンタイプ}","name":"{ボタン名}","linkMo":"{モバイルWebリンク}"}]}]}'
 ```
 
+<a id="response-2"></a>
+
 #### レスポンス
 
 ```
@@ -387,7 +403,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultMessage        | String  | 送信リクエスト結果メッセージ |
 | -- recipientGroupingKey | String  | 受信者グルーピングキー |
 
+<a id="list-messages"></a>
+
 ### メッセージリストの照会
+
+<a id="request"></a>
 
 #### リクエスト
 
@@ -436,6 +456,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 90日以上前の送信リクエストデータは照会されません。
 * 送信リクエスト日時の範囲は最大30日です。
+
+<a id="response-3"></a>
 
 #### レスポンス
 ```
@@ -518,7 +540,9 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
-#### SMS/LMS再送信ステータス
+<a id="get-messages"></a>
+
+### SMS/LMS再送信ステータス
 | 値 | 説明                      |
 | ----- | ------------------------------- |
 | RSC01 | 再送信の対象ではない                 |
@@ -528,6 +552,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | RSC05 | 再送信失敗                  |
 
 ### メッセージ単件照会
+
+<a id="request-2"></a>
 
 #### リクエスト
 
@@ -560,6 +586,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-4"></a>
 
 #### レスポンス
 ```
@@ -738,6 +766,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - senderGroupingKey    | String  | 発信グルーピングキー                            |
 | - recipientGroupingKey | String  | 受信者グルーピングキー                           |
 
+<a id="authentication-messages"></a>
+
 ## 認証メッセージ
 
 <span id="precautions-authword"></span>
@@ -750,6 +780,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 - 例1)認証メッセージAPI送信リクエストした時、全文(テンプレート日本語識別子含む)に認証文言が含まれていない場合は、送信に失敗します。
 - 例2)認証文言が英文の場合、大文字/小文字の区別なしで有効性チェックが行われます。
 
+
+<a id="request-of-sending-replaced-messages-2"></a>
 
 ### メッセージ置換送信リクエスト
 
@@ -853,7 +885,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","templateParameter":{"{日本語識別子フィールド}":"{置換データ}"}}]}'
 ```
 
-#### レスポンス
+**レスポンス**
 
 ```
 {
@@ -896,6 +928,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultCode           | Integer | 送信リクエスト結果コード |
 | -- resultMessage        | String  | 送信リクエスト結果メッセージ |
 | -- recipientGroupingKey | String  | 受信者グルーピングキー |
+
+<a id="request-of-sending-full-text-2"></a>
 
 ### メッセージ全文送信リクエスト
 
@@ -1011,7 +1045,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/raw-messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","content":"{内容}","buttons":[{"ordering":"{ボタン順序}","type":"{ボタンタイプ}","name":"{ボタン名}","linkMo":"{モバイルWebリンク}"}]}]}'
 ```
 
-#### レスポンス
+**レスポンス**
 
 ```
 {
@@ -1057,6 +1091,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultCode           | Integer | 送信リクエスト結果コード |
 | -- resultMessage        | String  | 送信リクエスト結果メッセージ |
 | -- recipientGroupingKey | String  | 受信者グルーピングキー |
+
+<a id="list-messages-2"></a>
 
 ### メッセージリストの照会
 
@@ -1108,7 +1144,7 @@ Content-Type: application/json;charset=UTF-8
 * 90日以上前の送信リクエストデータは照会されません。
 * 送信リクエスト日時の範囲は最大30日です。
 
-#### レスポンス
+**レスポンス**
 ```
 {
   "header" : {
@@ -1239,6 +1275,8 @@ Content-Type: application/json;charset=UTF-8
 | endUpdateDate       | 	String  | O   | 	結果アップデート照会終了時間(yyyy-MM-dd HH:mm) |
 | alimtalkMessageType | 	String  | X   | 	お知らせトークのメッセージタイプ(NORMAL, AUTH)           |
 
+<a id="request-3"></a>
+
 #### レスポンス
 
 ```
@@ -1266,7 +1304,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/message-results/count?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
-#### SMS/LMS再送信ステータス
+**SMS/LMS再送信ステータス**
 | 値 | 説明                      |
 | ----- | ------------------------------- |
 | RSC01 | 再送信の対象ではない                 |
@@ -1275,7 +1313,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | RSC04 | 再送信成功                  |
 | RSC05 | 再送信失敗                  |
 
+<a id="get-messages-2"></a>
+
 ### メッセージ単件照会
+
+<a id="request-4"></a>
 
 #### リクエスト
 
@@ -1308,6 +1350,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-5"></a>
 
 #### レスポンス
 ```
@@ -1381,8 +1425,14 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - senderGroupingKey    | String  | 発信グルーピングキー                            |
 | - recipientGroupingKey | String  | 受信者グルーピングキー                           |
 
+<a id="message"></a>
+
 ## メッセージ
+<a id="cancel-sending-messages"></a>
+
 ### メッセージ送信取消
+
+<a id="request-5"></a>
 
 #### リクエスト
 
@@ -1418,6 +1468,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 一般/認証メッセージは同じAPIでキャンセルできます。
 
+<a id="response-6"></a>
+
 #### レスポンス
 ```
 {
@@ -1441,7 +1493,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
 ```
 
+<a id="query-updates-of-message-result"></a>
+
 ### メッセージ結果アップデートの照会
+
+<a id="request-6"></a>
 
 #### リクエスト
 
@@ -1477,6 +1533,8 @@ Content-Type: application/json;charset=UTF-8
 | alimtalkMessageType | String  | X    | お知らせトークメッセージタイプ(NORMAL、AUTH)           |
 | pageNum             | Integer | X    | ページ番号(基本：1)                      |
 | pageSize            | Integer | X    | 照会件数(基本：15、最大: 1000)          |
+
+<a id="response-7"></a>
 
 #### レスポンス
 ```
@@ -1530,8 +1588,14 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/message-results?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
+<a id="mass-delivery"></a>
+
 ## 大量送信
+<a id="list-mass-delivery-requests"></a>
+
 ### 大量送信リクエストリスト照会
+
+<a id="request-8"></a>
 
 #### リクエスト
 [URL]
@@ -1571,6 +1635,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum | optional, Integer | - | X | ページ番号 |
 | pageSize | optional, Integer | 1000 | X | 検索数 |
 
+<a id="curl"></a>
+
 #### cURL
 ```
 curl -X GET \
@@ -1578,6 +1644,8 @@ https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appK
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-9"></a>
 
 #### レスポンス
 ```
@@ -1667,7 +1735,11 @@ https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appK
 | - totalCount | Integer | 総数
 
 
+<a id="list-mass-delivery-recipients"></a>
+
 ### 大量送信大量送信受信者リスト照会
+
+<a id="request-9"></a>
 
 #### リクエスト
 [URL]
@@ -1706,6 +1778,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum | optional, Integer | - | X | ページ番号 |
 | pageSize | optional, Integer | 1000 | X | 検索数 |
 
+<a id="curl-2"></a>
+
 #### cURL
 ```
 curl -X GET \
@@ -1713,6 +1787,8 @@ https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appK
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-10"></a>
 
 #### レスポンス
 ```
@@ -1758,7 +1834,11 @@ https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appK
 | -- resultCodeName | String | 結果コード内容 |
 | - totalCount | Integer | 総数 |
 
+<a id="get-a-mass-delivery-recipient"></a>
+
 ### 大量送信大量送信受信者照会
+
+<a id="request-10"></a>
 
 #### リクエスト
 [URL]
@@ -1798,6 +1878,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum | optional, Integer | - | X | ページ番号 |
 | pageSize | optional, Integer | 1000 | X | 検索数 |
 
+<a id="curl-3"></a>
+
 #### cURL
 ```
 curl -X GET \
@@ -1805,6 +1887,8 @@ https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appK
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-11"></a>
 
 #### レスポンス
 ```
@@ -1906,9 +1990,15 @@ https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appK
 |-- currencyType | String |	message(ユーザーに伝達されるメッセージ)内に含まれる価格/金額/決済金額の通貨単位KRW、USD、EURなどの国際通貨コードを使用(モーメント広告に該当) |
 
 
+<a id="templates"></a>
+
 ## テンプレート
 
+<a id="list-template-categories"></a>
+
 ### テンプレートカテゴリー照会
+<a id="request-11"></a>
+
 #### リクエスト
 [URL]
 
@@ -1932,6 +2022,8 @@ Content-Type: application/json;charset=UTF-8
 | 値    | タイプ | 必須 | 説明                               |
 |---|---|---|---|
 | X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+<a id="response-12"></a>
 
 #### レスポンス
 ```
@@ -1974,7 +2066,11 @@ Content-Type: application/json;charset=UTF-8
 |-- inclusion | String |	カテゴリー対象テンプレートの説明 |
 |-- exclusion| String| カテゴリの除外対象のテンプレートの説明 |
 
+<a id="register-templates"></a>
+
 ### テンプレートの登録
+<a id="request-12"></a>
+
 #### リクエスト
 [URL]
 
@@ -2053,6 +2149,8 @@ Content-Type: application/json;charset=UTF-8
 | -schemeIos      | String  | X    | iOSアプリリンク(ALタイプの場合は必須フィールド、最大500文字)       |
 | -schemeAndroid  | String  | X    | Androidアプリリンク(ALタイプの場合は必須フィールド、最大500文字)   |
 
+<a id="response-13"></a>
+
 #### レスポンス
 ```
 {
@@ -2071,7 +2169,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | 結果メッセージ |
 | - isSuccessful  | Boolean | 成否 |
 
+<a id="modify-templates"></a>
+
 ### テンプレートの修正
+<a id="request-13"></a>
+
 #### リクエスト
 [URL]
 
@@ -2149,6 +2251,8 @@ Content-Type: application/json;charset=UTF-8
 | -schemeIos      | String  | X    | iOSアプリリンク(ALタイプの場合は必須フィールド、最大500文字)       |
 | -schemeAndroid  | String  | X    | Androidアプリリンク(ALタイプの場合は必須フィールド、最大500文字)   |
 
+<a id="response-14"></a>
+
 #### レスポンス
 ```
 {
@@ -2167,7 +2271,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | 結果メッセージ |
 | - isSuccessful  | Boolean | 成否 |
 
+<a id="delete-templates"></a>
+
 ### テンプレートの削除
+<a id="request-14"></a>
+
 #### リクエスト
 [URL]
 
@@ -2190,6 +2298,8 @@ Content-Type: application/json;charset=UTF-8
   "X-Secret-Key": String
 }
 ```
+
+<a id="response-15"></a>
 
 #### レスポンス
 ```
@@ -2214,7 +2324,11 @@ Content-Type: application/json;charset=UTF-8
 * カカオに残っているテンプレートは1年間使っていないと休眠処理され、休眠状態が1年間続くと削除処理されます。(カカオでテンプレートが休眠に切り替わるときや、削除されるときは担当者に通知が送信されます。)
 
 
+<a id="inquire-of-templates"></a>
+
 ### テンプレートの問い合わせをする
+<a id="request-15"></a>
+
 #### リクエスト
 [URL]
 
@@ -2255,6 +2369,8 @@ Content-Type: application/json;charset=UTF-8
 
 * REJステータスのテンプレートにコメントを付けると、REQステータスに変更されます。
 
+<a id="response-16"></a>
+
 #### レスポンス
 ```
 {
@@ -2273,7 +2389,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | 結果メッセージ |
 | - isSuccessful  | Boolean | 成否 |
 
+<a id="send-inquiry-on-templates-with-file-attachment"></a>
+
 ### ファイルを添付してテンプレートお問い合わせ
+<a id="request-16"></a>
+
 #### リクエスト
 [URL]
 
@@ -2316,6 +2436,8 @@ Content-Type: application/json;charset=UTF-8
 
 * REJステータスのテンプレートにコメントを付けると、REQステータスに変更されます。
 
+<a id="response-17"></a>
+
 #### レスポンス
 ```
 {
@@ -2334,7 +2456,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 結果メッセージ|
 |- isSuccessful|	Boolean| 成否|
 
+<a id="change-template-to-channel-add-type"></a>
+
 ### テンプレート個別照会
+
+<a id="request-17"></a>
 
 #### リクエスト
 
@@ -2377,6 +2503,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}"
 ```
+
+<a id="response-18"></a>
 
 #### レスポンス
 
@@ -2556,7 +2684,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - updateDate            | String  |    X     | 修正日                                                                                                                                                                           |
 
 
+<a id="single-query-for-template"></a>
+
 ### テンプレートリストの照会
+
+<a id="request-18"></a>
 
 #### リクエスト
 
@@ -2605,6 +2737,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/templates?plusFriendId={発信キー}&templateStatus={テンプレートステータスコード}"
 ```
+
+<a id="response-19"></a>
 
 #### レスポンス
 ```
@@ -2708,7 +2842,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- createDate        | String  | 作成日時                                                                                                   |
 | - totalCount         | Integer | 総個数                                                                                                    |
 
+<a id="list-templates"></a>
+
 ### テンプレートチャンネル追加型に変更
+
+<a id="request-19"></a>
 
 #### リクエスト
 [URL]
@@ -2737,6 +2875,8 @@ Content-Type: application/json;charset=UTF-8
 
 * グループプロフィールに登録されたテンプレートは、チャンネルタイプに変換することはできません
 
+<a id="response-20"></a>
+
 #### レスポンス
 ```
 {
@@ -2755,7 +2895,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 結果メッセージ|
 |- isSuccessful|	Boolean| 成否|
 
+<a id="list-template-modifications"></a>
+
 ### テンプレートの修正リスト照会
+
+<a id="request-20"></a>
 
 #### リクエスト
 
@@ -2788,6 +2932,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}/modifications"
 ```
+
+<a id="response-21"></a>
 
 #### レスポンス
 ```
@@ -2893,7 +3039,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- createDate        | String  | 作成日時                            |
 | - totalCount         | Integer | 総個数                              |
 
+<a id="register-template-image"></a>
+
 ### テンプレート画像の登録
+<a id="request-21"></a>
+
 #### リクエスト
 [URL]
 
@@ -2929,6 +3079,8 @@ Content-Type: multipart/form-data
 curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/template-image" -F "file=@alimtalk-template-image.jpeg"
 ```
 
+<a id="response-22"></a>
+
 #### レスポンス
 ```
 {
@@ -2954,7 +3106,101 @@ curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}
 |- templateImageName    | String |	画像名（アップロードされたファイル名） |
 |- templateImageUrl     | String |	画像のURL |
 
+<a id="register-template-item-highlight-images"></a>
+
+### テンプレートアイテムハイライト画像の登録
+
+<!-- TODO: translate body -->
+
+<a id="request-22"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="response-23"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="register-template-plugin"></a>
+
+### テンプレートプラグイン登録
+
+<!-- TODO: translate body -->
+
+<a id="request-23"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="response-24"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="modify-template-plugin"></a>
+
+### テンプレートプラグイン修正
+
+<!-- TODO: translate body -->
+
+<a id="request-24"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="response-25"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="modify-template-plugin-2"></a>
+
+### テンプレートプラグイン削除
+
+<!-- TODO: translate body -->
+
+<a id="request-25"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="response-26"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="retrieve-template-plugin"></a>
+
+### テンプレートプラグイン照会
+
+<!-- TODO: translate body -->
+
+<a id="request-26"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="response-27"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="manage-alternative-delivery"></a>
+
 ## 代替送信管理
+<a id="register-an-sms-appkey"></a>
+
 ### SMS AppKey登録
 
 [URL]
@@ -2999,6 +3245,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
 ```
 
+<a id="response-28"></a>
+
 #### レスポンス
 ```
 
@@ -3010,6 +3258,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
   }
 }
 ```
+
+<a id="register-alternative-delivery-settings"></a>
 
 ### 代替送信設定登録
 
@@ -3057,6 +3307,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/failback/appkey -d '{"plusFriendId": "@プラスフレンド","isResend": true,"resendSendNo": "01012341234" }
 ```
+
+<a id="response-29"></a>
 
 #### レスポンス
 ```

--- a/ja/friendtalkupgrade-api-guide.md
+++ b/ja/friendtalkupgrade-api-guide.md
@@ -1,6 +1,10 @@
 ## Notification > KakaoTalk Bizmessage > ブランドメッセージ > API v1.0 Guide
 
+<a id="brand-message"></a>
+
 ## ブランドメッセージ
+
+<a id="api-domain"></a>
 
 #### [APIドメイン]
 
@@ -8,7 +12,11 @@
 |------------------------------------------------------------------------------|
 | [https://kakaotalk-bizmessage.api.nhncloudservice.com](https://kakaotalk-bizmessage.api.nhncloudservice.com) |
 
+<a id="introduce-v10-api"></a>
+
 ## v1.0 API紹介
+
+<a id="manage-non-friend-message-sending-targeting-m-n"></a>
 
 ## 非友だちメッセージ送信(ターゲティングM、N)管理
 
@@ -20,7 +28,11 @@
   - チャンネルの友だち数が5万以上
   - 3か月以内にお知らせトークの送信成功履歴を保有
 
+<a id="upload-marketing-consent-evidence"></a>
+
 ### マーケティング受信同意の証明資料のアップロード
+
+<a id="requested"></a>
 
 #### リクエスト
 
@@ -56,6 +68,8 @@ Content-Type: multipart/form-data
 |------|------|----|---------------|
 | file | File | O | マーケティング受信同意の証明資料 |
 
+<a id="response"></a>
+
 #### レスポンス
 
 ```
@@ -75,7 +89,11 @@ Content-Type: multipart/form-data
 | - resultMessage | String  | O        | 結果メッセージ |
 | - isSuccessful  | boolean | O        | 成否 |
 
+<a id="apply-for-using-non-friend-message-sending-targeting-m-n"></a>
+
 ### 非友だちメッセージ送信(ターゲティングM、N)の使用申請
+
+<a id="requested-2"></a>
 
 #### リクエスト
 
@@ -105,6 +123,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
 
+<a id="response-2"></a>
+
 #### レスポンス
 
 ```
@@ -123,6 +143,8 @@ Content-Type: application/json;charset=UTF-8
 | - resultCode    | Integer | O        | 結果コード |
 | - resultMessage | String  | O        | 結果メッセージ |
 | - isSuccessful  | boolean | O        | 成否 |
+
+<a id="request-to-send-a-free-form-message"></a>
 
 ## メッセージ自由形送信リクエスト
 
@@ -145,6 +167,8 @@ Content-Type: application/json;charset=UTF-8
 * 代替送信は、受信者ごとにresendParameterを介して設定できます。
 * 代替送信をご利用になる場合、代替送信管理APIを介してSMS Appkeyの登録及び送信設定が必要です。
 * **夜間送信制限(20:50～翌日08:00)**
+
+<a id="requested-3"></a>
 
 #### リクエスト
 
@@ -172,6 +196,8 @@ Content-Type: application/json;charset=UTF-8
 | 名前         | タイプ   | 必須 | 説明             |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
+
+<a id="request-text-type-sending"></a>
 
 #### テキスト型送信リクエスト
 
@@ -259,6 +285,8 @@ Content-Type: application/json;charset=UTF-8
 | -- resendUnsubscribeNo | String | X | 代替送信080受信拒否番号<br><span style="color:red">(SMSサービスに登録された080受信拒否番号ではない場合、代替送信に失敗することがあります。)</span> |
 | createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
 | statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
+
+<a id="request-image-type-sending"></a>
 
 #### 画像形式の送信リクエスト
 
@@ -353,6 +381,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
 | statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
 
+<a id="request-wide-image-type-sending"></a>
+
 #### ワイド画像形式の送信リクエスト
 
 [Request body]
@@ -445,6 +475,8 @@ Content-Type: application/json;charset=UTF-8
 | -- resendUnsubscribeNo | String | X | 代替送信080受信拒否番号<br><span style="color:red">(SMSサービスに登録された080受信拒否番号ではない場合、代替送信に失敗することがあります。)</span> |
 | createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
 | statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
+
+<a id="request-to-send-wide-item-list-type"></a>
 
 #### ワイドアイテムリスト形式の送信リクエスト
 
@@ -568,6 +600,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
 | statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
 
+<a id="request-to-send-premium-video-type"></a>
+
 #### プレミアム動画形式の送信リクエスト
 
 [Request body]
@@ -662,6 +696,8 @@ Content-Type: application/json;charset=UTF-8
 | -- resendUnsubscribeNo | String | X | 代替送信080受信拒否番号<br><span style="color:red">(SMSサービスに登録された080受信拒否番号ではない場合、代替送信に失敗することがあります。)</span> |
 | createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
 | statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
+
+<a id="request-to-send-commerce"></a>
 
 #### コマース形式の送信リクエスト
 
@@ -768,6 +804,8 @@ Content-Type: application/json;charset=UTF-8
 | -- resendUnsubscribeNo | String | X | 代替送信080受信拒否番号<br><span style="color:red">(SMSサービスに登録された080受信拒否番号ではない場合、代替送信に失敗することがあります。)</span> |
 | createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
 | statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
+
+<a id="request-to-send-carousel-feed-type"></a>
 
 #### カルーセルフィード形式の送信リクエスト
 
@@ -1066,6 +1104,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser | String | X  | 登録者(コンソールで送信時にユーザーUUIDとして保存) |
 | statsId | String | X  | 統計ID(送信検索条件には含まれません、最大8文字) |
 
+<a id="response-3"></a>
+
 #### レスポンス
 
 ```
@@ -1103,6 +1143,8 @@ Content-Type: application/json;charset=UTF-8
 | -- resultCode | Integer | O | 受信者別の送信結果コード(成功及び様々な失敗コードが存在する可能性があります) |
 | -- resultMessage | String | O | 受信者別の送信結果メッセージ(成功時は「success」または関連メッセージ、失敗時は失敗原因の詳細メッセージ) |
 
+<a id="request-to-send-basic-message"></a>
+
 ## メッセージ基本形送信リクエスト
 
 * テンプレートを利用した送信です。
@@ -1118,6 +1160,8 @@ Content-Type: application/json;charset=UTF-8
 * 代替送信は、受信者ごとにresendParameterを介して設定できます。
 * 代替送信をご利用になる場合、代替送信管理APIを介してSMS Appkeyの登録及び送信設定が必要です。
 * **夜間送信制限(20:50～翌日08:00)**
+
+<a id="cautions-for-use"></a>
 
 ### 使用時の注意事項
 
@@ -1150,6 +1194,8 @@ Content-Type: application/json;charset=UTF-8
 | 名前         | タイプ   | 必須 | 説明             |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
+
+<a id="requested-4"></a>
 
 #### 送信リクエスト
 
@@ -1219,6 +1265,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser | String | X | 登録者(コンソールから送信時、ユーザーUUIDとして保存) |
 | statsId | String | X | 統計ID(送信検索条件には含まれません。最大8文字) |
 
+<a id="response-4"></a>
+
 #### レスポンス
 
 ```
@@ -1256,7 +1304,11 @@ Content-Type: application/json;charset=UTF-8
 | -- resultCode | Integer | O | 受信者別の送信結果コード(成功及び様々な失敗コードが存在する可能性があります) |
 | -- resultMessage | String | O | 受信者別の送信結果メッセージ(成功時は「success」または関連メッセージ、失敗時は失敗原因の詳細メッセージ) |
 
+<a id="view-sending-list"></a>
+
 ## 送信リストの照会
+
+<a id="requested-5"></a>
 
 #### リクエスト
 
@@ -1299,6 +1351,8 @@ Content-Type: application/json;charset=UTF-8
 | resultCode       | String | X         | 送信結果(MRC01:成功MRC02:失敗)      |
 | pageNum          | String | X         | ページ番号(Default: 1)               |
 | pageSize | String | X | 照会件数(Default: 15、Max: 1,000) |
+
+<a id="response-5"></a>
 
 #### レスポンス
 
@@ -1371,7 +1425,11 @@ Content-Type: application/json;charset=UTF-8
 | -- createUser | String | X | 登録者(コンソールで送信時にユーザーUUIDとして保存) |
 | - totalCount | Integer | O | 合計数 |
 
+<a id="view-single-sending"></a>
+
 ## 送信単件照会
+
+<a id="requested-6"></a>
 
 #### リクエスト
 
@@ -1401,6 +1459,8 @@ Content-Type: application/json;charset=UTF-8
 | 名前         | タイプ   | 必須 | 説明             |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
+
+<a id="response-6"></a>
 
 #### レスポンス
 
@@ -1658,9 +1718,33 @@ Content-Type: application/json;charset=UTF-8
 | - resendRequestId     | String  | X        | 代替送信リクエストID                                                                                      | 
 | - createUser          | String  | X        | 登録者(コンソールから送信した場合、ユーザーUUIDで保存)                                                                      |
 
+<a id="cancel-message-sending"></a>
+
+## メッセージ送信取消
+
+<!-- TODO: translate body -->
+
+<a id="requested-7"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="response-7"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="manage-templates"></a>
+
 ## テンプレート管理
 
+<a id="view-template-list"></a>
+
 ### テンプレートリスト照会
+
+<a id="requested-8"></a>
 
 #### リクエスト
 
@@ -1699,6 +1783,8 @@ Content-Type: application/json;charset=UTF-8
 | status       | String  | X  | テンプレートステータスコード                   |
 | pageNum      | Integer | X  | ページ番号(Default: 1)            |
 | pageSize     | Integer | X  | 照会件数(Default: 15, Max: 1,000) |
+
+<a id="response-8"></a>
 
 #### レスポンス
 
@@ -1927,6 +2013,8 @@ Content-Type: application/json;charset=UTF-8
 | --- updateDate          | String  | X        | 修正日時                                |
 | - totalCount            | Integer | O        | 合計数                                  |
 
+<a id="view-single-template"></a>
+
 ### テンプレートの個別照会
 
 [URL]
@@ -1956,6 +2044,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
 |X-NC-API-IDEMPOTENCY-KEY| String| X | 重複メッセージ送信リクエストの基準key<br>10分間同じkeyでリクエストした場合、該当リクエストは失敗として処理します。 |
+
+<a id="response-9"></a>
 
 #### レスポンス
 
@@ -2178,7 +2268,11 @@ Content-Type: application/json;charset=UTF-8
 | - createDate          | String  | O        | 登録日時              |
 | - updateDate          | String  | X        | 修正日時              |
 
+<a id="register-template"></a>
+
 ### テンプレート登録
+
+<a id="requested-9"></a>
 
 #### リクエスト
 
@@ -2208,6 +2302,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
 
+<a id="note"></a>
+
 #### 注意事項
 
 * クーポン名にプレースホルダーを適用する場合、次のような固定プレースホルダーを使用する必要があります。
@@ -2226,6 +2322,8 @@ Content-Type: application/json;charset=UTF-8
     * discountPrice -> #{割引価格}
     * discountRate -> #{割引率}
     * discountFixed -> #{定額割引価格}
+
+<a id="request-to-register-text-type-template"></a>
 
 #### テキスト型テンプレート登録リクエスト
 
@@ -2280,6 +2378,8 @@ Content-Type: application/json;charset=UTF-8
 | - linkPc        | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                                               |
 | - schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                       |
 | - schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                         |
+
+<a id="request-to-register-image-type-template"></a>
 
 #### 画像型テンプレート登録リクエスト
 
@@ -2342,6 +2442,8 @@ Content-Type: application/json;charset=UTF-8
 | - schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                       |
 | - schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                         |
 
+<a id="request-to-register-wide-image-type-template"></a>
+
 #### ワイド画像型テンプレート登録リクエスト
 
 [Request body]
@@ -2402,6 +2504,8 @@ Content-Type: application/json;charset=UTF-8
 | - linkPc        | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                                               |
 | - schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                       |
 | - schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                         |
+
+<a id="request-to-register-wide-item-list-type-template"></a>
 
 #### ワイドアイテムリスト型テンプレート登録リクエスト
 
@@ -2493,6 +2597,8 @@ Content-Type: application/json;charset=UTF-8
 | - schemeAndroid  | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                     |
 | - schemeIos      | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                       |
 
+<a id="request-to-register-premium-video-type-template"></a>
+
 #### プレミアム動画型テンプレート登録リクエスト
 
 [Request body]
@@ -2555,6 +2661,8 @@ Content-Type: application/json;charset=UTF-8
 | - linkPc        | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                                               |
 | - schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                       |
 | - schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                         |
+
+<a id="request-to-register-commerce-type-template"></a>
 
 #### コマース型テンプレート登録リクエスト
 
@@ -2630,6 +2738,8 @@ Content-Type: application/json;charset=UTF-8
 | - linkPc          | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                             |
 | - schemeAndroid   | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                     |
 | - schemeIos       | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                       |
+
+<a id="request-to-register-carousel-feed-type-template"></a>
 
 #### カルーセルフィード型テンプレート登録リクエスト
 
@@ -2741,6 +2851,8 @@ Content-Type: application/json;charset=UTF-8
 | - recipientNo     | String  | O  | 受信番号                                                                                                                                                                                                                           |
 | createUser        | String  | X  | 登録者(コンソールから送信した場合、ユーザーUUIDで保存)                                                                                                                                                                                                       |
 
+<a id="request-to-register-carousel-commerce-type-template"></a>
+
 #### カルーセルコマース型テンプレート登録リクエスト
 
 [Request body]
@@ -2849,6 +2961,8 @@ Content-Type: application/json;charset=UTF-8
 | -- schemeAndroid     | String  | X  | Androidアプリリンク、500文字制限<br>プレースホルダーは使用不可。                                                                                                                                                                                               |
 | -- schemeIos         | String  | X  | iOSアプリリンク、500文字制限<br>プレースホルダーは使用不可。                                                                                                                                                                                                 |
 
+<a id="response-10"></a>
+
 #### レスポンス
 
 ```
@@ -2873,7 +2987,11 @@ Content-Type: application/json;charset=UTF-8
 | template        | Object  | X        | テンプレート情報 |
 | - templateCode  | String  | O        | テンプレートコード |
 
+<a id="modify-template"></a>
+
 ### テンプレート修正
+
+<a id="requested-10"></a>
 
 #### リクエスト
 
@@ -2908,6 +3026,8 @@ Content-Type: application/json;charset=UTF-8
 
 * テンプレート登録と仕様は同じです
 
+<a id="response-11"></a>
+
 #### レスポンス
 
 ```
@@ -2927,7 +3047,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 結果メッセージ |
 | - isSuccessful  | boolean | O        | 成否 |
 
+<a id="delete-template"></a>
+
 ### テンプレート削除
+
+<a id="requested-11"></a>
 
 #### リクエスト
 
@@ -2958,6 +3082,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
 
+<a id="response-12"></a>
+
 #### レスポンス
 
 ```
@@ -2977,9 +3103,15 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 結果メッセージ |
 | - isSuccessful  | boolean | O        | 成否 |
 
+<a id="manage-image"></a>
+
 ## 画像管理
 
+<a id="upload-image"></a>
+
 ### 画像アップロード
+
+<a id="requested-12"></a>
 
 #### リクエスト
 
@@ -3015,6 +3147,8 @@ Content-Type: multipart/form-data
 | image     | File   | O  | 画像                                                                                                                           |
 | imageType | String | O  | 画像タイプ <br>(IMAGE, WIDE_IMAGE,MAIN_WIDE_ITEMLIST_IMAGE,NORMAL_WIDE_ITEMLIST_IMAGE,CAROUSEL_FEED_IMAGE,CAROUSEL_COMMERCE_IMAGE) |
 
+<a id="response-13"></a>
+
 #### レスポンス
 
 ```
@@ -3043,6 +3177,8 @@ Content-Type: multipart/form-data
 | - imageUrl      | String  | O        | 画像のURL |
 | - imageName     | String  | X        | 画像名   |
 
+<a id="upload-image-specifications"></a>
+
 #### アップロード画像規格
 | 画像タイプ                      | 使用先                                                 | アップロード画像規格                                                                                                         |
 | :------------------------- | :-------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------- |
@@ -3053,7 +3189,7 @@ Content-Type: multipart/form-data
 | CAROUSEL_FEED_IMAGE        | カルーセルフィード形式の送信リクエストのセル別画像                           | **推奨サイズ：**800 × 600px または 800 × 400px（横500px以上）<br/>**画像比率：**0.5 ≤ 縦 ÷ 横 ≤ 1.333<br/>**ファイル形式／容量制限：**jpg、png／最大5MB |
 | CAROUSEL_COMMERCE_IMAGE    | コマース形式の送信リクエスト（カルーセルコマース形式）のイントロ画像、セル別画像            | **推奨サイズ：**800 × 600px または 800 × 400px（横500px以上）<br/>**画像比率：**0.5 ≤ 縦 ÷ 横 ≤ 1.333<br/>**ファイル形式／容量制限：**jpg、png／最大5MB |
 
-#### アップロード画像規格
+**アップロード画像規格**
 | 画像タイプ                     | 使用箇所                                                     | アップロード画像規格                                                                                                                              |
 |:---------------------------|:--------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------|
 | IMAGE                      | 画像型画像、コマース型画像、プレミアム動画型サムネイル                       | 推奨サイズ: 800 X 400px (横500px以上)<br/>画像比率: 0.5 ≤ 縦 ÷ 横 ≤ 1.333<br/>ファイル形式及び容量制限: jpg, png / 最大5MB                                |
@@ -3065,7 +3201,11 @@ Content-Type: multipart/form-data
 
 * アップロードされた画像を参照するテンプレートが全て削除されるか、別の画像に変更されると、Kakao CDNから該当の画像が削除され、URLが無効になります。画像照会APIでは画像情報が維持されますが、実際の画像にはアクセスできないため、オリジナルファイルは自社サーバーに別途保管することを推奨します。
 
+<a id="view-image"></a>
+
 ### 画像照会
+
+<a id="requested-13"></a>
 
 #### リクエスト
 
@@ -3102,6 +3242,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum    | String | X  | ページ番号(基本: 1)                                                                                                                  |
 | pageSize   | String | X  | 照会件数(基本: 15)                                                                                                                  |
 
+<a id="response-14"></a>
+
 #### レスポンス
 
 ```
@@ -3130,7 +3272,11 @@ Content-Type: application/json;charset=UTF-8
 | - imageUrl      | String  | O        | 画像のURL |
 | - imageName     | String  | X        | 画像名   |
 
+<a id="delete-image"></a>
+
 ### 画像削除
+
+<a id="requested-14"></a>
 
 #### リクエスト
 
@@ -3165,6 +3311,8 @@ Content-Type: application/json;charset=UTF-8
 |----------|--------|----|--------|
 | imageSeq | String | O  | 画像番号 |
 
+<a id="response-15"></a>
+
 #### レスポンス
 
 ```
@@ -3184,9 +3332,15 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 結果メッセージ |
 | - isSuccessful  | boolean | O        | 成否 |
 
+<a id="upload"></a>
+
 ## アップロード
 
+<a id="upload-bizform-key"></a>
+
 ### ビズフォームキーのアップロード
+
+<a id="requested-15"></a>
 
 #### リクエスト
 
@@ -3216,6 +3370,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
 
+<a id="response-16"></a>
+
 #### レスポンス
 
 ```
@@ -3235,9 +3391,15 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 結果メッセージ |
 | - isSuccessful  | boolean | O        | 成否 |
 
+<a id="manage-outgoing-profiles"></a>
+
 ## 送信プロフィール管理
 
+<a id="view-outgoing-profile"></a>
+
 ### 送信プロフィール照会
+
+<a id="requested-16"></a>
 
 #### リクエスト
 
@@ -3266,6 +3428,8 @@ Content-Type: application/json;charset=UTF-8
 | 名前         | タイプ   | 必須 | 説明             |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
+
+<a id="response-17"></a>
 
 #### レスポンス
 
@@ -3336,7 +3500,11 @@ Content-Type: application/json;charset=UTF-8
 | - createDate              | String  | X        | 登録日                                                                                                                |
 | - initialUserRestriction  | boolean | O        | 初回ユーザー制限の有無                                                                                                         |
 
+<a id="modify-outgoing-profile-080-opt-out-number"></a>
+
 ### 送信プロフィールの080受信拒否番号の修正
+
+<a id="requested-17"></a>
 
 #### リクエスト
 
@@ -3380,6 +3548,8 @@ Content-Type: application/json;charset=UTF-8
 | unsubscribeNo     | 	String | 	O  | 080無料受信拒否電話番号(両方とも未入力の場合、送信プロフィールに登録された無料受信拒否情報で送信されます)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx  |
 | unsubscribeAuthNo | 	String | 	X  | 080無料受信拒否認証番号(両方とも未入力の場合、送信プロフィールに登録された無料受信拒否情報で送信されます)<br>unsubscribe_phone_numberなしでunsubscribe_auth_numberのみの入力は不可<br>ex) 1234 |
 
+<a id="response-18"></a>
+
 #### レスポンス
 
 ```
@@ -3399,7 +3569,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 結果メッセージ |
 | - isSuccessful  | boolean | O        | 成否 |
 
+<a id="manage-fallback"></a>
+
 ## 代替送信管理
+
+<a id="register-sms-appkey"></a>
 
 ### SMS AppKeyの登録
 
@@ -3446,6 +3620,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
 ```
 
+<a id="response-19"></a>
+
 #### レスポンス
 
 ```
@@ -3458,6 +3634,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
   }
 }
 ```
+
+<a id="register-fallback-settings"></a>
 
 ### 代替送信設定の登録
 
@@ -3509,6 +3687,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/failback/appkey -d '{"senderKey": "0be23c29de88d6888798aeda57062516354d74ba","isResend": true,"resendSendNo": "01012341234" }
 ```
+
+<a id="response-20"></a>
 
 #### レスポンス
 

--- a/ko/alimtalk-api-guide-v2.0.md
+++ b/ko/alimtalk-api-guide-v2.0.md
@@ -1,6 +1,12 @@
+<!-- pre-align:aligned sig=4ea84933972e -->
+
 ## Notification > KakaoTalk Bizmessage > 알림톡 > API v2.0 Guide
 
+<a id="alimtalk"></a>
+
 ## 알림톡
+
+<a id="api-domain"></a>
 
 #### [API 도메인]
 
@@ -17,12 +23,18 @@
 </tbody>
 </table>
 
+<a id="overview-of-v20-api"></a>
+
 ## v2.0 API 소개
 1. 카카오 채널 추가 시, 발급 받은 senderKey 필드로 API 호출이 되도록 변경 되었습니다.(plusFriendId 필드 대체)
 2. API uri가 변경 되었습니다.(/plus-friends -> /senders)
 3. 카카오 채널 그룹 기능이 추가 되었습니다.
 
+<a id="general-messages"></a>
+
 ## 일반 메시지
+
+<a id="request-of-sending-replaced-messages"></a>
 
 ### 메시지 치환 발송 요청
 
@@ -115,6 +127,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages -d '{"senderKey":"{발신 키}","templateCode":"{템플릿 코드}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{수신번호}","templateParameter":{"{치환자 필드}":"{치환 데이터}"}}]}'
 ```
 
+<a id="response"></a>
+
 #### 응답
 
 ```
@@ -155,6 +169,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 |-- resultCode | Integer | 발송 요청 결과 코드 |
 |-- resultMessage | String | 발송 요청 결과 메시지 |
 |-- recipientGroupingKey | String | 수신자 그룹핑 키 |
+
+<a id="request-of-sending-full-text"></a>
 
 ### 메시지 전문 발송 요청
 
@@ -267,6 +283,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/raw-messages -d '{"senderKey":"{발신 키}","templateCode":"{템플릿 코드}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{수신번호}","content":"{내용}","buttons":[{"ordering":"{버튼 순서}","type":"{버튼 타입}","name":"{버튼 이름}","linkMo":"{모바일 웹 링크}"}]}]}'
 ```
 
+<a id="response-2"></a>
+
 #### 응답
 
 ```
@@ -308,7 +326,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 |-- resultMessage | String | 발송 요청 결과 메시지 |
 |-- recipientGroupingKey | String | 수신자 그룹핑 키 |
 
+<a id="list-messages"></a>
+
 ### 메시지 리스트 조회
+
+<a id="request"></a>
 
 #### 요청
 
@@ -357,6 +379,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 90일 이전 발송 요청 데이터는 조회되지 않습니다.
 * 발송 요청 일시의 범위는 최대 30일입니다.
+
+<a id="response-3"></a>
 
 #### 응답
 ```
@@ -446,7 +470,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<a id="get-messages"></a>
+
 ### 메시지 단건 조회
+
+<a id="request-2"></a>
 
 #### 요청
 
@@ -479,6 +507,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-4"></a>
 
 #### 응답
 ```
@@ -575,6 +605,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |- senderGroupingKey | String | 발신 그룹핑 키 |
 |- recipientGroupingKey | String |	수신자 그룹핑 키 |
 
+<a id="authentication-messages"></a>
+
 ## 인증 메시지
 
 <span id="precautions-authword"></span>
@@ -587,6 +619,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 - 예시 1-1) 인증 메시지 API 요청시 전문(템플릿 치환자 포함)에 인증 문구가 포함되어 있지 않은 경우 발송 실패됩니다.
 - 예시 1-2) 인증 문구가 영문인 경우 대소문자 구분 없이 유효성 검사가 진행됩니다.
 
+
+<a id="request-of-sending-replaced-messages-2"></a>
 
 ### 메시지 치환 발송 요청
 
@@ -676,6 +710,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/auth/messages -d '{"senderKey":"{발신 키}","templateCode":"{템플릿 코드}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{수신번호}","templateParameter":{"{치환자 필드}":"{치환 데이터}"}}]}'
 ```
 
+<a id="response-5"></a>
+
 #### 응답
 
 ```
@@ -716,6 +752,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 |-- resultCode | Integer | 발송 요청 결과 코드 |
 |-- resultMessage | String | 발송 요청 결과 메시지 |
 |-- recipientGroupingKey | String | 수신자 그룹핑 키 |
+
+<a id="request-of-sending-full-text-2"></a>
 
 ### 메시지 전문 발송 요청
 
@@ -823,6 +861,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/auth/raw-messages -d '{"senderKey":"{발신 키}","templateCode":"{템플릿 코드}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{수신번호}","content":"{내용}","buttons":[{"ordering":"{버튼 순서}","type":"{버튼 타입}","name":"{버튼 이름}","linkMo":"{모바일 웹 링크}"}]}]}'
 ```
 
+<a id="response-6"></a>
+
 #### 응답
 
 ```
@@ -864,7 +904,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 |-- resultMessage | String | 발송 요청 결과 메시지 |
 |-- recipientGroupingKey | String | 수신자 그룹핑 키 |
 
+<a id="list-messages-2"></a>
+
 ### 메시지 리스트 조회
+
+<a id="request-3"></a>
 
 #### 요청
 
@@ -913,6 +957,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 90일 이전 발송 요청 데이터는 조회되지 않습니다.
 * 발송 요청 일시의 범위는 최대 30일입니다.
+
+<a id="response-7"></a>
 
 #### 응답
 ```
@@ -1002,7 +1048,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/auth/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<a id="get-messages-2"></a>
+
 ### 메시지 단건 조회
+
+<a id="request-4"></a>
 
 #### 요청
 
@@ -1035,6 +1085,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/auth/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-8"></a>
 
 #### 응답
 ```
@@ -1131,8 +1183,14 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |- senderGroupingKey | String | 발신 그룹핑 키 |
 |- recipientGroupingKey | String |	수신자 그룹핑 키 |
 
+<a id="messages"></a>
+
 ## 메시지
+<a id="cancel-sending-messages"></a>
+
 ### 메시지 발송 취소
+
+<a id="request-5"></a>
 
 #### 요청
 
@@ -1168,6 +1226,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 일반/인증 메시지 모두 동일한 API로 취소할 수 있습니다.
 
+<a id="response-9"></a>
+
 #### 응답
 ```
 {
@@ -1191,7 +1251,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
 ```
 
+<a id="query-updates-of-message-result"></a>
+
 ### 메시지 결과 업데이트 조회
+
+<a id="request-6"></a>
 
 #### 요청
 
@@ -1227,6 +1291,8 @@ Content-Type: application/json;charset=UTF-8
 |alimtalkMessageType|	String| X |	알림톡 메시지 타입(NORMAL, AUTH) |
 |pageNum|	Integer|	X|	페이지 번호(기본: 1)|
 |pageSize|	Integer|	X|	조회 건수(Default: 15, Max: 1000)|
+
+<a id="response-10"></a>
 
 #### 응답
 ```
@@ -1280,6 +1346,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/message-results?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
+<a id="smslms-alternative-delivery-status-code"></a>
+
 ### SMS/LMS 대체 발송 상태 코드
 | 이름 |	설명|
 |---|---|
@@ -1289,9 +1357,15 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |RSC04|	대체 발송 성공|
 |RSC05|	대체 발송 실패|
 
+<a id="templates"></a>
+
 ## 템플릿
 
+<a id="list-template-categories"></a>
+
 ### 템플릿 카테고리 조회
+<a id="request-7"></a>
+
 #### 요청
 [URL]
 
@@ -1315,6 +1389,8 @@ Content-Type: application/json;charset=UTF-8
 | 이름 |	타입|	필수|	설명|
 |---|---|---|---|
 |X-Secret-Key|	String| O | 콘솔에서 생성할 수 있습니다.  |
+
+<a id="response-11"></a>
 
 #### 응답
 ```
@@ -1357,7 +1433,11 @@ Content-Type: application/json;charset=UTF-8
 |-- inclusion | String |	카테고리 적용 대상 템플릿 설명 |
 |-- exclusion| String| 카테고리 제외 대상 템플릿 설명 |
 
+<a id="register-templates"></a>
+
 ### 템플릿 등록
+<a id="request-8"></a>
+
 #### 요청
 [URL]
 
@@ -1432,6 +1512,8 @@ Content-Type: application/json;charset=UTF-8
 |-schemeIos | String | X |	iOS 앱 링크(AL 타입일 경우 필수 필드, 최대 500자) |
 |-schemeAndroid | String | X |	안드로이드 앱 링크(AL 타입일 경우 필수 필드, 최대 500자) |
 
+<a id="response-12"></a>
+
 #### 응답
 ```
 {
@@ -1450,7 +1532,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 결과 메시지|
 |- isSuccessful|	Boolean| 성공 여부|
 
+<a id="modify-templates"></a>
+
 ### 템플릿 수정
+<a id="request-9"></a>
+
 #### 요청
 [URL]
 
@@ -1524,6 +1610,8 @@ Content-Type: application/json;charset=UTF-8
 |-schemeIos | String | X |	iOS 앱 링크(AL 타입일 경우 필수 필드, 최대 500자) |
 |-schemeAndroid | String | X |	안드로이드 앱 링크(AL 타입일 경우 필수 필드, 최대 500자) |
 
+<a id="response-13"></a>
+
 #### 응답
 ```
 {
@@ -1542,7 +1630,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 결과 메시지|
 |- isSuccessful|	Boolean| 성공 여부|
 
+<a id="delete-templates"></a>
+
 ### 템플릿 삭제
+<a id="request-10"></a>
+
 #### 요청
 [URL]
 
@@ -1566,6 +1658,8 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
+<a id="response-14"></a>
+
 #### 응답
 ```
 {
@@ -1584,7 +1678,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 결과 메시지|
 |- isSuccessful|	Boolean| 성공 여부|
 
+<a id="inquire-of-templates"></a>
+
 ### 템플릿 문의하기
+<a id="request-11"></a>
+
 #### 요청
 [URL]
 
@@ -1623,6 +1721,8 @@ Content-Type: application/json;charset=UTF-8
 |---|---|---|---|
 |comment|	String |	O | 문의 내용 |
 
+<a id="response-15"></a>
+
 #### 응답
 ```
 {
@@ -1641,7 +1741,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 결과 메시지|
 |- isSuccessful|	Boolean| 성공 여부|
 
+<a id="attach-files-to-send-inquiry-on-templates"></a>
+
 ### 파일 첨부하여 템플릿 문의하기
+<a id="request-12"></a>
+
 #### 요청
 [URL]
 
@@ -1682,6 +1786,8 @@ Content-Type: application/json;charset=UTF-8
 |comment|	String |	O | 문의 내용           |
 |attachments| List<File> | X | 첨부 파일 목록(최대 10개) |
 
+<a id="response-16"></a>
+
 #### 응답
 ```
 {
@@ -1700,7 +1806,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 결과 메시지|
 |- isSuccessful|	Boolean| 성공 여부|
 
+<a id="list-templates"></a>
+
 ### 템플릿 리스트 조회
+
+<a id="request-13"></a>
 
 #### 요청
 
@@ -1749,6 +1859,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/senders/{senderKey}/templates?templateStatus={템플릿 상태 코드}"
 ```
+
+<a id="response-17"></a>
 
 #### 응답
 ```
@@ -1856,7 +1968,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |-- updateDate | String | 수정일자 |
 |- totalCount | Integer | 총개수 |
 
+<a id="list-template-modifications"></a>
+
 ### 템플릿 수정 리스트 조회
+
+<a id="request-14"></a>
 
 #### 요청
 
@@ -1889,6 +2005,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}/modifications"
 ```
+
+<a id="response-18"></a>
 
 #### 응답
 ```
@@ -1998,7 +2116,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |-- updateDate | String | 수정일자                                                                                             |
 |- totalCount | Integer | 총개수                                                                                              |
 
+<a id="alternative-delivery-management"></a>
+
 ## 대체 발송 관리
+<a id="sms-appkey-registration"></a>
+
 ### SMS AppKey 등록
 
 [URL]
@@ -2042,6 +2164,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
 ```
 
+<a id="response-19"></a>
+
 #### 응답
 ```
 
@@ -2053,6 +2177,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
   }
 }
 ```
+
+<a id="alternative-delivery-settings-registration"></a>
 
 ### 대체 발송 설정 등록
 
@@ -2100,6 +2226,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/failback/appkey -d '{"senderKey": "0be23c29de88d6888798aeda57062516354d74ba","isResend": true,"resendSendNo": "01012341234" }
 ```
+
+<a id="response-20"></a>
 
 #### 응답
 ```

--- a/ko/alimtalk-api-guide.md
+++ b/ko/alimtalk-api-guide.md
@@ -1,6 +1,10 @@
 ## Notification > KakaoTalk Bizmessage > 알림톡 > API v2.3 Guide
 
+<a id="alimtalk"></a>
+
 ## 알림톡
+
+<a id="api-domain"></a>
 
 #### [API Domain]
 
@@ -17,6 +21,8 @@
 </tbody>
 </table>
 
+<a id="overview-of-v23-api"></a>
+
 ## Overview of v2.3 API
 
 1. 알림톡 바로 연결, 아이템리스트, 톡 비즈 플러그인, 대표 링크, 비즈니스폼 버튼 기능이 추가되었습니다.
@@ -24,7 +30,11 @@
 3. 알림톡 플러그인 등록/수정/삭제/조회 API가 추가되었습니다.
 4. 메시지 리스트 조회 API에서 buttons 필드가 삭제되었습니다.
 
+<a id="general-messages"></a>
+
 ## 일반 메시지
+
+<a id="request-of-sending-replaced-messages"></a>
 
 ### 메시지 치환 발송 요청
 
@@ -154,6 +164,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages -d '{"senderKey":"{발신 키}","templateCode":"{템플릿 코드}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{수신번호}","templateParameter":{"{치환자 필드}":"{치환 데이터}"}}]}'
 ```
 
+<a id="response"></a>
+
 #### 응답
 
 ```
@@ -194,6 +206,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultCode           | Integer |    O     | 발송 요청 결과 코드  |
 | -- resultMessage        | String  |    O     | 발송 요청 결과 메시지 |
 | -- recipientGroupingKey | String  |    X     | 수신자 그룹핑 키    |
+
+<a id="request-of-sending-full-text"></a>
 
 ### 메시지 전문 발송 요청
 
@@ -393,6 +407,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/raw-messages -d '{"senderKey":"{발신 키}","templateCode":"{템플릿 코드}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{수신번호}","content":"{내용}","buttons":[{"ordering":"{버튼 순서}","type":"{버튼 타입}","name":"{버튼 이름}","linkMo":"{모바일 웹 링크}"}]}]}'
 ```
 
+<a id="response-2"></a>
+
 #### 응답
 
 ```
@@ -434,7 +450,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultMessage        | String  |    O     | 발송 요청 결과 메시지 |
 | -- recipientGroupingKey | String  |    X     | 수신자 그룹핑 키    |
 
+<a id="list-messages"></a>
+
 ### 메시지 리스트 조회
+
+<a id="request"></a>
 
 #### 요청
 
@@ -485,6 +505,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 90일 이전 발송 요청 데이터는 조회되지 않습니다.
 * 발송 요청 일시의 범위는 최대 30일입니다.
+
+<a id="response-3"></a>
 
 #### 응답
 
@@ -557,7 +579,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<a id="get-messages"></a>
+
 ### 메시지 단건 조회
+
+<a id="request-2"></a>
 
 #### 요청
 
@@ -593,6 +619,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-4"></a>
 
 #### 응답
 
@@ -774,6 +802,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - senderGroupingKey     | String  |    X     | 발신 그룹핑 키                                                                                                                                                               |
 | - recipientGroupingKey  | String  |    X     | 수신자 그룹핑 키                                                                                                                                                              |
 
+<a id="authentication-messages"></a>
+
 ## 인증 메시지
 
 <span id="precautions-authword"></span>
@@ -786,6 +816,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 
 - 예시 1-1) 인증 메시지 API 요청시 전문(템플릿 치환자 포함)에 인증 문구가 포함되어 있지 않은 경우 발송 실패됩니다.
 - 예시 1-2) 인증 문구가 영문인 경우 대소문자 구분 없이 유효성 검사가 진행됩니다.
+
+<a id="request-of-sending-replaced-messages-2"></a>
 
 ### 메시지 치환 발송 요청
 
@@ -818,6 +850,8 @@ Content-Type: application/json;charset=UTF-8
 [Request body]
 [위와 동일](./alimtalk-api-guide/#_3)
 
+<a id="request-of-sending-full-text-2"></a>
+
 ### 메시지 전문 발송 요청
 
 [URL]
@@ -849,7 +883,11 @@ Content-Type: application/json;charset=UTF-8
 [Request Body]
 [위와 동일](./alimtalk-api-guide/#_5)
 
+<a id="list-messages-2"></a>
+
 ### 메시지 리스트 조회
+
+<a id="request-3"></a>
 
 #### 요청
 
@@ -881,7 +919,11 @@ Content-Type: application/json;charset=UTF-8
 [Query parameter]
 [위와 동일](./alimtalk-api-guide/#_7)
 
+<a id="get-messages-2"></a>
+
 ### 메시지 단건 조회
+
+<a id="request-4"></a>
 
 #### 요청
 
@@ -918,13 +960,21 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/messages/{requestId}/{recipientSeq}"
 ```
 
+<a id="response-5"></a>
+
 #### 응답
 
 [위와 동일](./alimtalk-api-guide/#_9)
 
+<a id="message"></a>
+
 ## 메시지
 
+<a id="cancel-sending-messages"></a>
+
 ### 메시지 발송 취소
+
+<a id="request-5"></a>
 
 #### 요청
 
@@ -962,6 +1012,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 일반/인증 메시지 모두 동일한 API로 취소할 수 있습니다.
 
+<a id="response-6"></a>
+
 #### 응답
 
 ```
@@ -987,7 +1039,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
 ```
 
+<a id="query-updates-of-message-result"></a>
+
 ### 메시지 결과 업데이트 조회
+
+<a id="request-6"></a>
 
 #### 요청
 
@@ -1025,6 +1081,8 @@ Content-Type: application/json;charset=UTF-8
 | alimtalkMessageType | 	String  | X   | 	알림톡 메시지 타입(NORMAL, AUTH)           |
 | pageNum             | 	Integer | 	X  | 	페이지 번호(기본: 1)                      |
 | pageSize            | 	Integer | 	X  | 	조회 건수(Default: 15, Max: 1000)      |
+
+<a id="response-7"></a>
 
 #### 응답
 
@@ -1080,7 +1138,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/message-results?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
+<a id="query-the-number-of-message-result-updates"></a>
+
 ### 메시지 결과 업데이트 건수 조회
+
+<a id="request-7"></a>
 
 #### 요청
 
@@ -1117,6 +1179,8 @@ Content-Type: application/json;charset=UTF-8
 | endUpdateDate       | 	String  | O   | 	결과 업데이트 조회 종료 시간(yyyy-MM-dd HH:mm) |
 | alimtalkMessageType | 	String  | X   | 	알림톡 메시지 타입(NORMAL, AUTH)           |
 
+<a id="response-8"></a>
+
 #### 응답
 
 ```
@@ -1144,6 +1208,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/message-results/count?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
+<a id="status-code-of-smslms-resending"></a>
+
 ### SMS/LMS 대체 발송 상태 코드
 
 | 이름    | 	설명                                  |
@@ -1154,9 +1220,15 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | RSC04 | 	대체 발송 성공                            |
 | RSC05 | 	대체 발송 실패                            |
 
+<a id="mass-delivery"></a>
+
 ## 대량 발송
 
+<a id="list-mass-delivery-requests"></a>
+
 ### 대량 발송 요청 목록 조회
+
+<a id="request-8"></a>
 
 #### 요청
 
@@ -1199,6 +1271,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum          | optional, Integer | -     | X   | 페이지 번호    |
 | pageSize         | optional, Integer | 1000  | X   | 검색 수      |
 
+<a id="curl"></a>
+
 #### cURL
 
 ```
@@ -1207,6 +1281,8 @@ curl -X GET \
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-9"></a>
 
 #### 응답
 
@@ -1261,7 +1337,11 @@ curl -X GET \
 | -- createUser       | String  |    X     | 생성 사용자(콘솔에서 발송 시 사용자 UUID로 저장)                                                 |
 | - totalCount        | Integer |    X     | 총개수                                                                            |
 
+<a id="list-mass-delivery-recipients"></a>
+
 ### 대량 발송 수신자 목록 조회
+
+<a id="request-9"></a>
 
 #### 요청
 
@@ -1301,6 +1381,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum          | optional, Integer | -     | X   | 페이지 번호    |
 | pageSize         | optional, Integer | 1000  | X   | 검색 수      |
 
+<a id="curl-2"></a>
+
 #### cURL
 
 ```
@@ -1309,6 +1391,8 @@ curl -X GET \
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-10"></a>
 
 #### 응답
 
@@ -1355,7 +1439,11 @@ curl -X GET \
 | -- resultCodeName | String  |    X     | 결과 코드 내용   |
 | - totalCount      | Integer |    X     | 총개수        |
 
+<a id="get-a-mass-delivery-recipient"></a>
+
 ### 대량 발송 수신자 조회
+
+<a id="request-10"></a>
 
 #### 요청
 
@@ -1396,6 +1484,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum          | optional, Integer | -     | X   | 페이지 번호    |
 | pageSize         | optional, Integer | 1000  | X   | 검색 수      |
 
+<a id="curl-3"></a>
+
 #### cURL
 
 ```
@@ -1404,6 +1494,8 @@ curl -X GET \
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-11"></a>
 
 #### 응답
 
@@ -1572,9 +1664,15 @@ curl -X GET \
 | -- pluginId             | String  |    X     | 플러그인 ID(최대 24자)                                                                                                                                                        |
 | -- target               | String  |    X     | 웹 링크 타입일 경우, "target":"out" 속성 추가 시 아웃 링크\<br\>기본 인앱 링크로 발송                                                                                                            |
 
+<a id="templates"></a>
+
 ## 템플릿
 
+<a id="list-template-categories"></a>
+
 ### 템플릿 카테고리 조회
+
+<a id="request-11"></a>
 
 #### 요청
 
@@ -1602,6 +1700,8 @@ Content-Type: application/json;charset=UTF-8
 | 이름           | 	타입     | 	필수 | 	설명              |
 |--------------|---------|-----|------------------|
 | X-Secret-Key | 	String | O   | 콘솔에서 생성할 수 있습니다. |
+
+<a id="response-12"></a>
 
 #### 응답
 
@@ -1645,7 +1745,11 @@ Content-Type: application/json;charset=UTF-8
 | -- inclusion    | String  |    X     | 카테고리 적용 대상 템플릿 설명        |
 | -- exclusion    | String  |    X     | 카테고리 제외 대상 템플릿 설명        |
 
+<a id="register-templates"></a>
+
 ### 템플릿 등록
+
+<a id="request-12"></a>
 
 #### 요청
 
@@ -1798,6 +1902,8 @@ Content-Type: application/json;charset=UTF-8
 * 채널 추가형(AD) 또는 복합형(MI) 메시지 유형 템플릿 등록 시 채널 추가(AC) 버튼이 첫 번째 순서에 위치해야 합니다.
 * 채널 추가(AC) 버튼의 버튼명은 "채널 추가"로 고정하여 등록해야 합니다.
 
+<a id="response-13"></a>
+
 #### 응답
 
 ```
@@ -1817,7 +1923,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
 
+<a id="modify-templates"></a>
+
 ### 템플릿 수정
+
+<a id="request-13"></a>
 
 #### 요청
 
@@ -1969,6 +2079,8 @@ Content-Type: application/json;charset=UTF-8
 * 채널 추가형(AD)과 복합형(MI) 메시지 유형 템플릿 수정 시, 채널 추가(AC) 버튼이 첫 번째 순서에 위치해야 합니다.
 * 채널 추가(AC) 버튼의 버튼명은 "채널 추가"로 고정하여, 수정해야 합니다.
 
+<a id="response-14"></a>
+
 #### 응답
 
 ```
@@ -1988,7 +2100,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
 
+<a id="delete-templates"></a>
+
 ### 템플릿 삭제
+
+<a id="request-14"></a>
 
 #### 요청
 
@@ -2019,6 +2135,8 @@ Content-Type: application/json;charset=UTF-8
 * 승인된 템플릿의 경우, 카카오톡 비즈메시지의 제약 때문에 카카오 내부 데이터는 삭제할 수 없습니다.
 * 카카오에 남아 있는 템플릿은 1년 미사용 시 휴면 처리되고, 휴면 상태가 1년간 지속되면 삭제 처리됩니다.(카카오에서 템플릿이 휴면 전환되거나 삭제되면 담당자에게 알림이 발송됩니다.)
 
+<a id="response-15"></a>
+
 #### 응답
 
 ```
@@ -2038,7 +2156,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
 
+<a id="inquire-of-templates"></a>
+
 ### 템플릿 문의하기
+
+<a id="request-15"></a>
 
 #### 요청
 
@@ -2083,6 +2205,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 반려 상태의 템플릿에 문의를 남길 경우, 검수 중(REQ) 상태로 변경됩니다.
 
+<a id="response-16"></a>
+
 #### 응답
 
 ```
@@ -2102,7 +2226,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
 
+<a id="send-inquiry-on-templates-with-file-attachment"></a>
+
 ### 파일 첨부하여 템플릿 문의하기
+
+<a id="request-16"></a>
 
 #### 요청
 
@@ -2149,6 +2277,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 반려 상태의 템플릿에 문의를 남길 경우, 검수 중(REQ) 상태로 변경됩니다.
 
+<a id="response-17"></a>
+
 #### 응답
 
 ```
@@ -2168,7 +2298,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
 
+<a id="change-template-to-channel-add-type"></a>
+
 ### 템플릿 채널 추가형으로 변경
+
+<a id="request-17"></a>
 
 #### 요청
 
@@ -2201,6 +2335,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 그룹 발신 프로필에 등록된 템플릿은 채널 추가형으로 전환할 수 없습니다.
 
+<a id="response-18"></a>
+
 #### 응답
 
 ```
@@ -2220,7 +2356,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
 
+<a id="single-query-for-template"></a>
+
 ### 템플릿 단건 조회
+
+<a id="request-18"></a>
 
 #### 요청
 
@@ -2263,6 +2403,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}"
 ```
+
+<a id="response-19"></a>
 
 #### 응답
 
@@ -2443,7 +2585,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - updateDate            | String  |    X     | 수정일자                                                                                                                                                                             |
 
 
+<a id="list-templates"></a>
+
 ### 템플릿 리스트 조회
+
+<a id="request-19"></a>
 
 #### 요청
 
@@ -2495,6 +2641,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates?templateStatus={템플릿 상태 코드}"
 ```
+
+<a id="response-20"></a>
 
 #### 응답
 
@@ -2677,7 +2825,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- updateDate            | String  |    X     | 수정일자                                                                                                                                                                   |
 | - totalCount             | Integer |    X     | 총개수                                                                                                                                                                    |
 
+<a id="list-template-modifications"></a>
+
 ### 템플릿 수정 리스트 조회
+
+<a id="request-20"></a>
 
 #### 요청
 
@@ -2713,6 +2865,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}/modifications"
 ```
+
+<a id="response-21"></a>
 
 #### 응답
 
@@ -2891,7 +3045,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- updateDate                 | String  |    X     | 수정일자                                                                                                                                                                   |
 | - totalCount                  | Integer |    X     | 총개수                                                                                                                                                                    |
 
+<a id="register-template-image"></a>
+
 ### 템플릿 이미지 등록
+
+<a id="request-21"></a>
 
 #### 요청
 
@@ -2932,6 +3090,8 @@ Content-Type: multipart/form-data
 curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/template-image" -F "file=@alimtalk-template-image.jpeg"
 ```
 
+<a id="response-22"></a>
+
 #### 응답
 
 ```
@@ -2958,7 +3118,11 @@ curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}
 | - templateImageName | String  |    X     | 이미지명(업로드한 파일명) |
 | - templateImageUrl  | String  |    X     | 이미지 URL        |
 
+<a id="register-template-item-highlight-images"></a>
+
 ### 템플릿 아이템 하이라이트 이미지 등록
+
+<a id="request-22"></a>
 
 #### 요청
 
@@ -2999,6 +3163,8 @@ Content-Type: multipart/form-data
 curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/template-image/item-highlight" -F "file=@alimtalk-template-image.jpeg"
 ```
 
+<a id="response-23"></a>
+
 #### 응답
 
 ```
@@ -3025,7 +3191,11 @@ curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}
 | - templateImageName | String  |    X     | 이미지명(업로드한 파일명) |
 | - templateImageUrl  | String  |    X     | 이미지 URL        |
 
+<a id="register-template-plugin"></a>
+
 ### 템플릿 플러그인 등록
+
+<a id="request-23"></a>
 
 #### 요청
 
@@ -3071,6 +3241,8 @@ Content-Type: application/json;charset=UTF-8
 | pluginId    | 	String | 	O  | 플러그인 아이디                                                   |
 | callbackUrl | 	String | 	O  | 플러그인 버튼 클릭 시, 수신받을 콜백 URL                                  |
 
+<a id="response-24"></a>
+
 #### 응답
 
 ```
@@ -3090,7 +3262,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
 
+<a id="modify-template-plugin"></a>
+
 ### 템플릿 플러그인 수정
+
+<a id="request-24"></a>
 
 #### 요청
 
@@ -3135,6 +3311,8 @@ Content-Type: application/json;charset=UTF-8
 | pluginType  | 	String | 	O  | 플러그인 타입(SECURE_IMAGE: 보안 이미지 전송, ONE_TIME_PROFILE: 개인정보 이용) |
 | callbackUrl | 	String | 	O  | 플러그인 버튼 클릭 시, 수신받을 콜백 URL                                  |
 
+<a id="response-25"></a>
+
 #### 응답
 
 ```
@@ -3154,7 +3332,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
 
+<a id="modify-template-plugin-2"></a>
+
 ### 템플릿 플러그인 삭제
+
+<a id="request-25"></a>
 
 #### 요청
 
@@ -3185,6 +3367,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|---------|-----|------------------|
 | X-Secret-Key | 	String | O   | 콘솔에서 생성할 수 있습니다. |
 
+<a id="response-26"></a>
+
 #### 응답
 
 ```
@@ -3204,7 +3388,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
 
+<a id="retrieve-template-plugin"></a>
+
 ### 템플릿 플러그인 조회
+
+<a id="request-26"></a>
 
 #### 요청
 
@@ -3233,6 +3421,8 @@ Content-Type: application/json;charset=UTF-8
 | 이름           | 	타입     | 	필수 | 	설명              |
 |--------------|---------|-----|------------------|
 | X-Secret-Key | 	String | O   | 콘솔에서 생성할 수 있습니다. |
+
+<a id="response-27"></a>
 
 #### 응답
 
@@ -3271,7 +3461,11 @@ Content-Type: application/json;charset=UTF-8
 | - modifiable     | Boolean |    X     | 수정 가능 여부                                                   |
 | - deletable      | Boolean |    X     | 삭제 가능 여부                                                   |
 
+<a id="manage-alternative-delivery"></a>
+
 ## 대체 발송 관리
+
+<a id="register-an-sms-appkey"></a>
 
 ### SMS AppKey 등록
 
@@ -3318,6 +3512,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
 ```
 
+<a id="response-28"></a>
+
 #### 응답
 
 ```
@@ -3337,6 +3533,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | - resultCode    | Integer |    O     | 결과 코드  |
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
+
+<a id="register-alternative-delivery-settings"></a>
 
 ### 대체 발송 설정 등록
 
@@ -3386,6 +3584,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/failback/appkey -d '{"senderKey": "0be23c29de88d6888798aeda57062516354d74ba","isResend": true,"resendSendNo": "01012341234" }
 ```
+
+<a id="response-29"></a>
 
 #### 응답
 

--- a/ko/friendtalkupgrade-api-guide.md
+++ b/ko/friendtalkupgrade-api-guide.md
@@ -1,6 +1,10 @@
 ## Notification > KakaoTalk Bizmessage > 브랜드 메시지 > API v1.0 Guide
 
+<a id="brand-message"></a>
+
 ## 브랜드 메시지
+
+<a id="api-domain"></a>
 
 #### [API 도메인]
 
@@ -8,7 +12,11 @@
 |------------------------------------------------------------------------------|
 | [https://kakaotalk-bizmessage.api.nhncloudservice.com](https://kakaotalk-bizmessage.api.nhncloudservice.com) |
 
+<a id="introduce-v10-api"></a>
+
 ## v1.0 API 소개
+
+<a id="manage-non-friend-message-sending-targeting-m-n"></a>
 
 ## 비친구 메시지 발송(타겟팅 M, N) 관리
 
@@ -20,7 +28,11 @@
 - 채널 친구 수 5만 이상
 - 3개월 내 알림톡 발송 성공 이력 보유
 
+<a id="upload-marketing-consent-evidence"></a>
+
 ### 마케팅 수신 동의 증적 자료 업로드
+
+<a id="requested"></a>
 
 #### 요청
 
@@ -56,6 +68,8 @@ Content-Type: multipart/form-data
 |------|------|----|---------------|
 | file | File | O  | 마케팅 수신 동의 증적 자료 |
 
+<a id="response"></a>
+
 #### 응답
 
 ```
@@ -75,7 +89,11 @@ Content-Type: multipart/form-data
 | - resultMessage | String  | O        | 결과 메시지 |
 | - isSuccessful  | boolean | O        | 성공 여부  |
 
+<a id="apply-for-using-non-friend-message-sending-targeting-m-n"></a>
+
 ### 비친구 메시지 발송(타겟팅 M, N) 사용 신청
+
+<a id="requested-2"></a>
 
 #### 요청
 
@@ -105,6 +123,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | 콘솔에서 생성할 수 있습니다. |
 
+<a id="response-2"></a>
+
 #### 응답
 
 ```
@@ -123,6 +143,8 @@ Content-Type: application/json;charset=UTF-8
 | - resultCode    | Integer | O        | 결과 코드  |
 | - resultMessage | String  | O        | 결과 메시지 |
 | - isSuccessful  | boolean | O        | 성공 여부  |
+
+<a id="request-to-send-a-free-form-message"></a>
 
 ## 메시지 자유형 발송 요청
 
@@ -145,6 +167,8 @@ Content-Type: application/json;charset=UTF-8
 * 대체 발송은 수신자별 resendParameter를 통해 설정할 수 있습니다.
     * 대체 발송을 이용할 경우 대체 발송 관리 API를 통해 SMS Appkey 등록 및 발송 설정이 필요합니다.
 * **야간 발송 제한(20:50~다음 날 08:00)**
+
+<a id="requested-3"></a>
 
 #### 요청
 
@@ -172,6 +196,8 @@ Content-Type: application/json;charset=UTF-8
 | 이름           | 타입     | 필수 | 설명               |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | 콘솔에서 생성할 수 있습니다. |
+
+<a id="request-text-type-sending"></a>
 
 #### 텍스트형 발송 요청
 
@@ -276,6 +302,8 @@ Content-Type: application/json;charset=UTF-8
 | resellerCode          | String  | X  | 리셀러 코드(리셀러가 발송 시 사용)                                                                                                                                                                                                                                                       |
 | createUser             | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                                                                   |
 | statsId                | String  | 	X | 통계 ID(발신 검색 조건에는 포함되지 않습니다. 최대 8자)                                                                                                                                                                                                                                            |
+
+<a id="request-image-type-sending"></a>
 
 #### 이미지형 발송 요청
 
@@ -388,6 +416,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser             | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                                                                   |
 | statsId                | String  | 	X | 통계 ID(발신 검색 조건에는 포함되지 않습니다. 최대 8자)                                                                                                                                                                                                                                            |
 
+<a id="request-wide-image-type-sending"></a>
+
 #### 와이드 이미지형 발송 요청
 
 [Request body]
@@ -498,6 +528,8 @@ Content-Type: application/json;charset=UTF-8
 | resellerCode          | String  | X  | 리셀러 코드(리셀러가 발송 시 사용)                                                                                                                                                                                                                                                       |
 | createUser             | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                                                                   |
 | statsId                | String  | 	X | 통계 ID(발신 검색 조건에는 포함되지 않습니다. 최대 8자)                                                                                                                                                                                                                                            |
+
+<a id="request-to-send-wide-item-list-type"></a>
 
 #### 와이드 아이템리스트형 발송 요청
 
@@ -639,6 +671,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser             | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                                                                   |
 | statsId                | String  | 	X | 통계 ID(발신 검색 조건에는 포함되지 않습니다. 최대 8자)                                                                                                                                                                                                                                            |
 
+<a id="request-to-send-premium-video-type"></a>
+
 #### 프리미엄 동영상형 발송 요청
 
 [Request body]
@@ -751,6 +785,8 @@ Content-Type: application/json;charset=UTF-8
 | resellerCode          | String  | X  | 리셀러 코드(리셀러가 발송 시 사용)                                                                                                                                                                                                                                                       |
 | createUser             | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                                                                   |
 | statsId                | String  | 	X | 통계 ID(발신 검색 조건에는 포함되지 않습니다. 최대 8자)                                                                                                                                                                                                                                            |
+
+<a id="request-to-send-commerce"></a>
 
 #### 커머스형 발송 요청
 
@@ -875,6 +911,8 @@ Content-Type: application/json;charset=UTF-8
 | resellerCode          | String  | X  | 리셀러 코드(리셀러가 발송 시 사용)                                                                                                                                                                                                                                                       |
 | createUser             | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                                                                   |
 | statsId                | String  | 	X | 통계 ID(발신 검색 조건에는 포함되지 않습니다. 최대 8자)                                                                                                                                                                                                                                            |
+
+<a id="request-to-send-carousel-feed-type"></a>
 
 #### 캐러셀 피드형 발송 요청
 
@@ -1053,6 +1091,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser             | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                                                                   |
 | statsId                | String  | 	X | 통계 ID(발신 검색 조건에는 포함되지 않습니다. 최대 8자)                                                                                                                                                                                                                                            |
 
+<a id="request-to-send-carousel-commerce-type"></a>
+
 #### 캐러셀 커머스형 발송 요청
 
 [Request body]
@@ -1209,6 +1249,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser           | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                                                                   |
 | statsId              | String  | 	X | 통계 ID(발신 검색 조건에는 포함되지 않습니다. 최대 8자)                                                                                                                                                                                                                                            |
 
+<a id="response-3"></a>
+
 #### 응답
 
 ```
@@ -1246,6 +1288,8 @@ Content-Type: application/json;charset=UTF-8
 | -- resultCode    | Integer | O        | 수신자별 발송 결과 코드(성공 및 다양한 실패 코드가 존재할 수 있음)                     |
 | -- resultMessage | String  | O        | 수신자별 발송 결과 메시지(성공 시 "success" 또는 관련 메시지, 실패 시 실패 원인 상세 메시지) |
 
+<a id="request-to-send-basic-message"></a>
+
 ## 메시지 기본형 발송 요청
 
 * 템플릿을 이용한 발송입니다.
@@ -1261,6 +1305,8 @@ Content-Type: application/json;charset=UTF-8
 * 대체 발송은 수신자별 resendParameter를 통해 설정할 수 있습니다.
     * 대체 발송을 이용할 경우 대체 발송 관리 API를 통해 SMS Appkey 등록 및 발송 설정이 필요합니다.
 * **야간 발송 제한(20:50~다음 날 08:00)**
+
+<a id="cautions-for-use"></a>
 
 ### 사용 시 주의사항
 
@@ -1293,6 +1339,8 @@ Content-Type: application/json;charset=UTF-8
 | 이름           | 타입     | 필수 | 설명               |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | 콘솔에서 생성할 수 있습니다. |
+
+<a id="requested-4"></a>
 
 #### 발송 요청
 
@@ -1363,6 +1411,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser             | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                             |
 | statsId                | String  | X  | 통계 ID(발신 검색 조건에는 포함되지 않습니다. 최대 8자)                                                                                                                                                                                                      |
 
+<a id="response-4"></a>
+
 #### 응답
 
 ```
@@ -1400,7 +1450,11 @@ Content-Type: application/json;charset=UTF-8
 | -- resultCode    | Integer | O        | 수신자별 발송 결과 코드(성공 및 다양한 실패 코드가 존재할 수 있음)                     |
 | -- resultMessage | String  | O        | 수신자별 발송 결과 메시지(성공 시 "success" 또는 관련 메시지, 실패 시 실패 원인 상세 메시지) |
 
+<a id="view-sending-list"></a>
+
 ## 발송 목록 조회
+
+<a id="requested-5"></a>
 
 #### 요청
 
@@ -1445,6 +1499,8 @@ Content-Type: application/json;charset=UTF-8
 | recipientGroupingKey | 	String  | 	X         | 수신자 그룹핑 키                        |
 | pageNum          | String | X         | 페이지 번호(Default: 1)               |
 | pageSize         | String | X         | 조회 건수(Default: 15, Max: 1000)    |
+
+<a id="response-5"></a>
 
 #### 응답
 
@@ -1521,7 +1577,11 @@ Content-Type: application/json;charset=UTF-8
 | -- recipientGroupingKey     | String  | X        | 수신자 그룹핑 키                                           |
 | - totalCount                | Integer | O        | 총 개수                                                                  |
 
+<a id="view-single-sending"></a>
+
 ## 발송 단건 조회
+
+<a id="requested-6"></a>
 
 #### 요청
 
@@ -1551,6 +1611,8 @@ Content-Type: application/json;charset=UTF-8
 | 이름           | 타입     | 필수 | 설명               |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | 콘솔에서 생성할 수 있습니다. |
+
+<a id="response-6"></a>
 
 #### 응답
 
@@ -1812,7 +1874,11 @@ Content-Type: application/json;charset=UTF-8
 | - senderGroupingKey   | String  | X        | 발신 그룹핑 키                                                 |
 | - recipientGroupingKey | String  | X        | 수신자 그룹핑 키                                           |
 
+<a id="cancel-message-sending"></a>
+
 ## 메시지 발송 취소
+
+<a id="requested-7"></a>
 
 #### 요청
 
@@ -1848,6 +1914,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|---------|-----|---------------------------------------------|
 | recipientSeq | 	String | 	X  | 수신자 시퀀스 번호<br>(입력하지 않으면 요청 ID의 모든 발송 건을 취소) |
 
+<a id="response-7"></a>
+
 #### 응답
 
 ```
@@ -1872,9 +1940,15 @@ Content-Type: application/json;charset=UTF-8
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
 ```
 
+<a id="manage-templates"></a>
+
 ## 템플릿 관리
 
+<a id="view-template-list"></a>
+
 ### 템플릿 리스트 조회
+
+<a id="requested-8"></a>
 
 #### 요청
 
@@ -1913,6 +1987,8 @@ Content-Type: application/json;charset=UTF-8
 | status       | String  | X  | 템플릿 상태 코드                     |
 | pageNum      | Integer | X  | 페이지 번호(Default: 1)            |
 | pageSize     | Integer | X  | 조회 건수(Default: 15, Max: 1000) |
+
+<a id="response-8"></a>
 
 #### 응답
 
@@ -2141,6 +2217,8 @@ Content-Type: application/json;charset=UTF-8
 | --- updateDate          | String  | X        | 수정 일시                                  |
 | - totalCount            | Integer | O        | 총 개수                                   |
 
+<a id="view-single-template"></a>
+
 ### 템플릿 단건 조회
 
 [URL]
@@ -2170,6 +2248,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | 콘솔에서 생성할 수 있습니다. |
 |X-NC-API-IDEMPOTENCY-KEY|	String| X | 중복 메시지 발송 요청 기준 key<br>10분간 동일한 key로 요청 시 해당 요청을 실패 처리합니다. |
+
+<a id="response-9"></a>
 
 #### 응답
 
@@ -2392,7 +2472,11 @@ Content-Type: application/json;charset=UTF-8
 | - createDate          | String  | O        | 등록 일시                |
 | - updateDate          | String  | X        | 수정 일시                |
 
+<a id="register-template"></a>
+
 ### 템플릿 등록
+
+<a id="requested-9"></a>
 
 #### 요청
 
@@ -2422,6 +2506,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | 콘솔에서 생성할 수 있습니다. |
 
+<a id="note"></a>
+
 #### 유의 사항
 
 * 쿠폰 제목에 치환자를 적용할 경우 다음과 같은 고정 치환자를 사용해야 합니다.
@@ -2440,6 +2526,8 @@ Content-Type: application/json;charset=UTF-8
     * discountPrice -> #{할인가격}
     * discountRate -> #{할인율}
     * discountFixed -> #{정액할인가격}
+
+<a id="request-to-register-text-type-template"></a>
 
 #### 텍스트형 템플릿 등록 요청
 
@@ -2494,6 +2582,8 @@ Content-Type: application/json;charset=UTF-8
 | - linkPc        | String  | X  | PC 웹 링크(WL 타입일 경우 선택 필드), 500자 제한                                                                                                                                                                                                            |
 | - schemeAndroid | String  | X  | 안드로이드 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                                   |
 | - schemeIos     | String  | X  | iOS 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                                     |
+
+<a id="request-to-register-image-type-template"></a>
 
 #### 이미지형 템플릿 등록 요청
 
@@ -2556,6 +2646,8 @@ Content-Type: application/json;charset=UTF-8
 | - schemeAndroid | String  | X  | 안드로이드 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                                       |
 | - schemeIos     | String  | X  | iOS 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                                         |
 
+<a id="request-to-register-wide-image-type-template"></a>
+
 #### 와이드 이미지형 템플릿 등록 요청
 
 [Request body]
@@ -2616,6 +2708,8 @@ Content-Type: application/json;charset=UTF-8
 | - linkPc        | String  | X  | PC 웹 링크(WL 타입일 경우 선택 필드), 500자 제한                                                                                                                                                                                                                |
 | - schemeAndroid | String  | X  | 안드로이드 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                                       |
 | - schemeIos     | String  | X  | iOS 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                                         |
+
+<a id="request-to-register-wide-item-list-type-template"></a>
 
 #### 와이드 아이템리스트형 템플릿 등록 요청
 
@@ -2707,6 +2801,8 @@ Content-Type: application/json;charset=UTF-8
 | - schemeAndroid  | String  | X  | 안드로이드 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                     |
 | - schemeIos      | String  | X  | iOS 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                       |
 
+<a id="request-to-register-premium-video-type-template"></a>
+
 #### 프리미엄 동영상형 템플릿 등록 요청
 
 [Request body]
@@ -2769,6 +2865,8 @@ Content-Type: application/json;charset=UTF-8
 | - linkPc        | String  | X  | PC 웹 링크(WL 타입일 경우 선택 필드), 500자 제한                                                                                                                                                                                                                |
 | - schemeAndroid | String  | X  | 안드로이드 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                                       |
 | - schemeIos     | String  | X  | iOS 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                                         |
+
+<a id="request-to-register-commerce-type-template"></a>
 
 #### 커머스형 템플릿 등록 요청
 
@@ -2844,6 +2942,8 @@ Content-Type: application/json;charset=UTF-8
 | - linkPc          | String  | X  | PC 웹 링크(WL 타입일 경우 선택 필드), 500자 제한                                                                                                                                                                                              |
 | - schemeAndroid   | String  | X  | 안드로이드 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                     |
 | - schemeIos       | String  | X  | iOS 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                       |
+
+<a id="request-to-register-carousel-feed-type-template"></a>
 
 #### 캐러셀 피드형 템플릿 등록 요청
 
@@ -2955,6 +3055,8 @@ Content-Type: application/json;charset=UTF-8
 | - recipientNo     | String  | O  | 수신 번호                                                                                                                                                                                                                             |
 | createUser        | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                       |
 
+<a id="request-to-register-carousel-commerce-type-template"></a>
+
 #### 캐러셀 커머스형 템플릿 등록 요청
 
 [Request body]
@@ -3063,6 +3165,8 @@ Content-Type: application/json;charset=UTF-8
 | -- schemeAndroid     | String  | X  | 안드로이드 앱 링크, 500자 제한<br>치환자 사용 불가능                                                                                                                                                                                               |
 | -- schemeIos         | String  | X  | iOS 앱 링크, 500자 제한<br>치환자 사용 불가능                                                                                                                                                                                                 |
 
+<a id="response-10"></a>
+
 #### 응답
 
 ```
@@ -3087,7 +3191,11 @@ Content-Type: application/json;charset=UTF-8
 | template        | Object  | X        | 템플릿 정보 |
 | - templateCode  | String  | O        | 템플릿 코드 |
 
+<a id="modify-template"></a>
+
 ### 템플릿 수정
+
+<a id="requested-10"></a>
 
 #### 요청
 
@@ -3122,6 +3230,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 템플릿 등록과 스펙이 같음
 
+<a id="response-11"></a>
+
 #### 응답
 
 ```
@@ -3141,7 +3251,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 결과 메시지 |
 | - isSuccessful  | boolean | O        | 성공 여부  |
 
+<a id="delete-template"></a>
+
 ### 템플릿 삭제
+
+<a id="requested-11"></a>
 
 #### 요청
 
@@ -3172,6 +3286,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | 콘솔에서 생성할 수 있습니다. |
 
+<a id="response-12"></a>
+
 #### 응답
 
 ```
@@ -3191,9 +3307,15 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 결과 메시지 |
 | - isSuccessful  | boolean | O        | 성공 여부  |
 
+<a id="manage-image"></a>
+
 ## 이미지 관리
 
+<a id="upload-image"></a>
+
 ### 이미지 업로드
+
+<a id="requested-12"></a>
 
 #### 요청
 
@@ -3229,6 +3351,8 @@ Content-Type: multipart/form-data
 | image     | File   | O  | 이미지                                                                                                                            |
 | imageType | String | O  | 이미지 타입 <br>(IMAGE, WIDE_IMAGE,MAIN_WIDE_ITEMLIST_IMAGE,NORMAL_WIDE_ITEMLIST_IMAGE,CAROUSEL_FEED_IMAGE,CAROUSEL_COMMERCE_IMAGE) |
 
+<a id="response-13"></a>
+
 #### 응답
 
 ```
@@ -3257,6 +3381,8 @@ Content-Type: multipart/form-data
 | - imageUrl      | String  | O        | 이미지 URL |
 | - imageName     | String  | X        | 이미지명    |
 
+<a id="upload-image-specifications"></a>
+
 #### 업로드 이미지 규격
 | 이미지 타입                     | 사용처                                                     | 업로드 이미지 규격                                                                                                                              |
 |:---------------------------|:--------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------|
@@ -3269,7 +3395,11 @@ Content-Type: multipart/form-data
 
 * 템플릿 수정 시 이미지를 다른 이미지로 변경하면 기존 이미지가 카카오 CDN에서 삭제되어 URL이 유효하지 않게 됩니다. 동일한 이미지를 사용하는 다른 템플릿도 영향을 받으므로 주의가 필요합니다. 이미지 조회 API에서는 이미지 정보가 유지되지만, 실제 이미지에는 접근할 수 없으므로 원본 파일은 자체 서버에 별도로 보관하는 것을 권장합니다.
 
+<a id="view-image"></a>
+
 ### 이미지 조회
+
+<a id="requested-13"></a>
 
 #### 요청
 
@@ -3306,6 +3436,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum    | String | X  | 페이지 번호(기본: 1)                                                                                                                  |
 | pageSize   | String | X  | 조회 건수(기본: 15)                                                                                                                  |
 
+<a id="response-14"></a>
+
 #### 응답
 
 ```
@@ -3334,7 +3466,11 @@ Content-Type: application/json;charset=UTF-8
 | - imageUrl      | String  | O        | 이미지 URL |
 | - imageName     | String  | X        | 이미지명    |
 
+<a id="delete-image"></a>
+
 ### 이미지 삭제
+
+<a id="requested-14"></a>
 
 #### 요청
 
@@ -3369,6 +3505,8 @@ Content-Type: application/json;charset=UTF-8
 |----------|--------|----|--------|
 | imageSeq | String | O  | 이미지 번호 |
 
+<a id="response-15"></a>
+
 #### 응답
 
 ```
@@ -3388,9 +3526,15 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 결과 메시지 |
 | - isSuccessful  | boolean | O        | 성공 여부  |
 
+<a id="upload"></a>
+
 ## 업로드
 
+<a id="upload-bizform-key"></a>
+
 ### 비즈폼 키 업로드
+
+<a id="requested-15"></a>
 
 #### 요청
 
@@ -3420,6 +3564,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | 콘솔에서 생성할 수 있습니다. |
 
+<a id="response-16"></a>
+
 #### 응답
 
 ```
@@ -3439,9 +3585,15 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 결과 메시지 |
 | - isSuccessful  | boolean | O        | 성공 여부  |
 
+<a id="manage-outgoing-profiles"></a>
+
 ## 발신 프로필 관리
 
+<a id="view-outgoing-profile"></a>
+
 ### 발신 프로필 조회
+
+<a id="requested-16"></a>
 
 #### 요청
 
@@ -3470,6 +3622,8 @@ Content-Type: application/json;charset=UTF-8
 | 이름           | 타입     | 필수 | 설명               |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | 콘솔에서 생성할 수 있습니다. |
+
+<a id="response-17"></a>
 
 #### 응답
 
@@ -3540,7 +3694,11 @@ Content-Type: application/json;charset=UTF-8
 | - createDate              | String  | X        | 등록 일자                                                                                                                 |
 | - initialUserRestriction  | boolean | O        | 최초 사용자 제한 여부                                                                                                          |
 
+<a id="modify-outgoing-profile-080-opt-out-number"></a>
+
 ### 발신 프로필 080 수신거부번호 수정
+
+<a id="requested-17"></a>
 
 #### 요청
 
@@ -3584,6 +3742,8 @@ Content-Type: application/json;charset=UTF-8
 | unsubscribeNo     | 	String | 	O  | 080 무료수신거부 전화번호(모두 미입력 시 발신 프로필에 등록된 무료수신거부 정보로 발송됨)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx  |
 | unsubscribeAuthNo | 	String | 	X  | 080 무료수신거부 인증번호(모두 미입력 시 발신 프로필에 등록된 무료수신거부 정보로 발송됨)<br>unsubscribeNo 없이 unsubscribeAuthNo만 입력 불가<br>예: 1234 |
 
+<a id="response-18"></a>
+
 #### 응답
 
 ```
@@ -3603,7 +3763,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 결과 메시지 |
 | - isSuccessful  | boolean | O        | 성공 여부  |
 
+<a id="manage-fallback"></a>
+
 ## 대체 발송 관리
+
+<a id="register-sms-appkey"></a>
 
 ### SMS AppKey 등록
 
@@ -3650,6 +3814,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
 ```
 
+<a id="response-19"></a>
+
 #### 응답
 
 ```
@@ -3662,6 +3828,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
   }
 }
 ```
+
+<a id="register-fallback-settings"></a>
 
 ### 대체 발송 설정 등록
 
@@ -3713,6 +3881,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/failback/appkey -d '{"senderKey": "0be23c29de88d6888798aeda57062516354d74ba","isResend": true,"resendSendNo": "01012341234" }
 ```
+
+<a id="response-20"></a>
 
 #### 응답
 


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Body text is never modified.** The model only sees heading outlines; edits apply to heading lines (and `<!-- TODO: translate body -->` stubs for missing sections) only.

## Analysis

| | |
| --- | --- |
| Engine | `api (Anthropic SDK)` |
| Model | `claude-sonnet-4-20250514` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `pre-align/fix-headings-20260615-080708` |
| Scope | 32 doc(s) scanned · 9 file(s) changed · 29 unchanged |
| Self-verify | ⚠️ 10 mismatch(es) remain |
| Jenkins build | http://testlab.cloud.toastoven.net:8080/job/user-guide-agent/job/align-heading/job/260521/76/ |
| Generated | 2026-06-15T10:26:12 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`pre-align/fix-headings-20260615-080708`): [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FAlimtalk%2Ftree%2Fpre-align%2Ffix-headings-20260615-080708&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FAlimtalk%2Fpull%2F223&source=ko&langs=en%2Cja)

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra demoted | extra removed | verify |
| --- | --: | --: | --: | --: | --: | --: | --: | :--: |
| `ko/alimtalk-api-guide-v2.0.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/alimtalk-api-guide-v2.0.md` | 0 | 6 | 0 | 0 | 0 | 2 | 0 | ✅ |
| `ja/alimtalk-api-guide-v2.0.md` | 0 | 1 | 0 | 0 | 0 | 2 | 0 | ✅ |
| `ko/alimtalk-api-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/alimtalk-api-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/alimtalk-api-guide.md` | 1 | 15 | 0 | 0 | 0 | 4 | 0 | ⚠️ 8 |
| `ko/friendtalkupgrade-api-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/friendtalkupgrade-api-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/friendtalkupgrade-api-guide.md` | 0 | 3 | 0 | 0 | 0 | 1 | 0 | ⚠️ 2 |

<details><summary>남은 불일치 (검토 필요)</summary>

- `ja/alimtalk-api-guide.md`:
  - extra_in_target (ko#None/ja#14)
  - extra_in_target (ko#None/ja#21)
  - extra_in_target (ko#None/ja#22)
  - extra_in_target (ko#None/ja#23)
  - missing_in_target (ko#31/ja#None)
  - missing_in_target (ko#32/ja#None)
  - missing_in_target (ko#33/ja#None)
  - missing_in_target (ko#34/ja#None)
- `ja/friendtalkupgrade-api-guide.md`:
  - extra_in_target (ko#None/ja#21)
  - missing_in_target (ko#22/ja#None)

</details>

<details><summary>변경 없이 건너뛴 문서 (29) — 이미 `ko`와 정렬됨 / 대상 파일 없음 (PR에서 제외)</summary>

- `Overview.md`
- `alimtalk-api-guide-v1.4.md`
- `alimtalk-api-guide-v1.5.md`
- `alimtalk-api-guide-v2.1.md`
- `alimtalk-api-guide-v2.2.md`
- `alimtalk-console-guide.md`
- `alimtalk-overview.md`
- `common-api-guide.md`
- `common-console-guide.md`
- `error-code.md`
- `friendtalk-api-guide-v1.4.md`
- `friendtalk-api-guide-v1.5.md`
- `friendtalk-api-guide-v2.0.md`
- `friendtalk-api-guide-v2.2.md`
- `friendtalk-api-guide-v2.3.md`
- `friendtalk-api-guide.md`
- `friendtalk-compatible-api-guide.md`
- `friendtalk-console-guide.md`
- `friendtalk-overview.md`
- `friendtalkupgrade-console-guide.md`
- `friendtalkupgrade-overview.md`
- `release-notes.md`
- `sender-api-guide-v2.0.md`
- `sender-api-guide-v2.1.md`
- `sender-api-guide-v2.3.md`
- `sender-console-guide.md`
- `sender-overview.md`
- `troubleshooting-guide.md`
- `webhook-api-guide.md`

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/Alimtalk`