### PR TITLE
chore(pre-align): align-v2 heading structure (friendtalkupgrade-api-guide.md) with ko

### DIFF
--- a/en/friendtalkupgrade-api-guide.md
+++ b/en/friendtalkupgrade-api-guide.md
@@ -1,6 +1,10 @@
 ## Notification > KakaoTalk Bizmessage > Brand Message > API v1.0 Guide
 
+<a id="brand-message"></a>
+
 ## Brand Message
+
+<a id="api-domain"></a>
 
 #### \[API Domain]
 
@@ -8,7 +12,11 @@
 |----------|
 | [https://kakaotalk-bizmessage.api.nhncloudservice.com](https://kakaotalk-bizmessage.api.nhncloudservice.com)|
 
+<a id="introduce-v10-api"></a>
+
 ## Introduce v1.0 API
+
+<a id="manage-non-friend-message-sending-targeting-m-n"></a>
 
 ## Manage non-friend message sending (targeting M, N)
 
@@ -20,7 +28,11 @@ Non-friend message sending (targeting M, N) can be sent if all the conditions be
 - 50,000 or more channel friends
 - Successfully send notification messages within the past three months
 
+<a id="upload-marketing-consent-evidence"></a>
+
 ### Upload marketing consent evidence
+
+<a id="requested"></a>
 
 #### Requested
 
@@ -56,6 +68,8 @@ Content-Type: multipart/form-data
 |----------|----------|----------|----------|
 | file| File| O| Marketing consent evidence|
 
+<a id="response"></a>
+
 #### Response
 
 ```
@@ -75,7 +89,11 @@ Content-Type: multipart/form-data
 | \- resultMessage| String| O| Result message|
 | \- isSuccessful| boolean| O| Success status|
 
+<a id="apply-for-using-non-friend-message-sending-targeting-m-n"></a>
+
 ### Apply for using non-friend message sending (targeting M, N)
+
+<a id="requested-2"></a>
 
 #### Requested
 
@@ -105,6 +123,8 @@ Content-Type: application/json;charset=UTF-8
 |----------|----------|----------|----------|
 | X-Secret-Key| String| O| Available to create from the console.|
 
+<a id="response-2"></a>
+
 #### Response
 
 ```
@@ -123,6 +143,8 @@ Content-Type: application/json;charset=UTF-8
 | \- resultCode| Integer| O| Result code|
 | \- resultMessage| String| O| Result message|
 | \- isSuccessful| boolean| O| Success status|
+
+<a id="request-to-send-a-free-form-message"></a>
 
 ## Request to send a free-form message
 
@@ -145,6 +167,8 @@ Content-Type: application/json;charset=UTF-8
 * Fallback can be set via resendParameter for each recipient.
   * When using fallback, you need to register the SMS Appkey and set its sending through the fallback management API.
   * **Nighttime delivery restrictions(8:50 PM - 8:00 AM the next day)**
+
+<a id="requested-3"></a>
 
 #### Requested
 
@@ -172,6 +196,8 @@ Content-Type: application/json;charset=UTF-8
 | Name| Type| Required| Description|
 |----------|----------|----------|----------|
 | X-Secret-Key| String| O| Available to create from the console.|
+
+<a id="request-text-type-sending"></a>
 
 #### Request text-type sending
 
@@ -276,6 +302,8 @@ Content-Type: application/json;charset=UTF-8
 | resellerCode| String| X| Reseller code (used by resellers when sending)|
 | createUser| String| X| Registrant (stored as user UUID when sent from console)|
 | statsId| String| X| Statistics ID (not included in the outgoing search conditions. Up 8 characters)|
+
+<a id="request-image-type-sending"></a>
 
 #### Request image-type sending
 
@@ -388,6 +416,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser| String| X| Registrant (stored as user UUID when sent from console)|
 | statsId| String| X| Statistics ID (not included in the outgoing search conditions. Up 8 characters)|
 
+<a id="request-wide-image-type-sending"></a>
+
 #### Request wide image-type sending
 
 \[Request body]
@@ -498,6 +528,8 @@ Content-Type: application/json;charset=UTF-8
 | resellerCode| String| X| Reseller code (used by resellers when sending)|
 | createUser| String| X| Registrant (stored as user UUID when sent from console)|
 | statsId| String| X| Statistics ID (not included in the outgoing search conditions. Up 8 characters)|
+
+<a id="request-to-send-wide-item-list-type"></a>
 
 #### Request to send wide item list type
 
@@ -639,6 +671,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser| String| X| Registrant (stored as user UUID when sent from console)|
 | statsId| String| X| Statistics ID (not included in the outgoing search conditions. Up 8 characters)|
 
+<a id="request-to-send-premium-video-type"></a>
+
 #### Request to send premium video type
 
 \[Request body]
@@ -751,6 +785,8 @@ Content-Type: application/json;charset=UTF-8
 | resellerCode| String| X| Reseller code (used by resellers when sending)|
 | createUser| String| X| Registrant (stored as user UUID when sent from console)|
 | statsId| String| X| Statistics ID (not included in the outgoing search conditions. Up 8 characters)|
+
+<a id="request-to-send-commerce"></a>
 
 #### Request to send commerce
 
@@ -875,6 +911,8 @@ Content-Type: application/json;charset=UTF-8
 | resellerCode| String| X| Reseller code (used by resellers when sending)|
 | createUser| String| X| Registrant (stored as user UUID when sent from console)|
 | statsId| String| X| Statistics ID (not included in the outgoing search conditions. Up 8 characters)|
+
+<a id="request-to-send-carousel-feed-type"></a>
 
 #### Request to send carousel feed type
 ##### Carousel fixed placeholders (path-based template parameter)
@@ -1052,6 +1090,8 @@ Allow unique placeholder values for each item in a carousel-type template.
 | createUser| String| X        | Registrant (stored as user UUID when sent from console)|
 | statsId| String| X        | Statistics ID (not included in the outgoing search conditions. Up 8 characters)|
 
+<a id="request-to-send-carousel-commerce-type"></a>
+
 #### Request to send carousel commerce type
 
 \[Request body]
@@ -1208,6 +1248,8 @@ Allow unique placeholder values for each item in a carousel-type template.
 | createUser| String| X        | Registrant (stored as user UUID when sent from console)|
 | statsId| String| X        | Statistics ID (not included in the outgoing search conditions, up to 8 characters)|
 
+<a id="response-3"></a>
+
 #### Response
 
 ```
@@ -1245,6 +1287,8 @@ Allow unique placeholder values for each item in a carousel-type template.
 | \-- resultCode| Integer| O| Recipient-specific sending result code (success and various failure codes may exist)|
 | \-- resultMessage| String| O| Recipient-specific sending result message ("success" or a related message on success, detailed message on failure, cause on failure)|
 
+<a id="request-to-send-basic-message"></a>
+
 ## Request to send basic message
 
 * A sending using a template.
@@ -1260,6 +1304,8 @@ Allow unique placeholder values for each item in a carousel-type template.
 * Fallback can be set via resendParameter for each recipient.
   * When using fallback, you need to register the SMS Appkey and set its send through the fallback management API.
 * **Nighttime delivery restrictions(8:50 PM - 8:00 AM the next day)**
+
+<a id="cautions-for-use"></a>
 
 ### Cautions for use
 
@@ -1292,6 +1338,8 @@ Content-Type: application/json;charset=UTF-8
 | Name| Type| Required| Description|
 |----------|----------|----------|----------|
 | X-Secret-Key| String| O| Available to create from the console.|
+
+<a id="requested-4"></a>
 
 #### Requested
 
@@ -1359,6 +1407,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser| String| X| Registrant (stored as user UUID when sent from console)|
 | statsId| String| X| Statistics ID (not included in the outgoing search conditions, up to 8 characters)|
 
+<a id="response-4"></a>
+
 #### Response
 
 ```
@@ -1396,7 +1446,11 @@ Content-Type: application/json;charset=UTF-8
 | \-- resultCode| Integer| O| Recipient-specific sending result code (success and various failure codes may exist)|
 | \-- resultMessage| String| O| Recipient-specific sending result message ("success" or a related message on success, detailed message on failure, cause on failure)|
 
+<a id="view-sending-list"></a>
+
 ## View sending list
+
+<a id="requested-5"></a>
 
 #### Requested
 
@@ -1441,6 +1495,8 @@ Content-Type: application/json;charset=UTF-8
 | recipientGroupingKey| String| X| Recipient grouping key|
 | pageNum| String| X| Page number (default: 1\)|
 | pageSize| String| X| Number of views (default: 15, Max: 1,000)|
+
+<a id="response-5"></a>
 
 #### Response
 
@@ -1517,7 +1573,11 @@ Content-Type: application/json;charset=UTF-8
 | \-- recipientGroupingKey| String| X| Recipient grouping key|
 | \- totalCount| Integer| O| Total|
 
+<a id="view-single-sending"></a>
+
 ## View single sending
+
+<a id="requested-6"></a>
 
 #### Requested
 
@@ -1547,6 +1607,8 @@ Content-Type: application/json;charset=UTF-8
 | Name| Type| Required| Description|
 |----------|----------|----------|----------|
 | X-Secret-Key| String| O| Available to create from the console.|
+
+<a id="response-6"></a>
 
 #### Response
 
@@ -1808,7 +1870,11 @@ Content-Type: application/json;charset=UTF-8
 | \- senderGroupingKey| String| X| Outgoing grouping key|
 | \- recipientGroupingKey| String| X| Recipient grouping key|
 
+<a id="cancel-message-sending"></a>
+
 ## Cancel message sending
+
+<a id="requested-7"></a>
 
 #### Requested
 
@@ -1844,6 +1910,8 @@ Content-Type: application/json;charset=UTF-8
 |----------|----------|----------|----------|
 | recipientSeq| String| X| Recipient sequence number<br>(If you do not enter any information, all requests for that request ID will be canceled)|
 
+<a id="response-7"></a>
+
 #### Response
 
 ```
@@ -1869,9 +1937,15 @@ Content-Type: application/json;charset=UTF-8
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
 ```
 
+<a id="manage-templates"></a>
+
 ## Manage Templates
 
+<a id="view-template-list"></a>
+
 ### View template list
+
+<a id="requested-8"></a>
 
 #### Requested
 
@@ -1910,6 +1984,8 @@ Content-Type: application/json;charset=UTF-8
 | status| String| X| Template status code|
 | pageNum| Integer| X| Page number (Default: 1\)|
 | pageSize| Integer| X| Number of views (default: 15, Max: 1,000)|
+
+<a id="response-8"></a>
 
 #### Response
 
@@ -2138,6 +2214,8 @@ Content-Type: application/json;charset=UTF-8
 | \--- updateDate| String| X| Modified on|
 | \- totalCount| Integer| O| Total|
 
+<a id="view-single-template"></a>
+
 ### View single template
 
 \[URL]
@@ -2167,6 +2245,8 @@ Content-Type: application/json;charset=UTF-8
 |----------|----------|----------|----------|
 | X-Secret-Key| String| O| Available to create from the console.|
 | X-NC-API-IDEMPOTENCY-KEY | String | X | Key used as the basis for duplicate message delivery request detection<br>If a request is made with the same key within 10 minutes, the request will be treated as failed. |
+
+<a id="response-9"></a>
 
 #### Response
 
@@ -2389,7 +2469,11 @@ Content-Type: application/json;charset=UTF-8
 | \- createDate| String| O| Registered on|
 | \- updateDate| String| X| Modified on|
 
+<a id="register-template"></a>
+
 ### Register Template
+
+<a id="requested-9"></a>
 
 #### Requested
 
@@ -2419,6 +2503,8 @@ Content-Type: application/json;charset=UTF-8
 |----------|----------|----------|----------|
 | X-Secret-Key| String| O| Available to create from the console.|
 
+<a id="note"></a>
+
 #### Note
 
 * If applying placeholders to coupon titles, you must use the following fixed placeholders:
@@ -2437,6 +2523,8 @@ Content-Type: application/json;charset=UTF-8
   * discountPrice -> #{discount price}
   * discountRate -> #{discount rate}
   * discountFixed -> #{fixed discount price}
+
+<a id="request-to-register-text-type-template"></a>
 
 #### Request to register text type template
 
@@ -2491,6 +2579,8 @@ Content-Type: application/json;charset=UTF-8
 | \- linkPc| String| X| PC web link (optional for WL type), limited to 500 characters|
 | \- schemeAndroid| String| X| Android app link (required for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
 | \- schemeIos| String| X| iOS app link (required field for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
+
+<a id="request-to-register-image-type-template"></a>
 
 #### Request to register image type template
 
@@ -2553,6 +2643,8 @@ Content-Type: application/json;charset=UTF-8
 | \- schemeAndroid| String| X        | Android app link (required for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
 | \- schemeIos| String| X        | iOS app link (required field for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
 
+<a id="request-to-register-wide-image-type-template"></a>
+
 #### Request to register wide image type template
 
 \[Request body]
@@ -2613,6 +2705,8 @@ Content-Type: application/json;charset=UTF-8
 | \- linkPc| String| X        | PC web link (optional for WL type), limited to 500 characters|
 | \- schemeAndroid| String| X        | Android app link (required for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
 | \- schemeIos| String| X        | iOS app link (required field for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
+
+<a id="request-to-register-wide-item-list-type-template"></a>
 
 #### Request to register wide item list type template
 
@@ -2704,6 +2798,8 @@ Content-Type: application/json;charset=UTF-8
 | \- schemeAndroid| String| X| Android app link (required for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
 | \- schemeIos| String| X| iOS app link (required field for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
 
+<a id="request-to-register-premium-video-type-template"></a>
+
 #### Request to register premium video type template
 
 \[Request body]
@@ -2766,6 +2862,8 @@ Content-Type: application/json;charset=UTF-8
 | \- linkPc| String| X| PC web link (optional for WL type), limited to 500 characters|
 | \- schemeAndroid| String| X| Android app link (required for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
 | \- schemeIos| String| X| iOS app link (required field for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
+
+<a id="request-to-register-commerce-type-template"></a>
 
 #### Request to register commerce type template
 
@@ -2841,6 +2939,8 @@ Content-Type: application/json;charset=UTF-8
 | \- linkPc| String| X        | PC web link (optional for WL type), limited to 500 characters|
 | \- schemeAndroid| String| X        | Android app link (required for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
 | \- schemeIos| String| X        | iOS app link (required field for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
+
+<a id="request-to-register-carousel-feed-type-template"></a>
 
 #### Request to register carousel feed type template
 
@@ -2952,6 +3052,8 @@ Content-Type: application/json;charset=UTF-8
 | \- recipientNo| String| O        | Incoming number|
 | createUser| String| X        | Registrant (stored as user UUID when sent from console)|
 
+<a id="request-to-register-carousel-commerce-type-template"></a>
+
 #### Request to register carousel commerce type template
 
 \[Request body]
@@ -3060,6 +3162,8 @@ Content-Type: application/json;charset=UTF-8
 | \-- schemeAndroid| String| X        | Android app link, limited to 500 characters<br>No placeholders available|
 | \-- schemeIos| String| X        | iOS app link, limited to 500 characters<br>No placeholders available|
 
+<a id="response-10"></a>
+
 #### Response
 
 ```
@@ -3084,7 +3188,11 @@ Content-Type: application/json;charset=UTF-8
 | template| Object| X| Template Info|
 | \- templateCode| String| O| Template Code|
 
+<a id="modify-template"></a>
+
 ### Modify Template
+
+<a id="requested-10"></a>
 
 #### Requested
 
@@ -3119,6 +3227,8 @@ Content-Type: application/json;charset=UTF-8
 
 * Same specifications as template registration
 
+<a id="response-11"></a>
+
 #### Response
 
 ```
@@ -3138,7 +3248,11 @@ Content-Type: application/json;charset=UTF-8
 | \- resultMessage| String| O| Result message|
 | \- isSuccessful| boolean| O| Success status|
 
+<a id="delete-template"></a>
+
 ### Delete Template
+
+<a id="requested-11"></a>
 
 #### Requested
 
@@ -3169,6 +3283,8 @@ Content-Type: application/json;charset=UTF-8
 |----------|----------|----------|----------|
 | X-Secret-Key| String| O| Available to create from the console.|
 
+<a id="response-12"></a>
+
 #### Response
 
 ```
@@ -3188,9 +3304,15 @@ Content-Type: application/json;charset=UTF-8
 | \- resultMessage| String| O| Result message|
 | \- isSuccessful| boolean| O| Success status|
 
+<a id="manage-image"></a>
+
 ## Manage Image
 
+<a id="upload-image"></a>
+
 ### Upload image
+
+<a id="requested-12"></a>
 
 #### Requested
 
@@ -3226,6 +3348,8 @@ Content-Type: multipart/form-data
 | image| File| O| Image|
 | imageType| String| O| Image type <br>(IMAGE, WIDE_IMAGE,MAIN_WIDE_ITEMLIST_IMAGE,NORMAL_WIDE_ITEMLIST_IMAGE,CAROUSEL_FEED_IMAGE,CAROUSEL_COMMERCE_IMAGE)|
 
+<a id="response-13"></a>
+
 #### Response
 
 ```
@@ -3254,6 +3378,8 @@ Content-Type: multipart/form-data
 | \- imageUrl| String| O| Image URL|
 | \- imageName| String| X| Image Name|
 
+<a id="upload-image-specifications"></a>
+
 #### Upload Image Specifications
 | Image Type                 | Usage                                                                   | Upload Image Specifications                                                                                                                                                      |
 | :------------------------- | :---------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -3266,7 +3392,11 @@ Content-Type: multipart/form-data
 
 * If all templates referencing an uploaded image are deleted or changed to a different image, the image will be removed from the Kakao CDN, making the URL invalid. While image information is retained in the Image Retrieval API, the actual image cannot be accessed. It is recommended to store the original file separately on your own server.
 
+<a id="view-image"></a>
+
 ### View image
+
+<a id="requested-13"></a>
 
 #### Requested
 
@@ -3303,6 +3433,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum| String| X| Page number (default: 1\)|
 | pageSize| String| X| Number of views (default: 15\)|
 
+<a id="response-14"></a>
+
 #### Response
 
 ```
@@ -3331,7 +3463,11 @@ Content-Type: application/json;charset=UTF-8
 | \- imageUrl| String| O| Image URL|
 | \- imageName| String| X| Image Name|
 
+<a id="delete-image"></a>
+
 ### Delete Image
+
+<a id="requested-14"></a>
 
 #### Requested
 
@@ -3366,6 +3502,8 @@ Content-Type: application/json;charset=UTF-8
 |----------|----------|----------|----------|
 | imageSeq| String| O| Image number|
 
+<a id="response-15"></a>
+
 #### Response
 
 ```
@@ -3385,9 +3523,15 @@ Content-Type: application/json;charset=UTF-8
 | \- resultMessage| String| O| Result message|
 | \- isSuccessful| boolean| O| Success status|
 
+<a id="upload"></a>
+
 ## Upload
 
+<a id="upload-bizform-key"></a>
+
 ### Upload Bizform key
+
+<a id="requested-15"></a>
 
 #### Requested
 
@@ -3417,6 +3561,8 @@ Content-Type: application/json;charset=UTF-8
 |----------|----------|----------|----------|
 | X-Secret-Key| String| O| Available to create from the console.|
 
+<a id="response-16"></a>
+
 #### Response
 
 ```
@@ -3436,9 +3582,15 @@ Content-Type: application/json;charset=UTF-8
 | \- resultMessage| String| O| Result message|
 | \- isSuccessful| boolean| O| Success status|
 
+<a id="manage-outgoing-profiles"></a>
+
 ## Manage Outgoing Profiles
 
+<a id="view-outgoing-profile"></a>
+
 ### View outgoing profile
+
+<a id="requested-16"></a>
 
 #### Requested
 
@@ -3467,6 +3619,8 @@ Content-Type: application/json;charset=UTF-8
 | Name| Type| Required| Description|
 |----------|----------|----------|----------|
 | X-Secret-Key| String| O| Available to create from the console.|
+
+<a id="response-17"></a>
 
 #### Response
 
@@ -3537,7 +3691,11 @@ Content-Type: application/json;charset=UTF-8
 | \- createDate| String| X| Registered Date|
 | \- initialUserRestriction| boolean| O| First-time user restriction status|
 
+<a id="modify-outgoing-profile-080-opt-out-number"></a>
+
 ### Modify outgoing profile 080 opt-out number
+
+<a id="requested-17"></a>
 
 #### Requested
 
@@ -3581,6 +3739,8 @@ Content-Type: application/json;charset=UTF-8
 | unsubscribeNo| String| O| 080 toll-free opt-out phone number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx|
 | unsubscribeAuthNo| String| X| 080 toll-free opt-out verification number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>unsubscribeAuthNo cannot be entered without unsubscribeNo<br>ex) 1234|
 
+<a id="response-18"></a>
+
 #### Response
 
 ```
@@ -3600,7 +3760,11 @@ Content-Type: application/json;charset=UTF-8
 | \- resultMessage| String| O| Result message|
 | \- isSuccessful| boolean| O| Success status|
 
+<a id="manage-fallback"></a>
+
 ## Manage Fallback
+
+<a id="register-sms-appkey"></a>
 
 ### Register SMS AppKey
 
@@ -3647,6 +3811,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
 ```
 
+<a id="response-19"></a>
+
 #### Response
 
 ```
@@ -3659,6 +3825,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
   }
 }
 ```
+
+<a id="register-fallback-settings"></a>
 
 ### Register fallback settings
 
@@ -3710,6 +3878,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/failback/appkey -d '{"senderKey": "0be23c29de88d6888798aeda57062516354d74ba","isResend": true,"resendSendNo": "01012341234" }
 ```
+
+<a id="response-20"></a>
 
 #### Response
 

--- a/ja/friendtalkupgrade-api-guide-align-v2.md
+++ b/ja/friendtalkupgrade-api-guide-align-v2.md
@@ -1,0 +1,3713 @@
+## Notification > KakaoTalk Bizmessage > ブランドメッセージ > API v1.0 Guide
+
+<a id="brand-message"></a>
+
+## ブランドメッセージ
+
+<a id="api-domain"></a>
+
+#### [APIドメイン]
+
+| ドメイン                                                                        |
+|------------------------------------------------------------------------------|
+| [https://kakaotalk-bizmessage.api.nhncloudservice.com](https://kakaotalk-bizmessage.api.nhncloudservice.com) |
+
+<a id="introduce-v10-api"></a>
+
+## v1.0 API紹介
+
+<a id="manage-non-friend-message-sending-targeting-m-n"></a>
+
+## 非友だちメッセージ送信(ターゲティングM、N)管理
+
+非友だちメッセージ送信(ターゲティングM、N)は、以下の条件を全て満たす場合に送信できます。
+
+- ビジネス認証チャンネル
+  - 事業者番号の登録
+  - チャンネルカスタマーセンターの電話番号登録
+  - チャンネルの友だち数が5万以上
+  - 3か月以内にお知らせトークの送信成功履歴を保有
+
+<a id="upload-marketing-consent-evidence"></a>
+
+### マーケティング受信同意の証明資料のアップロード
+
+<a id="requested"></a>
+
+#### リクエスト
+
+[URL]
+
+```
+POST  /brand-message/v1.0/appkeys/{appKey}/senders/{senderKey}/upload-marketing-agreement
+Content-Type: multipart/form-data
+```
+
+[Path parameter]
+
+| 名前      | タイプ   | 説明   |
+|-----------|--------|--------|
+| appkey    | String | 固有のアプリキー |
+| senderKey | String | 発信キー |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前         | タイプ   | 必須 | 説明             |
+|--------------|--------|----|------------------|
+| X-Secret-Key | String | O  | コンソールで作成できます。 |
+
+[Request parameter]
+
+| 名前 | タイプ | 必須 | 説明          |
+|------|------|----|---------------|
+| file | File | O | マーケティング受信同意の証明資料 |
+
+<a id="response"></a>
+
+#### レスポンス
+
+```
+{
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
+  }
+}
+```
+
+| 名前            | タイプ    | Not Null | 説明   |
+|:----------------|:--------|:---------|:-------|
+| header          | Object  | O        | ヘッダ領域 |
+| - resultCode    | Integer | O        | 結果コード |
+| - resultMessage | String  | O        | 結果メッセージ |
+| - isSuccessful  | boolean | O        | 成否 |
+
+<a id="apply-for-using-non-friend-message-sending-targeting-m-n"></a>
+
+### 非友だちメッセージ送信(ターゲティングM、N)の使用申請
+
+<a id="requested-2"></a>
+
+#### リクエスト
+
+[URL]
+
+```
+POST  /brand-message/v1.0/appkeys/{appKey}/senders/{senderKey}/marketing-agreement
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 名前      | タイプ   | 説明   |
+|-----------|--------|--------|
+| appkey    | String | 固有のアプリキー |
+| senderKey | String | 発信キー |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前         | タイプ   | 必須 | 説明             |
+|--------------|--------|----|------------------|
+| X-Secret-Key | String | O  | コンソールで作成できます。 |
+
+<a id="response-2"></a>
+
+#### レスポンス
+
+```
+{
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
+  }
+}
+```
+
+| 名前            | タイプ    | Not Null | 説明   |
+|:----------------|:--------|:---------|:-------|
+| header          | Object  | O        | ヘッダ領域 |
+| - resultCode    | Integer | O        | 結果コード |
+| - resultMessage | String  | O        | 結果メッセージ |
+| - isSuccessful  | boolean | O        | 成否 |
+
+<a id="request-to-send-a-free-form-message"></a>
+
+## メッセージ自由形送信リクエスト
+
+* マーケティング受信同意ユーザーへの送信を利用できます。
+  * targetingフィールドを指定して、メッセージ対象のタイプを指定できます。
+        * M: 顧客企業の広告性情報受信に同意したユーザー(カカオトークでの受信に同意)
+        * N: 顧客企業の広告性情報受信に同意したユーザー(カカオトークでの受信に同意) - チャネルの友だち
+        * I: 顧客企業の送信リクエスト対象 ∩ チャネルの友だち
+* 従来のカカともへのメッセージの8つのメッセージタイプを全て使用できます。
+* BT、ACボタンタイプを使用できます。
+* AC(チャンネル追加)ボタンの使用時、以下の制約事項があります。
+    * 強調型ボタン(黄色)で表記されます。
+    * ボタンが複数ある場合、指定された位置で使用する必要があります。
+        * TEXT、IMAGE：最初のボタン(最上段)
+        * その他：2番目のボタン(右側)
+    * ボタン名(name)は「チャンネル追加」に固定されます。
+    * カルーセル型は、カルーセル全体を通して1つのみ使用可能です。
+    * ターゲティングM、Nのみ使用可能です。
+* BFボタンの使用時、カカオから発行されたビジネスフォームIDを入力して使用できます。
+* 代替送信は、受信者ごとにresendParameterを介して設定できます。
+* 代替送信をご利用になる場合、代替送信管理APIを介してSMS Appkeyの登録及び送信設定が必要です。
+* **夜間送信制限(20:50～翌日08:00)**
+
+<a id="requested-3"></a>
+
+#### リクエスト
+
+[URL]
+
+```
+POST  /brand-message/v1.0/appkeys/{appkey}/freestyle-messages
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 名前   | タイプ   | 説明   |
+|--------|--------|--------|
+| appkey | String | 固有のアプリキー |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前         | タイプ   | 必須 | 説明             |
+|--------------|--------|----|------------------|
+| X-Secret-Key | String | O  | コンソールで作成できます。 |
+
+<a id="request-text-type-sending"></a>
+
+#### テキスト型送信リクエスト
+
+[Request body]
+
+```
+{
+  "senderKey": String,
+  "chatBubbleType": "TEXT",
+  "pushAlarm": boolean,
+  "adult": boolean,
+  "content": String,
+  "buttons": [
+    {
+      "name": String,
+      "type": String,
+      "linkMo": String,
+      "linkPc": String,
+      "schemeAndroid": String,
+      "schemeIos": String,
+      "chatExtra": String,
+      "chatEvent": String,
+      "bizFormKey": String
+    }
+  ],
+  "coupon": {
+    "title": String,
+    "description": String,
+    "linkMo": String,
+    "linkPc": String,
+    "schemeAndroid": String,
+    "schemeIos": String
+  },
+  "recipientList": [
+    {
+      "recipientNo": String,
+      "resendParameter": {
+          "isResend": boolean,
+          "resendType": String,
+          "resendTitle": String,
+          "resendContent": String,
+          "resendSendNo": String,
+          "resendUnsubscribeNo": String
+      }
+    }
+  ],
+  "createUser": String,
+  "statsId": String
+}
+```
+
+| 名前                   | タイプ    | 必須 | 説明                                                                                                                                                                                                                                                                          |
+|------------------------|---------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| senderKey              | String  | O  | 発信キー(40文字). グループ発信キーは使用不可                                                                                                                                                                                                                                                     |
+| chatBubbleType         | String  | O  | メッセージタイプ(TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)                                                                                                                                                                         |
+| pushAlarm | boolean | X | メッセージプッシュ通知の送信有無(デフォルト: true) |
+| adult                  | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                                                                       |
+| unsubscribeAuthNo | String | X | 080無料受信拒否の認証番号(全て未入力の場合は送信プロフィールに登録された無料受信拒否情報で送信されます)<br>unsubscribeNoなしでunsubscribeAuthNoのみの入力不可<br>例: 1234 |
+| content | String | O | - TEXTタイプの場合、最大1,300文字(改行:最大99個、URL形式の入力が可能)<br>- IMAGEタイプの場合、最大400文字(改行:最大29回、URL形式の入力が可能)<br>- WIDEタイプの場合、最大76文字(改行:最大1回)<br>- PREMIUM_VIDEOタイプの場合、このフィールドをオプションとして使用可能。最大76文字(改行:最大1回)<br>- その他のタイプの場合、このフィールドは使用しません |
+| buttons | List | X | ボタンリスト<br>- TEXT、IMAGEタイプの場合、クーポン適用時は最大4件、それ以外は最大5件<br>- WIDE、WIDE_ITEM_LISTタイプの場合、最大2件<br>- PREMIUM_VIDEOタイプの場合、最大1件<br>- COMMERCEタイプの場合、最小1件、最大2件 |
+| - name | String | O | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字 |
+| - type | String | O | ボタンタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- BTタイプはカカオオープンビルダーのチャットボットを使用するチャンネルのみ利用可能<br>- BFタイプは最初のボタンとしてのみ使用でき、nameには以下の3つのフレーズのみ使用可能<br> - トークで予約する<br> - トークでアンケートする<br> - トークで応募する |
+| - linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド)、1,000文字制限 |
+| - linkPc | String | X | PCWebリンク(WLタイプの場合、任意フィールド)、1,000文字制限 |
+| - schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限 |
+| - schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限 |
+| - chatExtra | String | X | BTタイプのボタンの場合、伝達するメタ情報 |
+| - chatEvent | String | X | BTタイプのボタンの場合、連携するボットイベント名 |
+| - bizFormKey | String | X | BFタイプのボタンの場合、ビズフォームキー |
+| coupon                 | Object  | X  | クーポン要素                                                                                                                                                                                                                                                                       |
+| - title | String | O | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」 |
+| - description | String | O | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字。改行:不可<br>- その他のタイプの場合、最大12文字。改行:不可 |
+| - linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
+| - linkPc | String | X | PCWebリンク(WLタイプの場合、任意フィールド)、1,000文字制限 |
+| - schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
+| - schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
+| recipientList          | List    | O  | 受信者リスト(最大1,000人)                                                                                                                                                                                                                                                             |
+| - recipientNo          | String  | O  | 受信番号                                                                                                                                                                                                                                                                       |
+| - resendParameter      | Object  | X  | 代替送信情報                                                                                                                                                                                                                                                                    |
+| -- isResend | boolean | X | 送信に失敗した場合、メッセージを代替送信するかどうか<br>コンソールで代替送信を設定した場合、基本設定として代替送信されます。 |
+| -- resendType | String | X | 代替送信タイプ(SMS、LMS)<br>値がない場合、テンプレート本文の長さに応じてタイプが区分されます。 |
+| -- resendTitle | String | X | LMS代替送信の件名<br>(値がない場合、プラスフレンドIDで代替送信されます。) |
+| -- resendContent | String | X | 代替送信の内容<br>(値がない場合、[メッセージ本文]で代替送信されます。) |
+| -- resendSendNo | String | X | 代替送信の送信者番号<br><span style="color:red">(SMSサービスに登録されている送信者番号ではない場合、代替送信に失敗することがあります。)</span> |
+| -- resendUnsubscribeNo | String | X | 代替送信080受信拒否番号<br><span style="color:red">(SMSサービスに登録された080受信拒否番号ではない場合、代替送信に失敗することがあります。)</span> |
+| createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
+| statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
+
+<a id="request-image-type-sending"></a>
+
+#### 画像形式の送信リクエスト
+
+[Request body]
+
+```
+{
+  "senderKey": String,
+  "chatBubbleType": "IMAGE",
+  "pushAlarm": boolean,
+  "adult": boolean,
+  "content": String,
+  "image": {
+    "imageUrl": String,
+    "imageLink": String
+  },
+  "buttons": [
+    {
+      "name": String,
+      "type": String,
+      "linkMo": String,
+      "linkPc": String,
+      "schemeAndroid": String,
+      "schemeIos": String,
+      "chatExtra": String,
+      "chatEvent": String,
+      "bizFormKey": String
+    }
+  ],
+  "coupon": {
+    "title": String,
+    "description": String,
+    "linkMo": String,
+    "linkPc": String,
+    "schemeAndroid": String,
+    "schemeIos": String
+  },
+  "recipientList": [
+    {
+      "recipientNo": String,
+      "resendParameter": {
+          "isResend": boolean,
+          "resendType": String,
+          "resendTitle": String,
+          "resendContent": String,
+          "resendSendNo": String,
+          "resendUnsubscribeNo": String
+      }
+    }
+  ],
+  "createUser": String,
+  "statsId": String
+}
+```
+
+| 名前                   | タイプ    | 必須 | 説明                                                                                                                                                                                                                                                                          |
+|------------------------|---------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| senderKey              | String  | O  | 発信キー(40文字). グループ発信キーは使用不可                                                                                                                                                                                                                                                     |
+| chatBubbleType         | String  | O  | メッセージタイプ(TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)                                                                                                                                                                         |
+| pushAlarm | boolean | X | メッセージプッシュ通知の送信有無(デフォルト: true) |
+| adult                  | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                                                                       |
+| content | String | O | - TEXTタイプの場合、最大1,300文字(改行:最大99個、URL形式の入力が可能)<br>- IMAGEタイプの場合、最大400文字(改行:最大29回、URL形式の入力が可能)<br>- WIDEタイプの場合、最大76文字(改行:最大1回)<br>- PREMIUM_VIDEOタイプの場合、このフィールドをオプションとして使用可能。最大76文字(改行:最大1回)<br>- その他のタイプの場合、このフィールドは使用しません |
+| image | Object | O | 画像要素<br>- IMAGE、WIDE、COMMERCEタイプの場合、必須フィールド |
+| - imageUrl | String | O | 画像URL。一般画像としてアップロードされた画像URLを使用 |
+| - imageLink | String | X | 画像をクリックしたときに移動するURL。1,000文字制限<br>未設定の場合、カカオトーク内の画像ビューアを使用 |
+| buttons | List | X | ボタンリスト<br>- TEXT、IMAGEタイプの場合、クーポン適用時は最大4件、それ以外は最大5件<br>- WIDE、WIDE_ITEM_LISTタイプの場合、最大2件<br>- PREMIUM_VIDEOタイプの場合、最大1件<br>- COMMERCEタイプの場合、最小1件、最大2件 |
+| - name | String | O | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字 |
+| - type | String | O | ボタンタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- BTタイプはカカオオープンビルダーのチャットボットを使用するチャンネルのみ利用可能<br>- BFタイプは最初のボタンとしてのみ使用でき、nameには以下の3つのフレーズのみ使用可能<br> - トークで予約する<br> - トークでアンケートする<br> - トークで応募する |
+| - linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド)、1,000文字制限 |
+| - linkPc | String | X | PCWebリンク(WLタイプの場合、任意フィールド)、1,000文字制限 |
+| - schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限 |
+| - schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限 |
+| - chatExtra | String | X | BTタイプのボタンの場合、伝達するメタ情報 |
+| - chatEvent | String | X | BTタイプのボタンの場合、連携するボットイベント名 |
+| - bizFormKey | String | X | BFタイプのボタンの場合、ビズフォームキー |
+| coupon                 | Object  | X  | クーポン要素                                                                                                                                                                                                                                                                       |
+| - title | String | O | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」 |
+| - description | String | O | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字。改行:不可<br>- その他のタイプの場合、最大12文字。改行:不可 |
+| - linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
+| - linkPc | String | X | PCWebリンク(WLタイプの場合、任意フィールド)、1,000文字制限 |
+| - schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
+| - schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
+| recipientList          | List    | O  | 受信者リスト(最大1,000人)                                                                                                                                                                                                                                                             |
+| - recipientNo          | String  | O  | 受信番号                                                                                                                                                                                                                                                                       |
+| - resendParameter      | Object  | X  | 代替送信情報                                                                                                                                                                                                                                                                    |
+| -- isResend | boolean | X | 送信に失敗した場合、メッセージを代替送信するかどうか<br>コンソールで代替送信を設定した場合、基本設定として代替送信されます。 |
+| -- resendType | String | X | 代替送信タイプ(SMS、LMS)<br>値がない場合、テンプレート本文の長さに応じてタイプが区分されます。 |
+| -- resendTitle | String | X | LMS代替送信の件名<br>(値がない場合、プラスフレンドIDで代替送信されます。) |
+| -- resendContent | String | X | 代替送信の内容<br>(値がない場合、[メッセージ本文]で代替送信されます。) |
+| -- resendSendNo | String | X | 代替送信の送信者番号<br><span style="color:red">(SMSサービスに登録されている送信者番号ではない場合、代替送信に失敗することがあります。)</span> |
+| -- resendUnsubscribeNo | String | X | 代替送信080受信拒否番号<br><span style="color:red">(SMSサービスに登録された080受信拒否番号ではない場合、代替送信に失敗することがあります。)</span> |
+| createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
+| statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
+
+<a id="request-wide-image-type-sending"></a>
+
+#### ワイド画像形式の送信リクエスト
+
+[Request body]
+
+```
+{
+  "senderKey": String,
+  "chatBubbleType": "WIDE",
+  "pushAlarm": boolean,
+  "adult": boolean,
+  "content": String,
+  "image": {
+    "imageUrl": String,
+    "imageLink": String
+  },
+  "buttons": [
+    {
+      "name": String,
+      "type": String,
+      "linkMo": String,
+      "linkPc": String,
+      "schemeAndroid": String,
+      "schemeIos": String,
+      "chatExtra": String,
+      "chatEvent": String,
+      "bizFormKey": String
+    }
+  ],
+  "coupon": {
+    "title": String,
+    "description": String,
+    "linkMo": String,
+    "linkPc": String,
+    "schemeAndroid": String,
+    "schemeIos": String
+  },
+  "recipientList": [
+    {
+      "recipientNo": String,
+      "resendParameter": {
+          "isResend": boolean,
+          "resendType": String,
+          "resendTitle": String,
+          "resendContent": String,
+          "resendSendNo": String,
+          "resendUnsubscribeNo": String
+      }
+    }
+  ],
+  "createUser": String,
+  "statsId": String
+}
+```
+
+| 名前                   | タイプ    | 必須 | 説明                                                                                                                                                                                                                                                                          |
+|------------------------|---------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| senderKey              | String  | O  | 発信キー(40文字). グループ発信キーは使用不可                                                                                                                                                                                                                                                     |
+| chatBubbleType         | String  | O  | メッセージタイプ(TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)                                                                                                                                                                         |
+| pushAlarm | boolean | X | メッセージプッシュ通知の送信有無(デフォルト: true) |
+| adult                  | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                                                                       |
+| content | String | O | - TEXTタイプの場合、最大1,300文字(改行:最大99個、URL形式の入力が可能)<br>- IMAGEタイプの場合、最大400文字(改行:最大29回、URL形式の入力が可能)<br>- WIDEタイプの場合、最大76文字(改行:最大1回)<br>- PREMIUM_VIDEOタイプの場合、このフィールドをオプションとして使用可能。最大76文字(改行:最大1回)<br>- その他のタイプの場合、このフィールドは使用しません |
+| image | Object | O | 画像要素<br>- IMAGE、WIDE、COMMERCEタイプの場合、必須フィールド |
+| - imageUrl | String | O | 画像URL、ワイド画像としてアップロードされた画像URLを使用 |
+| - imageLink | String | X | 画像をクリックしたときに移動するURL。1,000文字制限<br>未設定の場合、カカオトーク内の画像ビューアを使用 |
+| buttons | List | X | ボタンリスト<br>- TEXT、IMAGEタイプの場合、クーポン適用時は最大4件、それ以外は最大5件<br>- WIDE、WIDE_ITEM_LISTタイプの場合、最大2件<br>- PREMIUM_VIDEOタイプの場合、最大1件<br>- COMMERCEタイプの場合、最小1件、最大2件 |
+| - name | String | O | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字 |
+| - type | String | O | ボタンタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- BTタイプはカカオオープンビルダーのチャットボットを使用するチャンネルのみ利用可能<br>- BFタイプは最初のボタンとしてのみ使用でき、nameには以下の3つのフレーズのみ使用可能<br> - トークで予約する<br> - トークでアンケートする<br> - トークで応募する |
+| - linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド)、1,000文字制限 |
+| - linkPc | String | X | PCWebリンク(WLタイプの場合、任意フィールド)、1,000文字制限 |
+| - schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限 |
+| - schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限 |
+| - chatExtra | String | X | BTタイプのボタンの場合、伝達するメタ情報 |
+| - chatEvent | String | X | BTタイプのボタンの場合、連携するボットイベント名 |
+| - bizFormKey | String | X | BFタイプのボタンの場合、ビズフォームキー |
+| coupon                 | Object  | X  | クーポン要素                                                                                                                                                                                                                                                                       |
+| - title | String | O | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」 |
+| - description | String | O | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字。改行:不可<br>- その他のタイプの場合、最大12文字。改行:不可 |
+| - linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
+| - linkPc | String | X | PCWebリンク(WLタイプの場合、任意フィールド)、1,000文字制限 |
+| - schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
+| - schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
+| recipientList          | List    | O  | 受信者リスト(最大1,000人)                                                                                                                                                                                                                                                             |
+| - recipientNo          | String  | O  | 受信番号                                                                                                                                                                                                                                                                       |
+| - resendParameter      | Object  | X  | 代替送信情報                                                                                                                                                                                                                                                                    |
+| -- isResend | boolean | X | 送信に失敗した場合、メッセージを代替送信するかどうか<br>コンソールで代替送信を設定した場合、基本設定として代替送信されます。 |
+| -- resendType | String | X | 代替送信タイプ(SMS、LMS)<br>値がない場合、テンプレート本文の長さに応じてタイプが区分されます。 |
+| -- resendTitle | String | X | LMS代替送信の件名<br>(値がない場合、プラスフレンドIDで代替送信されます。) |
+| -- resendContent | String | X | 代替送信の内容<br>(値がない場合、[メッセージ本文]で代替送信されます。) |
+| -- resendSendNo | String | X | 代替送信の送信者番号<br><span style="color:red">(SMSサービスに登録されている送信者番号ではない場合、代替送信に失敗することがあります。)</span> |
+| -- resendUnsubscribeNo | String | X | 代替送信080受信拒否番号<br><span style="color:red">(SMSサービスに登録された080受信拒否番号ではない場合、代替送信に失敗することがあります。)</span> |
+| createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
+| statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
+
+<a id="request-to-send-wide-item-list-type"></a>
+
+#### ワイドアイテムリスト形式の送信リクエスト
+
+[Request body]
+
+```
+{
+  "senderKey": String,
+  "chatBubbleType": "WIDE_ITEM_LIST",
+  "pushAlarm": boolean,
+  "adult": boolean,
+  "header": String,
+  "item": {
+    "list": [
+      {
+        "title": String,
+        "imageUrl": String,
+        "linkMo": String,
+        "linkPc": String,
+        "schemeAndroid": String,
+        "schemeIos": String
+      },
+      {
+        "title": String,
+        "imageUrl": String,
+        "linkMo": String,
+        "linkPc": String,
+        "schemeAndroid": String,
+        "schemeIos": String
+      },
+      {
+        "title": String,
+        "imageUrl": String,
+        "linkMo": String,
+        "linkPc": String,
+        "schemeAndroid": String,
+        "schemeIos": String
+      }
+    ]
+  },
+  "buttons": [
+    {
+      "name": String,
+      "type": String,
+      "linkMo": String,
+      "linkPc": String,
+      "schemeAndroid": String,
+      "schemeIos": String,
+      "chatExtra": String,
+      "chatEvent": String,
+      "bizFormKey": String
+    }
+  ],
+  "coupon": {
+    "title": String,
+    "description": String,
+    "linkMo": String,
+    "linkPc": String,
+    "schemeAndroid": String,
+    "schemeIos": String
+  },
+  "recipientList": [
+    {
+      "recipientNo": String,
+      "resendParameter": {
+          "isResend": boolean,
+          "resendType": String,
+          "resendTitle": String,
+          "resendContent": String,
+          "resendSendNo": String,
+          "resendUnsubscribeNo": String
+      }
+    }
+  ],
+  "createUser": String,
+  "statsId": String
+}
+```
+
+| 名前                   | タイプ    | 必須 | 説明                                                                                                                                                                                                                                                                          |
+|------------------------|---------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| senderKey              | String  | O  | 発信キー(40文字). グループ発信キーは使用不可                                                                                                                                                                                                                                                     |
+| chatBubbleType         | String  | O  | メッセージタイプ(TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)                                                                                                                                                                         |
+| pushAlarm | boolean | X | メッセージプッシュ通知の送信有無(デフォルト: true) |
+| adult                  | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                                                                       |
+| header | String | O | ヘッダ<br>- WIDE_ITEM_LISTタイプの場合、必須フィールドで最大20文字(改行:不可)<br>- PREMIUM_VIDEOタイプの場合、任意フィールドで最大20文字(改行:不可) |
+| item | Object | O | ワイドリスト要素(WIDE_ITEM_LISTタイプでのみ使用可能) |
+| - list                 | List    | O  | ワイドリスト(最小: 3、最大4)                                                                                                                                                                                                                                                         |
+| -- title | String | O | アイテムのタイトル<br>- 1番目のアイテムは最大25文字制限(改行:最大1回、1番目のアイテムの場合、titleは必須値ではありません)<br>- 2～4番目のアイテムは最大30文字制限(改行:最大1回) |
+| -- imageUrl | String | O | アイテムの画像URL<br>- 1番目のアイテムには、最初のワイドアイテムリスト画像としてアップロードされた画像URLを使用<br>- 2～4番目のアイテムは、一般ワイドアイテムリスト画像としてアップロードされた画像URLを使用 |
+| -- linkMo              | String  | O  | モバイルWebリンク、1,000文字制限                                                                                                                                                                                                                                                         |
+| -- linkPc              | String  | X  | PC Webリンク、1,000文字制限                                                                                                                                                                                                                                                          |
+| -- schemeAndroid       | String  | X  | Androidアプリリンク、1,000文字制限                                                                                                                                                                                                                                                       |
+| -- schemeIos           | String  | X  | iOSアプリリンク、1,000文字制限                                                                                                                                                                                                                                                         |
+| buttons | List | X | ボタンリスト<br>- TEXT、IMAGEタイプの場合、クーポン適用時は最大4件、それ以外は最大5件<br>- WIDE、WIDE_ITEM_LISTタイプの場合、最大2件<br>- PREMIUM_VIDEOタイプの場合、最大1件<br>- COMMERCEタイプの場合、最小1件、最大2件 |
+| - name | String | O | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字 |
+| - type | String | O | ボタンタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- BTタイプはカカオオープンビルダーのチャットボットを使用するチャンネルのみ利用可能<br>- BFタイプは最初のボタンとしてのみ使用でき、nameには以下の3つのフレーズのみ使用可能<br> - トークで予約する<br> - トークでアンケートする<br> - トークで応募する |
+| - linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド)、1,000文字制限 |
+| - linkPc | String | X | PCWebリンク(WLタイプの場合、任意フィールド)、1,000文字制限 |
+| - schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限 |
+| - schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限 |
+| - chatExtra | String | X | BTタイプのボタンの場合、伝達するメタ情報 |
+| - chatEvent | String | X | BTタイプのボタンの場合、連携するボットイベント名 |
+| - bizFormKey | String | X | BFタイプのボタンの場合、ビズフォームキー |
+| coupon                 | Object  | X  | クーポン要素                                                                                                                                                                                                                                                                       |
+| - title | String | O | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」 |
+| - description | String | O | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字。改行:不可<br>- その他のタイプの場合、最大12文字。改行:不可 |
+| - linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
+| - linkPc | String | X | PCWebリンク(WLタイプの場合、任意フィールド)、1,000文字制限 |
+| - schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
+| - schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
+| recipientList          | List    | O  | 受信者リスト(最大1,000人)                                                                                                                                                                                                                                                             |
+| - recipientNo          | String  | O  | 受信番号                                                                                                                                                                                                                                                                       |
+| - resendParameter      | Object  | X  | 代替送信情報                                                                                                                                                                                                                                                                    |
+| -- isResend | boolean | X | 送信に失敗した場合、メッセージを代替送信するかどうか<br>コンソールで代替送信を設定した場合、基本設定として代替送信されます。 |
+| -- resendType | String | X | 代替送信タイプ(SMS、LMS)<br>値がない場合、テンプレート本文の長さに応じてタイプが区分されます。 |
+| -- resendTitle | String | X | LMS代替送信の件名<br>(値がない場合、プラスフレンドIDで代替送信されます。) |
+| -- resendContent | String | X | 代替送信の内容<br>(値がない場合、[メッセージ本文]で代替送信されます。) |
+| -- resendSendNo | String | X | 代替送信の送信者番号<br><span style="color:red">(SMSサービスに登録されている送信者番号ではない場合、代替送信に失敗することがあります。)</span> |
+| -- resendUnsubscribeNo | String | X | 代替送信080受信拒否番号<br><span style="color:red">(SMSサービスに登録された080受信拒否番号ではない場合、代替送信に失敗することがあります。)</span> |
+| createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
+| statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
+
+<a id="request-to-send-premium-video-type"></a>
+
+#### プレミアム動画形式の送信リクエスト
+
+[Request body]
+
+```
+{
+  "senderKey": String,
+  "chatBubbleType": "PREMIUM_VIDEO",
+  "pushAlarm": boolean,
+  "adult": boolean,
+  "content": String,
+  "header": String,
+  "video": {
+    "videoUrl": String,
+    "thumbnailUrl": String
+  },
+  "buttons": [
+    {
+      "name": String,
+      "type": String,
+      "linkMo": String,
+      "linkPc": String,
+      "schemeAndroid": String,
+      "schemeIos": String,
+      "chatExtra": String,
+      "chatEvent": String,
+      "bizFormKey": String
+    }
+  ],
+  "coupon": {
+    "title": String,
+    "description": String,
+    "linkMo": String,
+    "linkPc": String,
+    "schemeAndroid": String,
+    "schemeIos": String
+  },
+  "recipientList": [
+    {
+      "recipientNo": String,
+      "resendParameter": {
+          "isResend": boolean,
+          "resendType": String,
+          "resendTitle": String,
+          "resendContent": String,
+          "resendSendNo": String,
+          "resendUnsubscribeNo": String
+      }
+    }
+  ],
+  "createUser": String,
+  "statsId": String
+}
+```
+
+| 名前                   | タイプ    | 必須 | 説明                                                                                                                                                                                                                                                                          |
+|------------------------|---------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| senderKey              | String  | O  | 発信キー(40文字). グループ発信キーは使用不可                                                                                                                                                                                                                                                     |
+| chatBubbleType         | String  | O  | メッセージタイプ(TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)                                                                                                                                                                         |
+| pushAlarm | boolean | X | メッセージプッシュ通知の送信有無(デフォルト: true) |
+| adult                  | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                                                                       |
+| content | String | X | - TEXTタイプの場合、最大1,300文字(改行:最大99個、URL形式の入力が可能)<br>- IMAGEタイプの場合、最大400文字(改行:最大29回、URL形式の入力が可能)<br>- WIDEタイプの場合、最大76文字(改行:最大1回)<br>- PREMIUM_VIDEOタイプの場合、このフィールドをオプションとして使用可能、最大76文字(改行:最大1回)<br>- その他のタイプの場合、このフィールドは使用しません |
+| header | String | X | ヘッダ<br>- WIDE_ITEM_LISTタイプの場合、必須フィールドで最大20文字(改行:不可)<br>- PREMIUM_VIDEOタイプの場合、任意フィールドで最大20文字(改行:不可) |
+| video | Object | O | 動画要素(PREMIUM_VIDEOタイプのみ使用可能) |
+| - videoUrl | String | O | カカオTV動画URL (カカオTVにアップロードされた動画アドレスのみ使用可能)、最大500文字制限 |
+| - thumbnailUrl | String | X | 動画サムネイル用画像URL、一般画像としてアップロードされたURLのみ使用可能(ない場合、カカオTV動画の基本サムネイルを使用) 、最大500文字制限 |
+| buttons | List | X | ボタンリスト<br>- TEXT、IMAGEタイプの場合、クーポン適用時は最大4件、それ以外は最大5件<br>- WIDE、WIDE_ITEM_LISTタイプの場合、最大2件<br>- PREMIUM_VIDEOタイプの場合、最大1件<br>- COMMERCEタイプの場合、最小1件、最大2件 |
+| - name | String | O | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字 |
+| - type | String | O | ボタンタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- BTタイプはカカオオープンビルダーのチャットボットを使用するチャンネルのみ利用可能<br>- BFタイプは最初のボタンとしてのみ使用でき、nameには以下の3つのフレーズのみ使用可能<br> - トークで予約する<br> - トークでアンケートする<br> - トークで応募する |
+| - linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド)、1,000文字制限 |
+| - linkPc | String | X | PCWebリンク(WLタイプの場合、任意フィールド)、1,000文字制限 |
+| - schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限 |
+| - schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限 |
+| - chatExtra | String | X | BTタイプのボタンの場合、伝達するメタ情報 |
+| - chatEvent | String | X | BTタイプのボタンの場合、連携するボットイベント名 |
+| - bizFormKey | String | X | BFタイプのボタンの場合、ビズフォームキー |
+| coupon                 | Object  | X  | クーポン要素                                                                                                                                                                                                                                                                       |
+| - title | String | O | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」 |
+| - description | String | O | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字。改行:不可<br>- その他のタイプの場合、最大12文字。改行:不可 |
+| - linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
+| - linkPc | String | X | PCWebリンク(WLタイプの場合、任意フィールド)、1,000文字制限 |
+| - schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
+| - schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
+| recipientList          | List    | O  | 受信者リスト(最大1,000人)                                                                                                                                                                                                                                                             |
+| - recipientNo          | String  | O  | 受信番号                                                                                                                                                                                                                                                                       |
+| - resendParameter      | Object  | X  | 代替送信情報                                                                                                                                                                                                                                                                    |
+| -- isResend | boolean | X | 送信に失敗した場合、メッセージを代替送信するかどうか<br>コンソールで代替送信を設定した場合、基本設定として代替送信されます。 |
+| -- resendType | String | X | 代替送信タイプ(SMS、LMS)<br>値がない場合、テンプレート本文の長さに応じてタイプが区分されます。 |
+| -- resendTitle | String | X | LMS代替送信の件名<br>(値がない場合、プラスフレンドIDで代替送信されます。) |
+| -- resendContent | String | X | 代替送信の内容<br>(値がない場合、[メッセージ本文]で代替送信されます。) |
+| -- resendSendNo | String | X | 代替送信の送信者番号<br><span style="color:red">(SMSサービスに登録されている送信者番号ではない場合、代替送信に失敗することがあります。)</span> |
+| -- resendUnsubscribeNo | String | X | 代替送信080受信拒否番号<br><span style="color:red">(SMSサービスに登録された080受信拒否番号ではない場合、代替送信に失敗することがあります。)</span> |
+| createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
+| statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
+
+<a id="request-to-send-commerce"></a>
+
+#### コマース形式の送信リクエスト
+
+[Request body]
+
+```
+{
+  "senderKey": String,
+  "chatBubbleType": "COMMERCE",
+  "pushAlarm": boolean,
+  "adult": boolean,
+  "additionalContent": String,
+  "image": {
+    "imageUrl": String,
+    "imageLink": String
+  },
+  "commerce": {
+    "title": String,
+    "regularPrice": Integer,
+    "discountPrice": Integer,
+    "discountRate": Integer,
+    "discountFixed": Integer
+  },
+  "buttons": [
+    {
+      "name": String,
+      "type": String,
+      "linkMo": String,
+      "linkPc": String,
+      "schemeAndroid": String,
+      "schemeIos": String,
+      "chatExtra": String,
+      "chatEvent": String,
+      "bizFormKey": String
+    }
+  ],
+  "coupon": {
+    "title": String,
+    "description": String,
+    "linkMo": String,
+    "linkPc": String,
+    "schemeAndroid": String,
+    "schemeIos": String
+  },
+  "recipientList": [
+    {
+      "recipientNo": String,
+      "resendParameter": {
+          "isResend": boolean,
+          "resendType": String,
+          "resendTitle": String,
+          "resendContent": String,
+          "resendSendNo": String,
+          "resendUnsubscribeNo": String
+      }
+    }
+  ],
+  "createUser": String,
+  "statsId": String
+}
+```
+
+| 名前                   | タイプ    | 必須 | 説明                                                                                                                                                                                                                                                                          |
+|------------------------|---------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| senderKey              | String  | O  | 発信キー(40文字). グループ発信キーは使用不可                                                                                                                                                                                                                                                     |
+| chatBubbleType         | String  | O  | メッセージタイプ(TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)                                                                                                                                                                         |
+| pushAlarm | boolean | X | メッセージプッシュ通知の送信有無(デフォルト: true) |
+| adult                  | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                                                                       |
+| additionalContent | String | X | 付加情報(最大34文字、改行:最大1回)、コマース形式でのみ使用可能 |
+| image | Object | O | 画像要素<br>- IMAGE、WIDE、COMMERCEタイプの場合、必須フィールド |
+| - imageUrl | String | O | 画像URL。一般画像としてアップロードされた画像URLを使用 |
+| - imageLink | String | X | 画像をクリックしたときに移動するURL。1,000文字制限<br>未設定の場合、カカオトーク内の画像ビューアを使用 |
+| commerce | Object | O | コマース(COMMERCEタイプでのみ使用可能) |
+| title | String | O | 商品名(最大30文字、改行:不可) |
+| regularPrice | Integer | O | 通常価格(0～99,999,999) |
+| discountPrice | Integer | X | 割引価格(0～99,999,999) |
+| discountRate | Integer | X | 割引率(0～100)、割引価格が存在する場合、割引率、定額割引価格のいずれかは必須 |
+| discountFixed | Integer | X | 定額割引価格(0 ～ 999,999)、割引価格が存在する場合、割引率、定額割引価格のいずれかは必須 |
+| buttons | List | O | ボタンリスト<br>- TEXT、IMAGEタイプの場合、クーポン適用時は最大4件、それ以外は最大5件<br>- WIDE、WIDE_ITEM_LISTタイプの場合、最大2件<br>- PREMIUM_VIDEOタイプの場合、最大1件<br>- COMMERCEタイプの場合、最小1件、最大2件 |
+| - name | String | O | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字 |
+| - type | String | O | ボタンタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- BTタイプはカカオオープンビルダーのチャットボットを使用するチャンネルのみ利用可能<br>- BFタイプは最初のボタンとしてのみ使用でき、nameには以下の3つのフレーズのみ使用可能<br> - トークで予約する<br> - トークでアンケートする<br> - トークで応募する |
+| - linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド)、1,000文字制限 |
+| - linkPc | String | X | PCWebリンク(WLタイプの場合、任意フィールド)、1,000文字制限 |
+| - schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限 |
+| - schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限 |
+| - chatExtra | String | X | BTタイプのボタンの場合、伝達するメタ情報 |
+| - chatEvent | String | X | BTタイプのボタンの場合、連携するボットイベント名 |
+| - bizFormKey | String | X | BFタイプのボタンの場合、ビズフォームキー |
+| coupon                 | Object  | X  | クーポン要素                                                                                                                                                                                                                                                                       |
+| - title | String | O | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」 |
+| - description | String | O | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字。改行:不可<br>- その他のタイプの場合、最大12文字。改行:不可 |
+| - linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
+| - linkPc | String | X | PCWebリンク(WLタイプの場合、任意フィールド)、1,000文字制限 |
+| - schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
+| - schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
+| recipientList          | List    | O  | 受信者リスト(最大1,000人)                                                                                                                                                                                                                                                             |
+| - recipientNo          | String  | O  | 受信番号                                                                                                                                                                                                                                                                       |
+| - resendParameter      | Object  | X  | 代替送信情報                                                                                                                                                                                                                                                                    |
+| -- isResend | boolean | X | 送信に失敗した場合、メッセージを代替送信するかどうか<br>コンソールで代替送信を設定した場合、基本設定として代替送信されます。 |
+| -- resendType | String | X | 代替送信タイプ(SMS、LMS)<br>値がない場合、テンプレート本文の長さに応じてタイプが区分されます。 |
+| -- resendTitle | String | X | LMS代替送信の件名<br>(値がない場合、プラスフレンドIDで代替送信されます。) |
+| -- resendContent | String | X | 代替送信の内容<br>(値がない場合、[メッセージ本文]で代替送信されます。) |
+| -- resendSendNo | String | X | 代替送信の送信者番号<br><span style="color:red">(SMSサービスに登録されている送信者番号ではない場合、代替送信に失敗することがあります。)</span> |
+| -- resendUnsubscribeNo | String | X | 代替送信080受信拒否番号<br><span style="color:red">(SMSサービスに登録された080受信拒否番号ではない場合、代替送信に失敗することがあります。)</span> |
+| createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
+| statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
+
+<a id="request-to-send-carousel-feed-type"></a>
+
+#### カルーセルフィード形式の送信リクエスト
+
+[Request body]
+
+```
+{
+  "senderKey": String,
+  "chatBubbleType": "CAROUSEL_FEED",
+  "pushAlarm": boolean,
+  "adult": boolean,
+  "carousel": {
+    "list": [
+      {
+        "header": String,
+        "message": String,
+        "imageUrl": String,
+        "imageLink": String,
+        "buttons": [
+          {
+            "name": String,
+            "type": String,
+            "linkMo": String,
+            "linkPc": String,
+            "schemeAndroid": String,
+            "schemeIos": String,
+            "chatExtra": String,
+            "chatEvent": String,
+            "bizFormKey": String
+          }
+        ],
+        "coupon": {
+          "title": String,
+          "description": String,
+          "linkMo": String,
+          "linkPc": String,
+          "schemeAndroid": String,
+          "schemeIos": String
+        }
+      },
+      {
+        "header": String,
+        "message": String,
+        "imageUrl": String,
+        "imageLink": String,
+        "buttons": [
+          {
+            "name": String,
+            "type": String,
+            "linkMo": String,
+            "linkPc": String,
+            "schemeAndroid": String,
+            "schemeIos": String,
+            "chatExtra": String,
+            "chatEvent": String,
+            "bizFormKey": String
+          }
+        ],
+        "coupon": {
+          "title": String,
+          "description": String,
+          "linkMo": String,
+          "linkPc": String,
+          "schemeAndroid": String,
+          "schemeIos": String
+        }
+      }
+    ],
+    "tail": {
+      "linkMo": String,
+      "linkPc": String,
+      "schemeAndroid": String,
+      "schemeIos": String
+    }
+  },
+  "recipientList": [
+    {
+      "recipientNo": String,
+      "resendParameter": {
+          "isResend": boolean,
+          "resendType": String,
+          "resendTitle": String,
+          "resendContent": String,
+          "resendSendNo": String,
+          "resendUnsubscribeNo": String
+      }
+    }
+  ],
+  "createUser": String,
+  "statsId": String
+}
+```
+
+| 名前                   | タイプ    | 必須 | 説明                                                                                                                                                                                                                                                                          |
+|------------------------|---------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| senderKey              | String  | O  | 発信キー(40文字). グループ発信キーは使用不可                                                                                                                                                                                                                                                     |
+| chatBubbleType         | String  | O  | メッセージタイプ(TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)                                                                                                                                                                         |
+| pushAlarm | boolean | X | メッセージプッシュ通知の送信有無(デフォルト: true) |
+| adult                  | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                                                                       |
+| carousel               | Object  | O  | カルーセル                                                                                                                                                                                                                                                                         |
+| - list | List | O | カルーセルリスト(最小2件、最大6件) |
+| -- header | String | O | カルーセルアイテムのタイトル(最大20文字)。カルーセルフィード形式でのみ使用可能 |
+| -- message | String | O | カルーセルアイテムのタイトル(最大20文字)、カルーセルアイテムのメッセージ(最大180文字)。カルーセルフィード形式でのみ使用可能 |
+| -- imageUrl | String | O | 画像URL(カルーセルフィード形式の画像としてアップロードされた画像のみ使用可能) |
+| -- imageLink           | String  | X  | 画像リンク、1,000文字制限                                                                                                                                                                                                                                                            |
+| -- buttons | List | O | カルーセルリストのボタンリスト最小1件、最大2件 |
+| --- name | String | O | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字 |
+| --- type | String | O | ボタンタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- BTタイプはカカオオープンビルダーのチャットボットを使用するチャンネルのみ利用可能<br>- BFタイプは最初のボタンとしてのみ使用でき、nameには以下の3つのフレーズのみ使用可能<br> - トークで予約する<br> - トークでアンケートする<br> - トークで応募する |
+| --- linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド)、1,000文字制限 |
+| --- linkPc | String | X | PC Webリンク(WLタイプの場合、任意フィールド)、1,000文字制限 |
+| --- schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限 |
+| --- schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限 |
+| --- chatExtra          | String  | X  | BTタイプのボタンの場合、伝達するメタ情報                                                                                                                                                                                                                                                 |
+| --- chatEvent          | String  | X  | BTタイプのボタンの場合、接続するボットイベント名                                                                                                                                                                                                                                                     |
+| --- bizFormKey | String | X | BFタイプのボタンの場合、ビズフォームキー |
+| -- coupon              | Object  | X  | クーポン要素                                                                                                                                                                                                                                                                       |
+| --- title | String | O | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」 |
+| --- description | String | O | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字、改行:不可<br>- その他のタイプの場合、最大12文字、改行:不可 |
+| --- linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
+| --- linkPc | String | X | PC Webリンク(WLタイプの場合、任意フィールド)、1,000文字制限 |
+| --- schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
+| --- schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
+| - tail | Object | X | もっと見るボタン情報 |
+| -- linkMo              | String  | O  | モバイルWebリンク、1,000文字制限                                                                                                                                                                                                                                                         |
+| -- linkPc              | String  | X  | PC Webリンク、1,000文字制限                                                                                                                                                                                                                                                          |
+| -- schemeAndroid       | String  | X  | Androidアプリリンク、1,000文字制限                                                                                                                                                                                                                                                       |
+| -- schemeIos           | String  | X  | iOSアプリリンク、1,000文字制限                                                                                                                                                                                                                                                         |
+| recipientList          | List    | O  | 受信者リスト(最大1,000人)                                                                                                                                                                                                                                                             |
+| - recipientNo          | String  | O  | 受信番号                                                                                                                                                                                                                                                                       |
+| - resendParameter      | Object  | X  | 代替送信情報                                                                                                                                                                                                                                                                    |
+| -- isResend | boolean | X | 送信に失敗した場合、メッセージを代替送信するかどうか<br>コンソールで代替送信を設定した場合、基本設定として代替送信されます。 |
+| -- resendType | String | X | 代替送信タイプ(SMS、LMS)<br>値がない場合、テンプレート本文の長さに応じてタイプが区分されます。 |
+| -- resendTitle | String | X | LMS代替送信の件名<br>(値がない場合、プラスフレンドIDで代替送信されます。) |
+| -- resendContent | String | X | 代替送信の内容<br>(値がない場合、[メッセージ本文]で代替送信されます。) |
+| -- resendSendNo | String | X | 代替送信の送信者番号<br><span style="color:red">(SMSサービスに登録されている送信者番号ではない場合、代替送信に失敗することがあります。)</span> |
+| -- resendUnsubscribeNo | String | X | 代替送信080受信拒否番号<br><span style="color:red">(SMSサービスに登録された080受信拒否番号ではない場合、代替送信に失敗することがあります。)</span> |
+| createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
+| statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
+
+<a id="request-to-send-carousel-commerce-type"></a>
+
+#### カルーセルコマース形式の送信リクエスト
+
+##### カルーセル固定置換パラメータ(pathベースのテンプレートパラメータ)
+
+カルーセルタイプにおいて、各アイテムに異なる置換パラメータ値を適用できます。
+
+* **使用形式**：`キー@$.carousel.list[インデックス]`(例：`productName@$.carousel.list[0]`)
+* head(カルーセルイントロ)がある場合、headが`list[0]`を占め、実際のアイテムは`list[1]`から開始します。
+* pathベースのキーで値が見つからない場合、一般的なキーにフォールバックされます。
+
+| 区分 | 置換可能なフィールド | path形式 |
+|------|--------------|----------|
+| カルーセルイントロ(head) | header, content, linkMo, linkPc, schemeAndroid, schemeIos | `キー@$.carousel.list[0]`(head存在時) |
+| カルーセルアイテム | header, message, additionalContent | `キー@$.carousel.list[インデックス]` |
+| カルーセルアイテムのボタン | linkMo, linkPc, schemeAndroid, schemeIos | `キー@$.carousel.list[インデックス]` |
+| カルーセルアイテムのクーポン | title, description, linkMo, linkPc, schemeAndroid, schemeIos | `キー@$.carousel.list[インデックス]` |
+| カルーセルアイテムのコマース | title | `キー@$.carousel.list[インデックス]` |
+
+* **Tail**：置換パラメータ使用不可
+* ボタンのインデックスはpathに含まれません。同じアイテム内のボタンは同じpath値で置換されます。
+
+> **注意** 置換パラメータのキー(`#{key}`)には`@`文字を使用できません。`@`はシステムでpathの区切り文字として使用されます。
+
+[Request body]
+
+```
+{
+  "senderKey": String,
+  "chatBubbleType": "CAROUSEL_COMMERCE",
+  "pushAlarm": boolean,
+  "adult": boolean,
+  "carousel": {
+    "head": {
+      "header": String,
+      "content": String,
+      "imageUrl": String,
+      "linkMo": String,
+      "linkPc": String,
+      "schemeAndroid": String,
+      "schemeIos": String
+    },
+    "list": [
+      {
+        "additionalContent": String,
+        "imageUrl": String,
+        "imageLink": String,
+        "buttons": [
+          {
+            "name": String,
+            "type": String,
+            "linkMo": String,
+            "linkPc": String,
+            "schemeAndroid": String,
+            "schemeIos": String,
+            "chatExtra": String,
+            "chatEvent": String,
+            "bizFormKey": String
+          }
+        ],
+        "coupon": {
+          "title": String,
+          "description": String,
+          "linkMo": String,
+          "linkPc": String,
+          "schemeAndroid": String,
+          "schemeIos": String
+        },
+        "commerce": {
+          "title": String,
+          "regularPrice": Integer,
+          "discountPrice": Integer,
+          "discountRate": Integer,
+          "discountFixed": Integer
+        },
+      }
+    ],
+    "tail": {
+      "linkMo": String,
+      "linkPc": String,
+      "schemeAndroid": String,
+      "schemeIos": String
+    }
+  },
+  "recipientList": [
+    {
+      "recipientNo": String,
+      "resendParameter": {
+          "isResend": boolean,
+          "resendType": String,
+          "resendTitle": String,
+          "resendContent": String,
+          "resendSendNo": String,
+          "resendUnsubscribeNo": String
+      }
+    }
+  ],
+  "createUser": String,
+  "statsId": String
+}
+```
+
+| 名前                 | タイプ    | 必須 | 説明                                                                                                                                                                                                                                                                          |
+|----------------------|---------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| senderKey | String | O  | 送信キー(40文字)、グループ送信キーは使用不可 |
+| chatBubbleType | String | O  | メッセージタイプ(TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE) |
+| pushAlarm | boolean | X  | メッセージプッシュ通知の送信有無(デフォルト: true) |
+| adult                | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                                                                       |
+| carousel             | Object  | O  | カルーセル                                                                                                                                                                                                                                                                         |
+| - head               | Object  | X  | カルーセルイントロ                                                                                                                                                                                                                                                                     |
+| -- header            | String  | O  | カルーセルイントロヘッダ(最大20文字)                                                                                                                                                                                                                                                            |
+| -- content           | String  | O  | カルーセルイントロ内容(最大50文字)                                                                                                                                                                                                                                                            |
+| -- imageUrl | String | O  | カルーセルイントロ画像アドレス(カルーセルコマース形式の画像としてアップロードされた画像を使用、使用される画像はカルーセルの画像と比率が同じである必要があります) |
+| -- linkMo | String | X  | モバイルWebリンク(linkMo、linkPc、schemeAndroid、schemeIosのいずれかを使用する場合、linkMoは必須値)、1,000文字制限 |
+| -- linkPc            | String  | X  | PC Webリンク、1,000文字制限                                                                                                                                                                                                                                                         |
+| -- schemeAndroid     | String  | X  | Androidアプリリンク、1,000文字制限                                                                                                                                                                                                                                                       |
+| -- schemeIos         | String  | X  | iOSアプリリンク、1,000文字制限                                                                                                                                                                                                                                                         |
+| - list | List | O  | カルーセルリスト(headが存在する場合、最小1件、最大5件 / それ以外は最小2件、最大6件) |
+| -- additionalContent | String | X  | 付加情報(最大34文字)、カルーセルコマース形式でのみ使用可能 |
+| -- imageUrl | String | O  | 画像URL (カルーセルコマース形式の画像としてアップロードされた画像を使用) |
+| -- imageLink         | String  | X  | 画像リンク、1,000文字制限                                                                                                                                                                                                                                                            |
+| -- commerce | Object | O  | コマース(CAROUSEL_COMMERCEタイプでのみ使用可能) |
+| --- title            | String  | O  | 商品名(最大30文字、改行:不可)                                                                                                                                                                                                                                                       |
+| --- regularPrice | Integer | O  | 通常価格(0～99,999,999) |
+| --- discountPrice | Integer | X  | 割引価格(0 ～ 99,999,999) |
+| --- discountRate | Integer | X  | 割引率(0 ～ 100)、割引価格が存在する場合、割引率、定額割引価格のいずれかは必須 |
+| --- discountFixed | Integer | X  | 定額割引価格(0 ～ 999,999)、割引価格が存在する場合、割引率、定額割引価格のいずれかは必須 |
+| -- buttons           | List    | O  | カルーセルリストボタンリスト最小1件、最大2件                                                                                                                                                                                                                                                  |
+| --- name | String | O  | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合は最大14文字<br>- それ以外のタイプの場合は最大8文字 |
+| --- type | String | O  | ボタンのタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- BTタイプはカカオオープンビルダーのチャットボットを使用するチャンネルのみ利用可能<br>- BFタイプは最初のボタンとしてのみ使用でき、nameには次の3つの文言のみ使用可能<br> - トークで予約する<br> - トークでアンケートする<br> - トークで応募する |
+| --- linkMo | String | X  | モバイルWebリンク(WLタイプの場合は必須フィールド)、1,000文字制限 |
+| --- linkPc | String | X  | PC Webリンク(WLタイプの場合は任意フィールド)、1,000文字制限 |
+| --- schemeAndroid | String | X  | Androidアプリリンク(ALタイプの場合は必須フィールド)、1,000文字制限 |
+| --- schemeIos | String | X  | iOSアプリリンク(ALタイプの場合は必須フィールド)、1,000文字制限 |
+| --- chatExtra | String | X  | BTタイプのボタンの場合に転送するメタ情報 |
+| --- chatEvent | String | X  | BTタイプのボタンの場合に接続するボットのイベント名 |
+| --- bizFormKey | String | X  | BFタイプのボタンの場合のビズフォームキー |
+| -- coupon            | Object  | X  | クーポン要素                                                                                                                                                                                                                                                                       |
+| --- title | String | O  | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」 |
+| --- description | String | O  | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合は最大18文字、改行：不可<br>- それ以外のタイプの場合は最大12文字、改行：不可 |
+| --- linkMo | String | X  | モバイルWebリンク(WLタイプの場合は必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは選択事項(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式：alimtalk=coupon://)を入力する場合、残りのフィールドが選択事項(オプション)になります。 |
+| --- linkPc | String | X  | PC Webリンク(WLタイプの場合は任意フィールド)、1,000文字制限 |
+| --- schemeAndroid | String | X  | Androidアプリリンク(ALタイプの場合は必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは選択事項(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式：alimtalk=coupon://)を入力する場合、残りのフィールドが選択事項(オプション)になります。 |
+| --- schemeIos | String | X  | iOSアプリリンク(ALタイプの場合は必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは選択事項(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式：alimtalk=coupon://)を入力する場合、残りのフィールドが選択事項(オプション)になります。 |
+| - tail | Object | X  | もっと見るボタンの情報 |
+| -- linkMo            | String  | O  | モバイルWebリンク、1,000文字制限                                                                                                                                                                                                                                                         |
+| -- linkPc            | String  | X  | PC Webリンク、1,000文字制限                                                                                                                                                                                                                                                          |
+| -- schemeAndroid     | String  | X  | Androidアプリリンク、1,000文字制限                                                                                                                                                                                                                                                       |
+| -- schemeIos         | String  | X  | iOSアプリリンク、1,000文字制限                                                                                                                                                                                                                                                         |
+| recipientList        | List    | O  | 受信者リスト(最大1,000人)                                                                                                                                                                                                                                                             |
+| - recipientNo        | String  | O  | 受信番号                                                                                                                                                                                                                                                                       |
+| - resendParameter    | Object  | X  | 代替送信情報                                                                                                                                                                                                                                                                    |
+| -- isResend | boolean | X  | 送信失敗時に、テキストメッセージで代替送信するかどうか<br>コンソールで代替送信を設定した場合、デフォルトで代替送信されます。 |
+| -- resendType | String | X  | 代替送信タイプ(SMS、LMS)<br>値がない場合、テンプレートの本文の長さに応じてタイプが区別されます。 |
+| -- resendTitle | String | X  | LMS代替送信の件名<br>(値がない場合、プラスフレンドIDで代替送信されます。) |
+| -- resendContent | String | X  | 代替送信の内容<br>(値がない場合、[メッセージ本文]で代替送信されます。) |
+| -- resendSendNo | String | X  | 代替送信の送信者番号<br><span style="color:red">(SMSサービスに登録された送信者番号でない場合、代替送信に失敗することがあります。)</span> |
+| createUser | String | X  | 登録者(コンソールで送信時にユーザーUUIDとして保存) |
+| statsId | String | X  | 統計ID(送信検索条件には含まれません、最大8文字) |
+
+<a id="response-3"></a>
+
+#### レスポンス
+
+```
+{
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
+  },
+  "message": {
+    "requestId": String,
+    "sendResults": [
+      {
+        "recipientSeq": Integer,
+        "recipientNo": String,
+        "resultCode": Integer,
+        "resultMessage": String
+      }
+    ]
+  }
+}
+```
+
+| 名前             | タイプ    | Not Null | 説明                                                         |
+|:-----------------|:--------|:---------|:-------------------------------------------------------------|
+| header           | Object  | O        | レスポンスヘッダ情報                                                   |
+| - isSuccessful   | boolean | O        | API呼び出し成否                                               |
+| - resultCode | Integer | O | API呼び出し結果コード(成功：0、失敗時はエラーコード) |
+| - resultMessage | String | O | API呼び出し結果メッセージ(成功時は「success」または関連する成功メッセージ、失敗時は失敗原因の詳細メッセージ) |
+| message | Object | X | メッセージ送信結果情報(送信リクエストがある場合にのみ存在) |
+| - requestId | String | X | 送信リクエストID(各送信リクエストを一意に識別するID) |
+| - sendResults | Array | O | 受信者別の送信結果リスト |
+| -- recipientSeq | Integer | O | 受信者リストの順番 |
+| -- recipientNo | String | X | 受信者の電話番号 |
+| -- resultCode | Integer | O | 受信者別の送信結果コード(成功及び様々な失敗コードが存在する可能性があります) |
+| -- resultMessage | String | O | 受信者別の送信結果メッセージ(成功時は「success」または関連メッセージ、失敗時は失敗原因の詳細メッセージ) |
+
+<a id="request-to-send-basic-message"></a>
+
+## メッセージ基本形送信リクエスト
+
+* テンプレートを利用した送信です。
+* 広告やプロモーション情報を受け取ることに同意したユーザーに対してメッセージ送信を使用できます。
+    * targetingフィールドを指定して、メッセージ対象のタイプを指定できます。
+        * M: 顧客企業の広告性情報受信に同意したユーザー(カカオトークでの受信に同意)
+        * N: 顧客企業の広告性情報受信に同意したユーザー(カカオトークでの受信に同意) - チャネルの友だち
+        * I: 顧客企業の送信リクエスト対象 ∩ チャネルの友だち
+* 既存カカともへのメッセージの8つのメッセージタイプを全て使用できます。
+* BTボタンタイプは使用できません。
+* AC(チャンネル追加)ボタンを使用できます。
+* BFボタンを使用する場合、カカオから発行されたビジネスフォームIDをアップロードしてビズフォームキーを発行して使用できます。
+* 代替送信は、受信者ごとにresendParameterを介して設定できます。
+* 代替送信をご利用になる場合、代替送信管理APIを介してSMS Appkeyの登録及び送信設定が必要です。
+* **夜間送信制限(20:50～翌日08:00)**
+
+<a id="cautions-for-use"></a>
+
+### 使用時の注意事項
+
+- unsubscribeNo、unsubscribeAuthNoは080無料受信拒否電話番号と認証番号で、どちらか一方でも入力しない場合は、送信プロフィールに登録された無料受信拒否情報で送信されます。
+- 送信時にunsubscribeNo、unsubscribeAuthNoを入力すると、送信プロフィールに登録されている無料受信拒否情報ではなく、入力した値で送信されます。
+- 送信時にunsubscribeNo、unsubscribeAuthNoを入力しない場合、送信プロフィールに登録されている無料受信拒否情報で送信されます。
+- unsubscribeNo、unsubscribeAuthNoは受信者ごとに入力でき、共通フィールドと受信者ごとフィールドの両方を入力した場合、共通フィールドが優先的に適用されます。
+
+[URL]
+
+```
+POST  /brand-message/v1.0/appkeys/{appkey}/basic-messages
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 名前   | タイプ   | 説明   |
+|--------|--------|--------|
+| appkey | String | 固有のアプリキー |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前         | タイプ   | 必須 | 説明             |
+|--------------|--------|----|------------------|
+| X-Secret-Key | String | O  | コンソールで作成できます。 |
+
+<a id="requested-4"></a>
+
+#### 送信リクエスト
+
+```
+{
+  "senderKey": String,
+  "templateCode": String,
+  "pushAlarm": boolean,
+  "unsubscribeNo": String,
+  "unsubscribeAuthNo": String,
+  "recipientList": [
+    {
+      "recipientNo": String,
+      "targeting": String,
+      "templateParameter": Object,
+      "imageParameters": List,
+      "videoParameter": Object,
+      "resendParameter": {
+          "isResend": boolean,
+          "resendType": String,
+          "resendTitle": String,
+          "resendContent": String,
+          "resendSendNo": String,
+          "resendUnsubscribeNo": String
+      },
+      "unsubscribeNo": String,
+      "unsubscribeAuthNo": String,
+      "recipientGroupingKey": String
+    }
+  ],
+  "senderGroupingKey": String,
+  "resellerCode": String,
+  "createUser": String,
+  "statsId": String
+}
+```
+
+| 名前                     | タイプ      | 必須 | 説明                                                                                                                                                                                                                                     |
+|------------------------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| senderKey              | String  | O  | 送信キー(40文字)、グループ送信キーは使用不可                                                                                                                                                                                                                |
+| templateCode           | String  | O  | 使用するテンプレートコード                                                                                                                                                                                                                           |
+| pushAlarm              | boolean | X  | メッセージのプッシュ通知送信有無(デフォルト値：true)                                                                                                                                                                                                              |
+| requestDate            | String  | X  | リクエスト日時(yyyy-MM-dd HH:mm)<br>(入力しない場合は即時送信)<br>最大60日後まで予約可能                                                                                                                                                                     |
+| unsubscribeNo          | String  | X  | 080無料受信拒否電話番号(全て未入力の場合は送信プロファイルに登録された無料受信拒否情報で送信される)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx                                                                                                           |
+| unsubscribeAuthNo      | String  | X  | 080無料受信拒否認証番号(全て未入力の場合は送信プロファイルに登録された無料受信拒否情報で送信される)<br>unsubscribe_phone_numberなしでunsubscribe_auth_numberのみの入力は不可<br>例：1234                                                                                                           |
+| recipientList          | List    | O  | 受信者一覧(最大1,000名)                                                                                                                                                                                                                       |
+| - recipientNo          | String  | O  | 受信番号                                                                                                                                                                                                                                  |
+| - targeting            | String  | O  | メッセージ対象のタイプ(M：マーケティング受信同意ユーザー、N：友だちではないマーケティング受信同意ユーザーのみ、I：友だちのユーザー)                                                                                                                                                                       |
+| - templateParameter    | Object  | X  | テンプレートパラメータ(テンプレートに置換する変数が含まれる場合は必須)<br>- カルーセルタイプ：アイテムごとに異なる置換パラメータ値を適用する場合は`キー@$.carousel.list[インデックス]`形式を使用(例：`productName@$.carousel.list[0]`)<br>- headがある場合はheadがlist[0]を占め、実際のアイテムはlist[1]から開始<br>- 置換パラメータのキーに`@`文字は使用不可<br>- キー/値はそれぞれ最大1,300文字 |
+| - imageParameters      | List    | X  | テンプレートの画像フィールド値を変更できる動的パラメータ(テンプレートに存在する画像数と同じサイズのJSONリストのみ使用可能。使用する場合、変更しない画像には空のJSONオブジェクトを入力する必要がある)                                                                                                                       |
+| -- imageUrl            | String  | O  | 画像URL                                                                                                                                                                                                                                 |
+| -- imageLink           | String  | X  | 画像リンク                                                                                                                                                                                                                                 |
+| - videoParameter       | Object  | X  | テンプレートの動画フィールド値を変更できる動的パラメータ                                                                                                                                                                                                         |
+| -- videoUrl            | String  | O  | カカオTV動画URL                                                                                                                                                                                                                           |
+| -- thumbnailUrl        | String  | X  | 動画サムネイル用の画像URL                                                                                                                                                                                                                        |
+| - resendParameter      | Object  | X  | 代替送信情報                                                                                                                                                                                                                               |
+| -- isResend            | boolean | X  | 送信失敗時、メッセージの代替送信有無<br>コンソールで代替送信を設定した場合、デフォルトで代替送信されます。                                                                                                                                                                                 |
+| -- resendType          | String  | X  | 代替送信タイプ(SMS、LMS)<br>値がない場合、テンプレートの本文の長さに応じてタイプが区別されます。                                                                                                                                                                                 |
+| -- resendTitle         | String  | X  | LMS代替送信のタイトル<br>(値がない場合、プラス友だちIDで代替送信されます。)                                                                                                                                                                                         |
+| -- resendContent       | String  | X  | 代替送信の内容<br>(値がない場合、[メッセージ本文]で代替送信されます。)                                                                                                                                                                                            |
+| -- resendSendNo        | String  | X  | 代替送信の送信番号<br><span style="color:red">(SMSサービスに登録された送信番号ではない場合、代替送信に失敗する可能性があります。)</span>                                                                                                                                           |
+| - unsubscribeNo        | String  | X  | 080無料受信拒否電話番号(全て未入力の場合は送信プロファイルに登録された無料受信拒否情報で送信される)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx                                                                                                           |
+| - unsubscribeAuthNo    | String  | X  | 080無料受信拒否認証番号(全て未入力の場合は送信プロファイルに登録された無料受信拒否情報で送信される)<br>unsubscribe_phone_numberなしでunsubscribe_auth_numberのみの入力は不可<br>例：1234                                                                                                           |
+| - recipientGroupingKey | String | X | 受信者グルーピングキー(受信者ごとにグルーピングキーを指定できます。最大100文字) |
+| senderGroupingKey | String | X | 送信者グルーピングキー(送信者ごとにグルーピングキーを指定できます。最大100文字) |
+| resellerCode | String | X | リセラーコード(リセラーが送信時に使用) |
+| createUser | String | X | 登録者(コンソールから送信時、ユーザーUUIDとして保存) |
+| statsId | String | X | 統計ID(送信検索条件には含まれません。最大8文字) |
+
+<a id="response-4"></a>
+
+#### レスポンス
+
+```
+{
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
+  },
+  "message": {
+    "requestId": String,
+    "sendResults": [
+      {
+        "recipientSeq": Integer,
+        "recipientNo": String,
+        "resultCode": Integer,
+        "resultMessage": String
+      }
+    ]
+  }
+}
+```
+
+| 名前             | タイプ    | Not Null | 説明                                                         |
+|:-----------------|:--------|:---------|:-------------------------------------------------------------|
+| header           | Object  | O        | レスポンスヘッダ情報                                                   |
+| - isSuccessful   | boolean | O        | API呼び出し成否                                               |
+| - resultCode | Integer | O | API呼び出し結果コード(成功：0、失敗時はエラーコード) |
+| - resultMessage | String | O | API呼び出し結果メッセージ(成功時は「success」または関連する成功メッセージ、失敗時は失敗原因の詳細メッセージ) |
+| message | Object | X | メッセージ送信結果情報(送信リクエストがある場合にのみ存在) |
+| - requestId | String | X | 送信リクエストID(各送信リクエストを一意に識別するID) |
+| - sendResults | Array | O | 受信者別の送信結果リスト |
+| -- recipientSeq | Integer | O | 受信者リストの順番 |
+| -- recipientNo | String | X | 受信者の電話番号 |
+| -- resultCode | Integer | O | 受信者別の送信結果コード(成功及び様々な失敗コードが存在する可能性があります) |
+| -- resultMessage | String | O | 受信者別の送信結果メッセージ(成功時は「success」または関連メッセージ、失敗時は失敗原因の詳細メッセージ) |
+
+<a id="view-sending-list"></a>
+
+## 送信リストの照会
+
+<a id="requested-5"></a>
+
+#### リクエスト
+
+[URL]
+
+```
+GET  /brand-message/v1.0/appkeys/{appkey}/messages
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 名前   | タイプ   | 説明   |
+|--------|--------|--------|
+| appkey | String | 固有のアプリキー |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前         | タイプ   | 必須 | 説明             |
+|--------------|--------|----|------------------|
+| X-Secret-Key | String | O  | コンソールで作成できます。 |
+
+[Query parameter] 1番or 2番の条件が必須
+
+| 名前             | タイプ   | 必須      | 説明                             |
+|------------------|--------|-----------|----------------------------------|
+| requestId | String | 条件付き必須(1番) | リクエストID |
+| startRequestDate | String | 条件付き必須(2番) | 送信リクエスト日付の開始値(yyyy-MM-dd HH:mm) |
+| endRequestDate | String | 条件付き必須(2番) | 送信リクエスト日付の終了値(yyyy-MM-dd HH:mm) |
+| senderKey        | String | X         | 発信キー                           |
+| templateCode     | String | X         | テンプレートコード                         |
+| recipientNo      | String | X         | 受信番号                          |
+| messageStatus | String | X | リクエストステータス(COMPLETED：成功、FAILED：失敗) |
+| resultCode       | String | X         | 送信結果(MRC01:成功MRC02:失敗)      |
+| pageNum          | String | X         | ページ番号(Default: 1)               |
+| pageSize | String | X | 照会件数(Default: 15、Max: 1,000) |
+
+<a id="response-5"></a>
+
+#### レスポンス
+
+```
+{
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
+  },
+  "messageSearchResultResponse": {
+    "messages": [
+      {
+        "requestId": String,
+        "recipientSeq": Integer,
+        "plusFriendId": String,
+        "senderKey": String,
+        "templateCode": String,
+        "recipientNo": String,
+        "targeting": String,
+        "requestDate": String,
+        "createDate": String,
+        "receiveDate": String,
+        "chatBubbleType": String,
+        "pushAlarm": boolean,
+        "messageStatus": String,
+        "resendStatusCode": String,
+        "resendStatusName": String,
+        "resendResultCode": String,
+        "resendRequestId": String,
+        "isAddedChannel": boolean,
+        "resultCode": String,
+        "resultCodeName": String,
+        "createUser": String
+      }
+    ],
+    "totalCount": Integer
+  }
+}
+```
+
+| 名前                        | タイプ    | Not Null | 説明                                                                  |
+|:----------------------------|:--------|:---------|:-----------------------------------------------------------------------|
+| header                      | Object  | O        | ヘッダ領域                                                               |
+| - resultCode                | Integer | O        | 結果コード                                                               |
+| - resultMessage             | String  | O        | 結果メッセージ                                                              |
+| - isSuccessful              | boolean | O        | 成否                                                               |
+| messageSearchResultResponse | Object  | X        | 本文領域                                                               |
+| - messages                  | Array   | O        | メッセージリスト                                                             |
+| -- requestId                | String  | O        | リクエストID                                                                 |
+| -- recipientSeq             | Integer | O        | 受信者シーケンス番号                                                          |
+| -- plusFriendId             | String  | O        | 送信プロフィールID                                                             |
+| -- senderKey                | String  | O        | 発信キー                                                                |
+| -- templateCode             | String  | X        | テンプレートコード                                                              |
+| -- recipientNo              | String  | O        | 受信番号                                                               |
+| -- targeting | String | O | メッセージ対象のタイプ(M - マーケティング受信同意ユーザー、N - 友だちではないマーケティング受信同意ユーザーにのみ、I - 友だちであるユーザー) |
+| -- requestDate              | String  | O        | リクエスト日時                                                               |
+| -- createDate               | String  | O        | 登録日時                                                               |
+| -- receiveDate              | String  | X        | 受信日時                                                               |
+| -- chatBubbleType           | String  | O        | メッセージタイプ                                                              |
+| -- pushAlarm | boolean | O | プッシュ通知を使用するかどうか |
+| -- messageStatus | String | O | リクエストステータス(COMPLETED：成功、FAILED：失敗) |
+| -- resendStatusCode         | String  | X        | 代替送信ステータスコード                                                         |
+| -- resendStatusName | String | X | 代替送信ステータス名 |
+| -- resendResultCode         | String  | X        | 代替送信結果コード                                                         |
+| -- resendRequestId          | String  | X        | 代替送信リクエストID                                                           |
+| -- isAddedChannel | boolean | O | チャンネルの友達かどうか |
+| -- resultCode               | String  | X        | 受信結果コード                                                            |
+| -- resultCodeName           | String  | X        | 受信結果コード名                                                           |
+| -- createUser | String | X | 登録者(コンソールで送信時にユーザーUUIDとして保存) |
+| - totalCount | Integer | O | 合計数 |
+
+<a id="view-single-sending"></a>
+
+## 送信単件照会
+
+<a id="requested-6"></a>
+
+#### リクエスト
+
+[URL]
+
+```
+GET  /brand-message/v1.0/appkeys/{appkey}/messages/{requestId}/{recipientSeq}
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 名前         | タイプ    | 説明       |
+|--------------|---------|------------|
+| appkey       | String  | 固有のアプリキー   |
+| requestId    | String  | リクエストID      |
+| recipientSeq | Integer | 受信者シーケンス番号 |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前         | タイプ   | 必須 | 説明             |
+|--------------|--------|----|------------------|
+| X-Secret-Key | String | O  | コンソールで作成できます。 |
+
+<a id="response-6"></a>
+
+#### レスポンス
+
+```
+{
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
+  },
+  "message": {
+    "requestId": String,
+    "recipientSeq": Integer,
+    "plusFriendId": String,
+    "senderKey": String,
+    "templateCode": String,
+    "recipientNo": String,
+    "targeting": String,
+    "requestDate": String,
+    "createDate": String,
+    "receiveDate": String,
+    "chatBubbleType": String,
+    "content": String,
+    "adult": boolean,
+    "header": String,
+    "additionalContent": String,
+    "image": {
+      "imageUrl": String,
+      "imageLink": String
+    },
+    "buttons": [
+      {
+        "name": String,
+        "type": String,
+        "linkMo": String,
+        "linkPc": String,
+        "schemeIos": String,
+        "schemeAndroid": String,
+        "chatExtra": String,
+        "chatEvent": String,
+        "bizFormKey": String
+      }
+    ],
+    "item": {
+      "list": [
+        {
+          "title": String,
+          "imageUrl": String,
+          "linkMo": String,
+          "linkPc": String,
+          "schemeIos": String,
+          "schemeAndroid": String
+        }
+      ]
+    },
+    "coupon": {
+      "title": String,
+      "description": String,
+      "linkMo": String,
+      "linkPc": String,
+      "schemeAndroid": String,
+      "schemeIos": String
+    },
+    "commerce": {
+      "title": String,
+      "regularPrice": Integer,
+      "discountPrice": Integer,
+      "discountRate": Integer,
+      "discountFixed": Integer
+    },
+    "video": {
+      "videoUrl": String,
+      "thumbnailUrl": String
+    },
+    "carousel": {
+      "head": {
+        "header": String,
+        "content": String,
+        "imageUrl": String,
+        "linkMo": String,
+        "linkPc": String,
+        "schemeIos": String,
+        "schemeAndroid": String
+      },
+      "list": [
+        {
+          "header": String,
+          "message": String,
+          "additionalContent": String,
+          "imageUrl": String,
+          "imageLink": String,
+          "commerce": {
+            "title": String,
+            "regularPrice": Integer,
+            "discountPrice": Integer,
+            "discountRate": Integer,
+            "discountFixed": Integer
+          },
+          "buttons": [
+            {
+              "name": String,
+              "type": String,
+              "linkMo": String,
+              "linkPc": String,
+              "schemeAndroid": String,
+              "schemeIos": String,
+              "chatExtra": String,
+              "chatEvent": String,
+              "bizFormKey": String
+            }
+          ],
+          "coupon": {
+            "title": String,
+            "description": String,
+            "linkMo": String,
+            "linkPc": String,
+            "schemeAndroid": String,
+            "schemeIos": String
+          }
+        }
+      ],
+      "tail": {
+        "linkMo": String,
+        "linkPc": String,
+        "schemeAndroid": String,
+        "schemeIos": String
+      }
+    },
+    "templateParameter": String,
+    "pushAlarm": boolean,
+    "messageStatus": String,
+    "isAddedChannel": boolean,
+    "resultCode": String,
+    "resultCodeName": String,
+    "resendStatusCode": String,
+    "resendStatusName": String,
+    "resendResultCode": String,
+    "resendRequestId": String,
+    "createUser": String
+  }
+}
+```
+
+| 名前                  | タイプ    | Not Null | 説明                                                                                             | 
+ |:----------------------|:--------|:---------|:-------------------------------------------------------------------------------------------------| 
+| header                | Object  | O        | ヘッダ領域                                                                                          | 
+| - resultCode          | Integer | O        | 結果コード                                                                                          | 
+| - resultMessage       | String  | O        | 結果メッセージ                                                                                         | 
+| - isSuccessful        | boolean | O        | 成否                                                                                          | 
+| message | Object | X | メッセージ本文領域(メッセージ失敗時は存在しない場合があります) |
+| - requestId | String | O | リクエストID(messageオブジェクトが存在する場合Not Null) |
+| - recipientSeq | Integer | O | 受信者シーケンス番号(messageオブジェクトが存在する場合Not Null) |
+| - plusFriendId | String | O | 送信プロフィールID(messageオブジェクトが存在する場合Not Null) |
+| - senderKey | String | O | 送信キー(messageオブジェクトが存在する場合Not Null) |
+| - templateCode        | String  | X        | テンプレートコード                                                                                         | 
+| - recipientNo | String | O | 受信番号(messageオブジェクトが存在する場合Not Null) |
+| - targeting | String | O | メッセージ対象のタイプ(M - マーケティング受信同意ユーザー、N - 友だちではないマーケティング受信同意ユーザーにのみ、I - 友だちであるユーザー)(messageオブジェクトが存在する場合Not Null) |
+| - requestDate | String | O | リクエスト日時(messageオブジェクトが存在する場合Not Null) |
+| - createDate | String | O | 登録日時(messageオブジェクトが存在する場合Not Null) |
+| - receiveDate         | String  | X        | 受信日時                                                                                          | 
+| - chatBubbleType      | String  | O        | メッセージタイプ(messageオブジェクトが存在する場合Not Null)                                                                | 
+| - content | String | X | メッセージの内容 |
+| - adult | boolean | O | 成人向けメッセージかどうか(messageオブジェクトが存在する場合Not Null) |
+| - header              | String  | X        | ヘッダ(メッセージ内)                                                                                       | 
+| - additionalContent   | String  | X        | 付加情報(メッセージ内)                                                                                    |
+| - image | Object | X | 画像要素 |
+| -- imageUrl | String | O | 画像のURL(imageオブジェクトが存在する場合Not Null) |
+| -- imageLink | String | X | 画像のリンク |
+| - buttons             | Array   | X        | ボタンリスト                                                                                          | 
+| --- name | String | O | ボタンのタイトル(buttons配列の項目が存在する場合Not Null) |
+| --- type | String | O | ボタンのタイプ(buttons配列の項目が存在する場合Not Null) |
+| -- linkMo             | String  | X        | モバイルWebリンク                                                                                       | 
+| -- linkPc             | String  | X        | PC Webリンク                                                                                        | 
+| -- schemeIos          | String  | X        | iOSアプリリンク                                                                                       | 
+| -- schemeAndroid      | String  | X        | Androidアプリリンク                                                                                     | 
+| --- chatExtra | String | X | BTタイプのボタンの場合に転送するメタ情報 |
+| --- chatEvent | String | X | BTタイプのボタンの場合に接続するボットのイベント名 |
+| --- bizFormKey | String | X | BFタイプのボタンの場合のビズフォームキー |
+| - item                | Object  | X        | ワイドリスト要素                                                                                     | 
+| -- list | Array | X | ワイドリスト(itemオブジェクトが存在する場合Nullable) |
+| --- title             | String  | X        | アイテムのタイトル                                                                                         | 
+| --- imageUrl | String | O | アイテム画像のURL(item.listの項目が存在する場合Not Null) |
+| --- linkMo | String | O | モバイルWebリンク(item.listの項目が存在する場合Not Null) |
+| --- linkPc            | String  | X        | PC Webリンク                                                                                        | 
+| --- schemeIos         | String  | X        | iOSアプリリンク                                                                                       | 
+| --- schemeAndroid     | String  | X        | Androidアプリリンク                                                                                     | 
+| - coupon              | Object  | X        | クーポン要素                                                                                          | 
+| -- title              | String  | O        | クーポンのタイトル(couponオブジェクトが存在する場合Not Null)                                                                  | 
+| -- description | String | O | クーポンの詳細説明(couponオブジェクトが存在する場合Not Null) |
+| -- linkMo             | String  | X        | モバイルWebリンク                                                                                       | 
+| -- linkPc             | String  | X        | PC Webリンク                                                                                        | 
+| -- schemeAndroid      | String  | X        | Androidアプリリンク                                                                                     | 
+| -- schemeIos          | String  | X        | iOSアプリリンク                                                                                       | 
+| - commerce            | Object  | X        | コマース要素                                                                                         | 
+| -- title              | String  | O        | 商品名(commerceオブジェクトが存在する場合Not Null)                                                                | 
+| -- regularPrice       | Integer | X        | 通常価格                                                                                          | 
+| -- discountPrice      | Integer | X        | 割引価格                                                                                           | 
+| -- discountRate       | Integer | X        | 割引率                                                                                            | 
+| -- discountFixed      | Integer | X        | 定額割引価格                                                                                         | 
+| - video               | Object  | X        | 動画要素                                                                                         | 
+| -- videoUrl | String | O | カカオTVの動画URL(videoオブジェクトが存在する場合Not Null) |
+| -- thumbnailUrl | String | X | 動画のサムネイル用画像のURL |
+| - carousel            | Object  | X        | カルーセル                                                                                            | 
+| -- head | Object | X | カルーセルのイントロ(carouselオブジェクトが存在する場合Nullable) |
+| --- header | String | O | カルーセルのイントロヘッダ(headオブジェクトが存在する場合Not Null) |
+| --- content | String | O | カルーセルのイントロ内容(headオブジェクトが存在する場合Not Null) |
+| --- imageUrl | String | O | カルーセルのイントロ画像のURL(headオブジェクトが存在する場合Not Null) |
+| --- linkMo            | String  | X        | モバイルWebリンク                                                                                       | 
+| --- linkPc            | String  | X        | PC Webリンク                                                                                        | 
+| --- schemeIos         | String  | X        | iOSアプリリンク                                                                                       | 
+| --- schemeAndroid     | String  | X        | Androidアプリリンク                                                                                     | 
+| -- list               | Array   | O        | カルーセルリスト(carouselオブジェクトが存在する場合Not Null)                                                              | 
+| --- header | String | X | カルーセルアイテムのヘッダ |
+| --- message | String | O | カルーセルアイテムのメッセージ(listの項目が存在する場合Not Null) |
+| --- additionalContent | String  | X        | 付加情報                                                                                          | 
+| --- imageUrl | String | X | 画像のURL |
+| --- imageLink | String | X | 画像のリンク |
+| --- commerce | Object | X | コマース(カルーセル内) |
+| ---- title | String | O | 商品のタイトル(carousel.list.commerceが存在する場合Not Null) |
+| ---- regularPrice     | Integer | X        | 通常価格                                                                                          | 
+| ---- discountPrice    | Integer | X        | 割引価格                                                                                           | 
+| ---- discountRate     | Integer | X        | 割引率                                                                                            | 
+| ---- discountFixed    | Integer | X        | 定額割引価格                                                                                         | 
+| --- buttons           | Array   | X        | ボタンリスト(カルーセル内)                                                                                    | 
+| ---- name | String | O | ボタンのタイトル(carousel.list.buttonsの項目が存在する場合Not Null) |
+| ---- type | String | O | ボタンのタイプ(carousel.list.buttonsの項目が存在する場合Not Null) |
+| ---- linkMo           | String  | X        | モバイルWebリンク                                                                                       | 
+| ---- linkPc           | String  | X        | PC Webリンク                                                                                        | 
+| ---- schemeAndroid    | String  | X        | Androidアプリリンク                                                                                     | 
+| ---- schemeIos        | String  | X        | iOSアプリリンク                                                                                       | 
+| ---- chatExtra | String | X | BTタイプのボタンの場合に転送するメタ情報 |
+| ---- chatEvent | String | X | BTタイプのボタンの場合に接続するボットのイベント名 |
+| ---- bizFormKey | String | X | BFタイプのボタンの場合のビズフォームキー |
+| --- coupon | Object | X | クーポン(カルーセル内) |
+| ---- title | String | O | クーポンの件名(carousel.list.couponが存在する場合Not Null) |
+| ---- description | String | O | クーポンの詳細説明(carousel.list.couponが存在する場合Not Null) |
+| ---- linkMo           | String  | X        | モバイルWebリンク                                                                                       | 
+| ---- linkPc           | String  | X        | PC Webリンク                                                                                        | 
+| ---- schemeAndroid    | String  | X        | Androidアプリリンク                                                                                     | 
+| ---- schemeIos        | String  | X        | iOSアプリリンク                                                                                       | 
+| -- tail | Object | X | もっと見るボタンの情報(carouselオブジェクトが存在する場合Nullable) |
+| --- linkMo | String | O | モバイルWebリンク(tailオブジェクトが存在する場合Not Null) |
+| --- linkPc            | String  | X        | PC Webリンク                                                                                        | 
+| --- schemeAndroid     | String  | X        | Androidアプリリンク                                                                                     | 
+| --- schemeIos         | String  | X        | iOSアプリリンク                                                                                       | 
+| - templateParameter   | String  | X        | テンプレートパラメータ                                                                                       | 
+| - pushAlarm | boolean | O | プッシュ通知を使用するかどうか(messageオブジェクトが存在する場合Not Null) |
+| - messageStatus | String | O | リクエストステータス(COMPLETED：成功、FAILED：失敗)(messageオブジェクトが存在する場合Not Null) |
+| - isAddedChannel | boolean | O | チャンネルの友だちかどうか(messageオブジェクトが存在する場合Not Null) |
+| - resultCode          | String  | X        | 受信結果コード(メッセージ内)                                                                                 | 
+| - resultCodeName      | String  | X        | 受信結果コード名(メッセージ内)                                                                                | 
+| - resendStatusCode    | String  | X        | 代替送信ステータスコード                                                                                    | 
+| - resendStatusName    | String  | X        | 代替送信ステータスコード名                                                                                   | 
+| - resendResultCode    | String  | X        | 代替送信結果コード                                                                                    | 
+| - resendRequestId     | String  | X        | 代替送信リクエストID                                                                                      | 
+| - createUser          | String  | X        | 登録者(コンソールから送信した場合、ユーザーUUIDで保存)                                                                      |
+
+<a id="cancel-message-sending"></a>
+
+## メッセージ送信取消
+
+<!-- TODO: translate body -->
+
+<a id="requested-7"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="response-7"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="manage-templates"></a>
+
+## テンプレート管理
+
+<a id="view-template-list"></a>
+
+### テンプレートリスト照会
+
+<a id="requested-8"></a>
+
+#### リクエスト
+
+[URL]
+
+```
+GET  /brand-message/v1.0/appkeys/{appkey}/senders/{senderKey}/templates
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 名前      | タイプ   | 説明   |
+|-----------|--------|--------|
+| appkey    | String | 固有のアプリキー |
+| senderKey | String | 発信キー |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前         | タイプ   | 必須 | 説明             |
+|--------------|--------|----|------------------|
+| X-Secret-Key | String | O  | コンソールで作成できます。 |
+
+[Query parameter]
+
+| 名前         | タイプ    | 必須 | 説明                          |
+|--------------|---------|----|-------------------------------|
+| templateCode | String  | X  | テンプレートコード                      |
+| templateName | String  | X  | テンプレート名                      |
+| status       | String  | X  | テンプレートステータスコード                   |
+| pageNum      | Integer | X  | ページ番号(Default: 1)            |
+| pageSize     | Integer | X  | 照会件数(Default: 15, Max: 1,000) |
+
+<a id="response-8"></a>
+
+#### レスポンス
+
+```
+{
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
+  },
+  "templateListResponse": {
+    "templates": [
+      {
+        "plusFriendId": String,
+        "plusFriendType": String,
+        "templateCode": String,
+        "templateName": String,
+        "chatBubbleType": String,
+        "content": String,
+        "header": String,
+        "additionalContent": String,
+        "adult": boolean,
+        "image": {
+          "imageUrl": String,
+          "imageLink": String
+        },
+        "buttons": [
+          {
+            "name": String,
+            "type": String,
+            "linkMo": String,
+            "linkPc": String,
+            "schemeIos": String,
+            "schemeAndroid": String,
+            "bizFormId": Integer,
+          }
+        ],
+        "item": {
+          "list": [
+            {
+              "title": String,
+              "imageUrl": String,
+              "linkMo": String,
+              "linkPc": String,
+              "schemeAndroid": String,
+              "schemeIos": String
+            }
+          ]
+        },
+        "coupon": {
+          "title": String,
+          "description": String,
+          "linkMo": String,
+          "linkPc": String,
+          "schemeAndroid": String,
+          "schemeIos": String
+        },
+        "commerce": {
+          "title": String,
+          "regularPrice": Integer,
+          "discountPrice": Integer,
+          "discountRate": Integer,
+          "discountFixed": Integer
+        },
+        "video": {
+          "videoUrl": String,
+          "thumbnailUrl": String
+        },
+        "carousel": {
+          "head": {
+            "header": String,
+            "content": String,
+            "imageUrl": String,
+            "linkMo": String,
+            "linkPc": String,
+            "schemeAndroid": String,
+            "schemeIos": String
+          },
+          "list": [
+            {
+              "header": String,
+              "message": String,
+              "additionalContent": String,
+              "imageUrl": String,
+              "imageLink": String,
+              "commerce": {
+                "title": String,
+                "regularPrice": Integer,
+                "discountPrice": Integer,
+                "discountRate": Integer,
+                "discountFixed": Integer
+              },
+              "buttons": [
+                {
+                  "name": String,
+                  "type": String,
+                  "linkMo": String,
+                  "linkPc": String,
+                  "schemeIos": String,
+                  "schemeAndroid": String,
+                  "bizFormId": Integer,
+                }
+              ],
+              "coupon": {
+                "title": String,
+                "description": String,
+                "linkMo": String,
+                "linkPc": String,
+                "schemeAndroid": String,
+                "schemeIos": String
+              }
+            }
+          ],
+          "tail": {
+            "linkMo": String,
+            "linkPc": String,
+            "schemeAndroid": String,
+            "schemeIos": String
+          }
+        },
+        "status": String,
+        "createDate": String,
+        "updateDate": String
+      }
+    ],
+    "totalCount": Integer
+  }
+}
+```
+
+| 名前                    | タイプ    | Not Null | 説明                                   |
+|:------------------------|:--------|:---------|:---------------------------------------|
+| header                  | Object  | O        | ヘッダ領域                                |
+| - resultCode            | Integer | O        | 結果コード                                |
+| - resultMessage         | String  | O        | 結果メッセージ                               |
+| - isSuccessful          | boolean | O        | 成否                                |
+| templateListResponse    | Object  | O        | 本文領域                                |
+| - templates             | Array   | O        | テンプレートリスト                              |
+| -- plusFriendId         | String  | O        | 送信プロフィールID                              |
+| -- plusFriendType       | String  | O        | 送信プロフィールタイプ                            |
+| -- templateCode         | String  | O        | テンプレートコード                               |
+| -- templateName         | String  | O        | テンプレート名                                |
+| -- chatBubbleType       | String  | O        | メッセージタイプ                               |
+| -- content              | String  | X        | メッセージの内容                                |
+| -- header               | String  | X        | ヘッダ                                   |
+| -- additionalContent    | String  | X        | (説明テーブル参考)                            |
+| -- adult                | boolean | O        | 成人向けメッセージかどうか                            |
+| -- image                | Object  | X        | 画像情報                                |
+| --- imageUrl            | String  | O        | 画像のURL                                |
+| --- imageLink           | String  | X        | 画像のリンク                                |
+| -- buttons              | Array   | X        | ボタンリスト                                |
+| --- name                | String  | O        | ボタンのタイトル                                 |
+| --- type                | String  | O        | ボタンタイプ                                |
+| --- linkMo              | String  | X        | モバイルWebリンク                             |
+| --- linkPc              | String  | X        | PC Webリンク                              |
+| --- schemeIos           | String  | X        | iOSアプリリンク                             |
+| --- schemeAndroid       | String  | X        | Androidアプリリンク                           |
+| --- bizFormId           | Integer | X        | ビズフォームID (JSON基準)                       |
+| -- item                 | Object  | X        | ワイドリスト要素                           |
+| --- list                | Array   | X        | ワイドリスト                              |
+| ---- title              | String  | X        | アイテムのタイトル                                |
+| ---- imageUrl           | String  | O        | アイテム画像のURL                            |
+| ---- linkMo             | String  | O        | モバイルWebリンク                             |
+| ---- linkPc             | String  | X        | PC Webリンク                              |
+| ---- schemeAndroid      | String  | X        | Androidアプリリンク                           |
+| ---- schemeIos          | String  | X        | iOSアプリリンク                             |
+| -- coupon               | Object  | X        | クーポン要素                                |
+| --- title               | String  | O        | クーポン名                                |
+| --- description         | String  | O        | クーポンの詳細説明                              |
+| --- linkMo              | String  | X        | モバイルWebリンク                             |
+| --- linkPc              | String  | X        | PC Webリンク                              |
+| --- schemeAndroid       | String  | X        | Androidアプリリンク                           |
+| --- schemeIos           | String  | X        | iOSアプリリンク                             |
+| -- commerce             | Object  | X        | コマース要素                               |
+| --- title               | String  | O        | 商品名                                 |
+| --- regularPrice        | Integer | X        | 通常価格                                |
+| --- discountPrice       | Integer | X        | 割引価格                                 |
+| --- discountRate        | Integer | X        | 割引率                                  |
+| --- discountFixed       | Integer | X        | 定額割引価格                               |
+| -- video                | Object  | X        | 動画要素                               |
+| --- videoUrl            | String  | O        | カカオTVの動画URL                          |
+| --- thumbnailUrl        | String  | X        | 動画のサムネイル用画像のURL                       |
+| -- carousel             | Object  | X        | カルーセル                                  |
+| --- head                | Object  | X        | カルーセルイントロ                              |
+| ---- header             | String  | O        | カルーセルイントロヘッダ                           |
+| ---- content            | String  | O        | カルーセルイントロ内容                           |
+| ---- imageUrl           | String  | O        | カルーセルイントロ画像アドレス                        |
+| ---- linkMo             | String  | X        | モバイルWebリンク                             |
+| ---- linkPc             | String  | X        | PC Webリンク                              |
+| ----- schemeAndroid     | String  | X        | Androidアプリリンク                           |
+| ----- schemeIos         | String  | X        | iOSアプリリンク                             |
+| ---- list               | Array   | O        | カルーセルリスト                              |
+| ----- header            | String  | O        | カルーセルアイテムヘッダ                           |
+| ----- message           | String  | O        | カルーセルアイテムメッセージ(Not Nullリストのcontentマッピング) |
+| ----- additionalContent | String  | X        | 付加情報                                |
+| ----- imageUrl          | String  | O        | 画像URL (カルーセルアイテム内)                    |
+| ----- imageLink         | String  | X        | 画像リンク(カルーセルアイテム内)                     |
+| ----- commerce          | Object  | O        | コマース(カルーセルアイテム内)                        |
+| ------ title            | String  | O        | 商品名                                 |
+| ------ regularPrice     | Integer | X        | 通常価格                                |
+| ------ discountPrice    | Integer | X        | 割引価格                                 |
+| ------ discountRate     | Integer | X        | 割引率                                  |
+| ------ discountFixed    | Integer | X        | 定額割引価格                               |
+| ----- buttons           | Array   | O        | カルーセルリストのボタン一覧                         |
+| ------ name             | String  | O        | ボタンのタイトル                                 |
+| ------ type             | String  | O        | ボタンタイプ                                |
+| ------ linkMo           | String  | X        | モバイルWebリンク                             |
+| ------ linkPc           | String  | X        | PC Webリンク                              |
+| ------ schemeIos        | String  | X        | iOSアプリリンク                             |
+| ------ schemeAndroid    | String  | X        | Androidアプリリンク                           |
+| ------ bizFormId        | Integer | X        | ビズフォームID (JSON基準)                       |
+| ----- coupon            | Object  | X        | クーポン要素(カルーセルアイテム内)                      |
+| ------ title            | String  | X        | クーポン名                                 |
+| ------ description      | String  | X        | クーポンの詳細説明                              |
+| ------ linkMo           | String  | X        | モバイルWebリンク                             |
+| ------ linkPc           | String  | X        | PC Webリンク                              |
+| ------ schemeAndroid    | String  | X        | Androidアプリリンク                           |
+| ------ schemeIos        | String  | X        | iOSアプリリンク                             |
+| ---- tail               | Object  | X        | もっと見るボタン情報                             |
+| ----- linkMo            | String  | O        | モバイルWebリンク                             |
+| ----- linkPc            | String  | X        | PC Webリンク                              |
+| ----- schemeAndroid     | String  | X        | Androidアプリリンク                           |
+| ----- schemeIos         | String  | X        | iOSアプリリンク                             |
+| --- status              | String  | O        | テンプレートの状態(A:登録、 S:ブロック)                   |
+| --- createDate          | String  | O        | 登録日時                                |
+| --- updateDate          | String  | X        | 修正日時                                |
+| - totalCount            | Integer | O        | 合計数                                  |
+
+<a id="view-single-template"></a>
+
+### テンプレートの個別照会
+
+[URL]
+
+```
+GET  /brand-message/v1.0/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 名前         | タイプ   | 説明   |
+|--------------|--------|--------|
+| appkey       | String | 固有のアプリキー |
+| senderKey    | String | 発信キー |
+| templateCode | String | テンプレートコード |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前         | タイプ   | 必須 | 説明             |
+|--------------|--------|----|------------------|
+| X-Secret-Key | String | O  | コンソールで作成できます。 |
+|X-NC-API-IDEMPOTENCY-KEY| String| X | 重複メッセージ送信リクエストの基準key<br>10分間同じkeyでリクエストした場合、該当リクエストは失敗として処理します。 |
+
+<a id="response-9"></a>
+
+#### レスポンス
+
+```
+{
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
+  },
+  "template": {
+    "plusFriendId": String,
+    "plusFriendType": String,
+    "templateCode": String,
+    "templateName": String,
+    "chatBubbleType": String,
+    "content": String,
+    "header": String,
+    "additionalContent": String,
+    "adult": boolean,
+    "image": {
+      "imageUrl": String,
+      "imageLink": String
+    },
+    "buttons": [
+      {
+        "name": String,
+        "type": String,
+        "linkMo": String,
+        "linkPc": String,
+        "schemeIos": String,
+        "schemeAndroid": String,
+        "bizFormId": Integer
+      }
+    ],
+    "item": {
+      "list": [
+        {
+          "title": String,
+          "imageUrl": String,
+          "linkMo": String,
+          "linkPc": String,
+          "schemeAndroid": String,
+          "schemeIos": String
+        }
+      ]
+    },
+    "coupon": {
+      "title": String,
+      "description": String,
+      "linkMo": String,
+      "linkPc": String,
+      "schemeAndroid": String,
+      "schemeIos": String
+    },
+    "commerce": {
+      "title": String,
+      "regularPrice": Integer,
+      "discountPrice": Integer,
+      "discountRate": Integer,
+      "discountFixed": Integer
+    },
+    "video": {
+      "videoUrl": String,
+      "thumbnailUrl": String
+    },
+    "carousel": {
+      "head": {
+        "header": String,
+        "content": String,
+        "imageUrl": String,
+        "linkMo": String,
+        "linkPc": String,
+        "schemeAndroid": String,
+        "schemeIos": String
+      },
+      "list": [
+        {
+          "header": String,
+          "message": String,
+          "additionalContent": String,
+          "imageUrl": String,
+          "imageLink": String,
+          "commerce": {
+            "title": String,
+            "regularPrice": Integer,
+            "discountPrice": Integer,
+            "discountRate": Integer,
+            "discountFixed": Integer
+          },
+          "buttons": [
+            {
+              "name": String,
+              "type": String,
+              "linkMo": String,
+              "linkPc": String,
+              "schemeIos": String,
+              "schemeAndroid": String,
+              "bizFormId": Integer
+            }
+          ],
+          "coupon": {
+            "title": String,
+            "description": String,
+            "linkMo": String,
+            "linkPc": String,
+            "schemeAndroid": String,
+            "schemeIos": String
+          }
+        }
+      ],
+      "tail": {
+        "linkMo": String,
+        "linkPc": String,
+        "schemeAndroid": String,
+        "schemeIos": String
+      }
+    },
+    "status": String,
+    "createDate": String,
+    "updateDate": String
+  }
+}
+```
+
+| 名前                  | タイプ    | Not Null | 説明                 |
+|:----------------------|:--------|:---------|:---------------------|
+| header                | Object  | O        | ヘッダ領域              |
+| - resultCode          | Integer | O        | 結果コード              |
+| - resultMessage       | String  | O        | 結果メッセージ             |
+| - isSuccessful        | boolean | O        | 成否              |
+| template              | Object  | O        | テンプレート本文領域          |
+| - plusFriendId        | String  | O        | 送信プロフィールID            |
+| - plusFriendType      | String  | O        | 送信プロフィールタイプ          |
+| - templateCode        | String  | O        | テンプレートコード             |
+| - templateName        | String  | O        | テンプレート名              |
+| - chatBubbleType      | String  | O        | メッセージタイプ             |
+| - pushAlarm           | boolean | X        | プッシュ通知の有無            |
+| - content             | String  | X        | メッセージの内容              |
+| - adult               | boolean | O        | 成人向けメッセージかどうか          |
+| - header              | String  | X        | ヘッダ(テンプレート内)           |
+| - additionalContent   | String  | X        | 付加情報(テンプレート内)        |
+| - image               | Object  | X        | 画像情報              |
+| -- imageUrl           | String  | O        | 画像のURL              |
+| -- imageLink          | String  | X        | 画像のリンク              |
+| - buttons             | Array   | X        | ボタンリスト              |
+| -- name               | String  | O        | ボタンのタイトル               |
+| -- type               | String  | O        | ボタンタイプ              |
+| -- linkMo             | String  | X        | モバイルWebリンク           |
+| -- linkPc             | String  | X        | PC Webリンク            |
+| -- schemeIos          | String  | X        | iOSアプリリンク           |
+| -- schemeAndroid      | String  | X        | Androidアプリリンク         |
+| -- bizFormId          | Integer | X        | ビズフォームID (JSON基準)     |
+| - item                | Object  | X        | ワイドリスト要素         |
+| -- list               | Array   | X        | ワイドリスト            |
+| --- title             | String  | X        | アイテムのタイトル              |
+| --- imageUrl          | String  | O        | アイテム画像のURL          |
+| --- linkMo            | String  | O        | モバイルWebリンク           |
+| --- linkPc            | String  | X        | PC Webリンク            |
+| --- schemeIos         | String  | X        | iOSアプリリンク           |
+| --- schemeAndroid     | String  | X        | Androidアプリリンク         |
+| - coupon              | Object  | X        | クーポン要素              |
+| -- title              | String  | O        | クーポン名               |
+| -- description        | String  | O        | クーポンの詳細説明            |
+| -- linkMo             | String  | X        | モバイルWebリンク           |
+| -- linkPc             | String  | X        | PC Webリンク            |
+| -- schemeIos          | String  | X        | iOSアプリリンク           |
+| -- schemeAndroid      | String  | X        | Androidアプリリンク         |
+| - commerce            | Object  | X        | コマース要素             |
+| -- title              | String  | O        | 商品名              |
+| -- regularPrice       | Integer | X        | 通常価格              |
+| -- discountPrice      | Integer | X        | 割引価格               |
+| -- discountRate       | Integer | X        | 割引率                |
+| -- discountFixed      | Integer | X        | 定額割引価格             |
+| - video               | Object  | X        | 動画要素             |
+| -- videoUrl           | String  | O        | カカオTVの動画URL        |
+| -- thumbnailUrl       | String  | X        | 動画のサムネイル用画像のURL     |
+| - carousel            | Object  | X        | カルーセル                |
+| -- head               | Object  | X        | カルーセルイントロ            |
+| --- header            | String  | O        | カルーセルイントロヘッダ         |
+| --- content           | String  | O        | カルーセルイントロ内容         |
+| --- imageUrl          | String  | O        | カルーセルイントロ画像アドレス      |
+| --- linkMo            | String  | X        | モバイルWebリンク           |
+| --- linkPc            | String  | X        | PC Webリンク            |
+| --- schemeIos         | String  | X        | iOSアプリリンク           |
+| --- schemeAndroid     | String  | X        | Androidアプリリンク         |
+| -- list               | Array   | O        | カルーセルリスト            |
+| --- header            | String  | O        | カルーセルアイテムヘッダ         |
+| --- message           | String  | O        | カルーセルアイテムメッセージ        |
+| --- additionalContent | String  | X        | 付加情報(カルーセルアイテム内)    |
+| --- imageUrl          | String  | O        | 画像URL (カルーセルアイテム内)  |
+| --- imageLink         | String  | X        | 画像リンク(カルーセルアイテム内)   |
+| --- commerce          | Object  | O        | コマース(カルーセルアイテム内)      |
+| ---- title            | String  | O        | 商品名              |
+| ---- regularPrice     | Integer | X        | 通常価格              |
+| ---- discountPrice    | Integer | X        | 割引価格               |
+| ---- discountRate     | Integer | X        | 割引率                |
+| ---- discountFixed    | Integer | X        | 定額割引価格             |
+| --- buttons           | Array   | O        | カルーセルリストのボタン一覧       |
+| ---- name             | String  | O        | ボタンのタイトル               |
+| ---- type             | String  | O        | ボタンタイプ              |
+| ---- linkMo           | String  | X        | モバイルWebリンク           |
+| ---- linkPc           | String  | X        | PC Webリンク            |
+| ---- schemeIos        | String  | X        | iOSアプリリンク           |
+| ---- schemeAndroid    | String  | X        | Androidアプリリンク         |
+| ---- bizFormId        | Integer | X        | ビズフォームID (JSON基準)     |
+| --- coupon            | Object  | X        | クーポン要素(カルーセルアイテム内)    |
+| ---- title            | String  | X        | クーポン名               |
+| ---- description      | String  | X        | クーポンの詳細説明            |
+| ---- linkMo           | String  | X        | モバイルWebリンク           |
+| ---- linkPc           | String  | X        | PC Webリンク            |
+| ---- schemeIos        | String  | X        | iOSアプリリンク           |
+| ---- schemeAndroid    | String  | X        | Androidアプリリンク         |
+| -- tail               | Object  | X        | もっと見るボタン情報           |
+| --- linkMo            | String  | O        | モバイルWebリンク           |
+| --- linkPc            | String  | X        | PC Webリンク            |
+| --- schemeIos         | String  | X        | iOSアプリリンク           |
+| --- schemeAndroid     | String  | X        | Androidアプリリンク         |
+| - status              | String  | O        | テンプレートの状態(A:登録、 S:ブロック) |
+| - createDate          | String  | O        | 登録日時              |
+| - updateDate          | String  | X        | 修正日時              |
+
+<a id="register-template"></a>
+
+### テンプレート登録
+
+<a id="requested-9"></a>
+
+#### リクエスト
+
+[URL]
+
+```
+POST  /brand-message/v1.0/appkeys/{appkey}/senders/{senderKey}/templates
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 名前      | タイプ   | 説明   |
+|-----------|--------|--------|
+| appkey    | String | 固有のアプリキー |
+| senderKey | String | 発信キー |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前         | タイプ   | 必須 | 説明             |
+|--------------|--------|----|------------------|
+| X-Secret-Key | String | O  | コンソールで作成できます。 |
+
+<a id="note"></a>
+
+#### 注意事項
+
+* クーポン名にプレースホルダーを適用する場合、次のような固定プレースホルダーを使用する必要があります。
+
+```
+- #{割引金額}KRW割引クーポン(#{割引金額}の範囲は1 ～ 99,999,999)
+- #{割引率}%割引クーポン(#{割引率}の範囲は1 ～ 100)
+- 送料割引クーポン
+- #{商品名}無料クーポン(#{商品名}は最大7文字)
+- #{商品名} UPクーポン(#{商品名}は最大7文字)
+```
+
+* コマースで商品名を除いたregularPrice、 discountPrice、 discountRate、 discountFixedフィールドには、ユーザーがプレースホルダーを指定することはできません。
+    * 商品名を除く全てのフィールドの値を空にした場合、自動的に固定プレースホルダーが入力されて保存されます。
+    * regularPrice -> #{通常価格}
+    * discountPrice -> #{割引価格}
+    * discountRate -> #{割引率}
+    * discountFixed -> #{定額割引価格}
+
+<a id="request-to-register-text-type-template"></a>
+
+#### テキスト型テンプレート登録リクエスト
+
+[Request body]
+
+```
+{
+  "templateName": String,
+  "chatBubbleType": "TEXT",
+  "adult": boolean,
+  "content": String,
+  "buttons": [
+    {
+      "name": String,
+      "type": String,
+      "linkMo": String,
+      "linkPc": String,
+      "schemeAndroid": String,
+      "schemeIos": String,
+      "bizFormKey": String
+    }
+  ],
+  "coupon": {
+    "title": String,
+    "description": String,
+    "linkMo": String,
+    "linkPc": String,
+    "schemeAndroid": String,
+    "schemeIos": String
+  }
+}
+```
+
+| 名前            | タイプ    | 必須 | 説明                                                                                                                                                                                                                                                |
+|-----------------|---------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| templateName    | String  | O  | テンプレート名(最大200文字)                                                                                                                                                                                                                                     |
+| chatBubbleType  | String  | O  | メッセージタイプ(TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE)                                                                                                                                               |
+| adult           | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                                             |
+| content         | String  | O  | - TEXTタイプの場合、最大1,300文字(改行:最大99個、URL形式入力可能)<br>- IMAGEタイプの場合、最大400文字(改行:最大29個、URL形式入力可能)<br>- WIDEタイプの場合、最大76文字(改行:最大1個)<br>- PREMIUM_VIDEOタイプの場合、該当フィールドをオプションとして使用可能、最大76文字(改行:最大1個)<br>- その他のタイプの場合、該当フィールドは使用しません |
+| buttons         | List    | X  | ボタンリスト<br>- TEXT、IMAGEタイプの場合、クーポン適用時は最大4件、それ以外は最大5件<br>- WIDE、WIDE_ITEM_LISTタイプの場合、最大2件<br>- PREMIUM_VIDEOタイプの場合、最大1件<br>- COMMERCEタイプの場合、最小1件、最大2件                                                                                      |
+| - name          | String  | O  | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字<br>プレースホルダー使用不可                                                                                                                                                                           |
+| - type          | String  | O  | ボタンタイプ(WL: Webリンク、 AL:アプリリンク、 BK:ボットキーワード、 MD:メッセージ伝達、 AC:チャンネル追加、 BC:トーク相談転換、 BT:チャットボット転換、 BF:ビジネスフォーム)<br>- テンプレートではBCタイプは利用できません <br>- BTタイプ <br>- テンプレートではBFタイプは利用できません<br>- ACタイプはTEXT、IMAGEの場合、最初のボタンとして、その他のメッセージタイプの場合は最後のボタンとして登録する必要があります                  |
+| - linkMo        | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                                              |
+| - linkPc        | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                                               |
+| - schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                                            |
+| - schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合は必須フィールド)、500文字制限                                                                                                                                                                                                              |
+| - bizFormKey    | String  | X  | BFタイプのボタンの場合、ビズフォームキー<br>プレースホルダー使用不可                                                                                                                                                                                                                   |
+| coupon          | Object  | X  | クーポン要素                                                                                                                                                                                                                                             |
+| - title         | String  | O  | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」                                                                                  |
+| - description   | String  | O  | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字、改行:不可<br>- その他のタイプの場合、最大12文字、改行:不可                                                                                                                                           |
+| - linkMo        | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                         |
+| - linkPc        | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                                               |
+| - schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                       |
+| - schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                         |
+
+<a id="request-to-register-image-type-template"></a>
+
+#### 画像型テンプレート登録リクエスト
+
+[Request body]
+
+```
+{
+  "templateName": String,
+  "chatBubbleType": "IMAGE",
+  "adult": boolean,
+  "content": String,
+  "image": {
+    "imageUrl": String,
+    "imageLink": String
+  },
+  "buttons": [
+    {
+      "name": String,
+      "type": String,
+      "linkMo": String,
+      "linkPc": String,
+      "schemeAndroid": String,
+      "schemeIos": String,
+      "bizFormKey": String
+    }
+  ],
+  "coupon": {
+    "title": String,
+    "description": String,
+    "linkMo": String,
+    "linkPc": String,
+    "schemeAndroid": String,
+    "schemeIos": String
+  }
+}
+```
+
+| 名前            | タイプ    | 必須 | 説明                                                                                                                                                                                                                                                |
+|-----------------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| templateName    | String  | O  | テンプレート名(最大200文字)                                                                                                                                                                                                                                     |
+| chatBubbleType  | String  | O  | メッセージタイプ(TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE)                                                                                                                                               |
+| adult           | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                                             |
+| content         | String  | O  | - TEXTタイプの場合、最大1,300文字(改行:最大99個、URL形式入力可能)<br>- IMAGEタイプの場合、最大400文字(改行:最大29個、URL形式入力可能)<br>- WIDEタイプの場合、最大76文字(改行:最大1個)<br>- PREMIUM_VIDEOタイプの場合、該当フィールドをオプションとして使用可能、最大76文字(改行:最大1個)<br>- その他のタイプの場合、該当フィールドは使用しません |
+| image           | Object  | O  | 画像要素<br>- IMAGE、WIDE、COMMERCEタイプの場合、必須フィールド                                                                                                                                                                                                     |
+| - imageUrl      | String  | O  | 画像URL、一般画像としてアップロードされた画像URLを使用<br>プレースホルダー使用不可                                                                                                                                                                                                     |
+| - imageLink     | String  | X  | 画像をクリックした際に移動するURL、500文字制限<br>未設定の場合、カカオトーク内の画像ビューアを使用<br>プレースホルダー使用不可                                                                                                                                                                                   |
+| buttons         | List    | X  | ボタンリスト<br>- TEXT、IMAGEタイプの場合、クーポン適用時は最大4件、それ以外は最大5件<br>- WIDE、WIDE_ITEM_LISTタイプの場合、最大2件<br>- PREMIUM_VIDEOタイプの場合、最大1件<br>- COMMERCEタイプの場合、最小1件、最大2件                                                                                      |
+| - name          | String  | O  | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字<br>プレースホルダー使用不可                                                                                                                                                                           |
+| - type          | String  | O  | ボタンタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- ACタイプはTEXT、IMAGEの場合は最初のボタンとして、それ以外のメッセージタイプの場合は最後のボタンとして登録する必要がある             |
+| - linkMo        | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                                              |
+| - linkPc        | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                                               |
+| - schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                                            |
+| - schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合は必須フィールド)、500文字制限                                                                                                                                                                                                              |
+| - bizFormKey    | String  | X  | BFタイプのボタンの場合、ビズフォームキー                                                                                                                                                                                                                                 |
+| coupon          | Object  | X  | クーポン要素                                                                                                                                                                                                                                             |
+| - title         | String  | O  | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」                                                                                  |
+| - description   | String  | O  | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字、改行:不可<br>- その他のタイプの場合、最大12文字、改行:不可                                                                                                                                           |
+| - linkMo        | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                         |
+| - linkPc        | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                                               |
+| - schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                       |
+| - schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                         |
+
+<a id="request-to-register-wide-image-type-template"></a>
+
+#### ワイド画像型テンプレート登録リクエスト
+
+[Request body]
+
+```
+{
+  "templateName": String,
+  "chatBubbleType": "WIDE",
+  "adult": boolean,
+  "content": String,
+  "image": {
+    "imageUrl": String,
+    "imageLink": String
+  },
+  "buttons": [
+    {
+      "name": String,
+      "type": String,
+      "linkMo": String,
+      "linkPc": String,
+      "schemeAndroid": String,
+      "schemeIos": String,
+      "bizFormKey": String
+    }
+  ],
+  "coupon": {
+    "title": String,
+    "description": String,
+    "linkMo": String,
+    "linkPc": String,
+    "schemeAndroid": String,
+    "schemeIos": String
+  }
+}
+```
+
+| 名前            | タイプ    | 必須 | 説明                                                                                                                                                                                                                                                |
+|-----------------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| templateName    | String  | O  | テンプレート名(最大200文字)                                                                                                                                                                                                                                     |
+| chatBubbleType  | String  | O  | メッセージタイプ(TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE)                                                                                                                                               |
+| adult           | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                                             |
+| content         | String  | O  | - TEXTタイプの場合、最大1,300文字(改行:最大99個、URL形式入力可能)<br>- IMAGEタイプの場合、最大400文字(改行:最大29個、URL形式入力可能)<br>- WIDEタイプの場合、最大76文字(改行:最大1個)<br>- PREMIUM_VIDEOタイプの場合、該当フィールドをオプションとして使用可能、最大76文字(改行:最大1個)<br>- その他のタイプの場合、該当フィールドは使用しません |
+| image           | Object  | O  | 画像要素<br>- IMAGE、WIDE、COMMERCEタイプの場合、必須フィールド                                                                                                                                                                                                     |
+| - imageUrl      | String  | O  | 画像URL、ワイド画像としてアップロードされた画像URLを使用<br>プレースホルダー使用不可                                                                                                                                                                                                    |
+| - imageLink     | String  | X  | 画像をクリックした際に移動するURL、500文字制限<br>未設定の場合、カカオトーク内の画像ビューアを使用<br>プレースホルダー使用不可                                                                                                                                                                                   |
+| buttons         | List    | X  | ボタンリスト<br>- TEXT、IMAGEタイプの場合、クーポン適用時は最大4件、それ以外は最大5件<br>- WIDE、WIDE_ITEM_LISTタイプの場合、最大2件<br>- PREMIUM_VIDEOタイプの場合、最大1件<br>- COMMERCEタイプの場合、最小1件、最大2件                                                                                      |
+| - name          | String  | O  | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字<br>プレースホルダー使用不可                                                                                                                                                                           |
+| - type          | String  | O  | ボタンタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- ACタイプはTEXT、IMAGEの場合は最初のボタンとして、それ以外のメッセージタイプの場合は最後のボタンとして登録する必要がある                   |
+| - linkMo        | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                                              |
+| - linkPc        | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                                               |
+| - schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                                            |
+| - schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合は必須フィールド)、500文字制限                                                                                                                                                                                                              |
+| - bizFormKey    | String  | X  | BFタイプのボタンの場合、ビズフォームキー                                                                                                                                                                                                                                 |
+| coupon          | Object  | X  | クーポン要素                                                                                                                                                                                                                                             |
+| - title         | String  | O  | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」                                                                                  |
+| - description   | String  | O  | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字、改行:不可<br>- その他のタイプの場合、最大12文字、改行:不可                                                                                                                                           |
+| - linkMo        | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                         |
+| - linkPc        | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                                               |
+| - schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                       |
+| - schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                         |
+
+<a id="request-to-register-wide-item-list-type-template"></a>
+
+#### ワイドアイテムリスト型テンプレート登録リクエスト
+
+[Request body]
+
+```
+{
+  "templateName": String,
+  "chatBubbleType": "WIDE_ITEM_LIST",
+  "adult": boolean,
+  "header": String,
+  "item": {
+    "list": [
+      {
+        "title": String,
+        "imageUrl": String,
+        "linkMo": String,
+        "linkPc": String,
+        "schemeAndroid": String,
+        "schemeIos": String
+      },
+      {
+        "title": String,
+        "imageUrl": String,
+        "linkMo": String,
+        "linkPc": String,
+        "schemeAndroid": String,
+        "schemeIos": String
+      },
+      {
+        "title": String,
+        "imageUrl": String,
+        "linkMo": String,
+        "linkPc": String,
+        "schemeAndroid": String,
+        "schemeIos": String
+      }
+    ]
+  },
+  "buttons": [
+    {
+      "name": String,
+      "type": String,
+      "linkMo": String,
+      "linkPc": String,
+      "schemeAndroid": String,
+      "schemeIos": String,
+      "bizFormKey": String
+    }
+  ],
+  "coupon": {
+    "title": String,
+    "description": String,
+    "linkMo": String,
+    "linkPc": String,
+    "schemeAndroid": String,
+    "schemeIos": String
+  }
+}
+```
+
+| 名前             | タイプ    | 必須 | 説明                                                                                                                                                                                                                              |
+|------------------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| templateName     | String  | O  | テンプレート名(最大200文字)                                                                                                                                                                                                                   |
+| chatBubbleType   | String  | O  | メッセージタイプ(TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE)                                                                                                                             |
+| adult            | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                           |
+| header           | String  | O  | ヘッダ<br>- WIDE_ITEM_LISTタイプの場合、必須フィールドで最大20文字(改行:不可)<br>- PREMIUM_VIDEOタイプの場合、任意フィールドで最大20文字(改行:不可)                                                                                                                         |
+| item             | Object  | O  | ワイドリスト要素(WIDE_ITEM_LISTタイプでのみ使用可能)                                                                                                                                                                                           |
+| - list           | List    | O  | ワイドリスト(最小: 3、最大4)                                                                                                                                                                                                             |
+| -- title         | String  | O  | アイテムのタイトル<br>- 1番目のアイテムは最大25文字に制限(改行:最大1個、1番目のアイテムの場合、titleは必須値ではありません)<br>- 1番目のアイテムはtitleが必須フィールドではありません<br>- 2～4番目のアイテムは最大30文字に制限(改行:最大1個)                                                                                     |
+| -- imageUrl      | String  | O  | アイテム画像URL<br>- 1番目のアイテムには、最初のワイドアイテムリスト画像としてアップロードされた画像URLを使用<br>- 2～4番目のアイテムは、一般のワイドアイテムリスト画像としてアップロードされた画像URLを使用<br>プレースホルダー使用不可                                                                                                  |
+| -- linkMo        | String  | O  | モバイルWebリンク、500文字制限                                                                                                                                                                                                             |
+| -- linkPc        | String  | X  | PC Webリンク、500文字制限                                                                                                                                                                                                              |
+| -- schemeAndroid | String  | X  | Androidアプリリンク、500文字制限                                                                                                                                                                                                           |
+| -- schemeIos     | String  | X  | iOSアプリリンク、500文字制限                                                                                                                                                                                                             |
+| buttons          | List    | X  | ボタンリスト<br>- TEXT、IMAGEタイプの場合、クーポン適用時は最大4件、それ以外は最大5件<br>- WIDE、WIDE_ITEM_LISTタイプの場合、最大2件<br>- PREMIUM_VIDEOタイプの場合、最大1件<br>- COMMERCEタイプの場合、最小1件、最大2件                                                                    |
+| - name           | String  | O  | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字<br>プレースホルダー使用不可                                                                                                                                                         |
+| - type          | String  | O  | ボタンタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- ACタイプはTEXT、IMAGEの場合は最初のボタンとして、それ以外のメッセージタイプの場合は最後のボタンとして登録する必要がある                   |
+| - linkMo         | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                            |
+| - linkPc         | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                             |
+| - schemeAndroid  | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                          |
+| - schemeIos      | String  | X  | iOSアプリリンク(ALタイプの場合は必須フィールド)、500文字制限                                                                                                                                                                                            |
+| - bizFormKey     | String  | X  | BFタイプのボタンの場合、ビズフォームキー                                                                                                                                                                                                               |
+| coupon           | Object  | X  | クーポン要素                                                                                                                                                                                                                           |
+| - title          | String  | O  | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」                                                                |
+| - description    | String  | O  | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字、改行:不可<br>- その他のタイプの場合、最大12文字、改行:不可                                                                                                                         |
+| - linkMo         | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                       |
+| - linkPc         | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                             |
+| - schemeAndroid  | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                     |
+| - schemeIos      | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                       |
+
+<a id="request-to-register-premium-video-type-template"></a>
+
+#### プレミアム動画型テンプレート登録リクエスト
+
+[Request body]
+
+```
+{
+  "templateName": String,
+  "chatBubbleType": "PREMIUM_VIDEO",
+  "adult": boolean,
+  "content": String,
+  "header": String,
+  "video": {
+    "videoUrl": String,
+    "thumbnailUrl": String
+  },
+  "buttons": [
+    {
+      "name": String,
+      "type": String,
+      "linkMo": String,
+      "linkPc": String,
+      "schemeAndroid": String,
+      "schemeIos": String,
+      "bizFormKey": String
+    }
+  ],
+  "coupon": {
+    "title": String,
+    "description": String,
+    "linkMo": String,
+    "linkPc": String,
+    "schemeAndroid": String,
+    "schemeIos": String
+  }
+}
+```
+
+| 名前            | タイプ    | 必須 | 説明                                                                                                                                                                                                                                                |
+|-----------------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| templateName    | String  | O  | テンプレート名(最大200文字)                                                                                                                                                                                                                                     |
+| chatBubbleType  | String  | O  | メッセージタイプ(TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE)                                                                                                                                               |
+| adult           | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                                             |
+| content         | String  | X  | - TEXTタイプの場合、最大1,300文字(改行:最大99個、URL形式の入力が可能)<br>- IMAGEタイプの場合、最大400文字(改行:最大29回、URL形式の入力が可能)<br>- WIDEタイプの場合、最大76文字(改行:最大1回)<br>- PREMIUM_VIDEOタイプの場合、このフィールドをオプションとして使用可能、最大76文字(改行:最大1回)<br>- その他のタイプの場合、このフィールドは使用しません |
+| header          | String  | X  | ヘッダ<br>- WIDE_ITEM_LISTタイプの場合、必須フィールドで最大20文字(改行:不可)<br>- PREMIUM_VIDEOタイプの場合、任意フィールドで最大20文字(改行:不可)                                                                                                                                           |
+| video           | Object  | O  | 動画要素(PREMIUM_VIDEOタイプのみ使用可能)                                                                                                                                                                                                                    |
+| - videoUrl      | String  | O  | カカオTV動画URL (カカオTVにアップロードされた動画アドレスのみ使用可能)、最大500文字制限<br>プレースホルダー使用不可                                                                                                                                                                                |
+| - thumbnailUrl  | String  | X  | 動画サムネイル用画像URL。一般画像としてアップロードされたURLのみ使用可能(ない場合はカカオTV動画の基本サムネイルを使用)、最大500文字制限<br>プレースホルダー使用不可                                                                                                                                                    |
+| buttons         | List    | X  | ボタンリスト<br>- TEXT、IMAGEタイプの場合、クーポン適用時は最大4件、それ以外は最大5件<br>- WIDE、WIDE_ITEM_LISTタイプの場合、最大2件<br>- PREMIUM_VIDEOタイプの場合、最大1件<br>- COMMERCEタイプの場合、最小1件、最大2件                                                                                      |
+| - name          | String  | O  | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字<br>プレースホルダー使用不可                                                                                                                                                                           |
+| - type           | String  | O  | ボタンタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- ACタイプはTEXT、IMAGEの場合は最初のボタンとして、それ以外のメッセージタイプの場合は最後のボタンとして登録する必要がある |
+| - linkMo        | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                                              |
+| - linkPc        | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                                               |
+| - schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                                            |
+| - schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合は必須フィールド)、500文字制限                                                                                                                                                                                                              |
+| - bizFormKey    | String  | X  | BFタイプのボタンの場合、ビズフォームキー                                                                                                                                                                                                                                 |
+| coupon          | Object  | X  | クーポン要素                                                                                                                                                                                                                                             |
+| - title         | String  | O  | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」                                                                                  |
+| - description   | String  | O  | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字、改行:不可<br>- その他のタイプの場合、最大12文字、改行:不可                                                                                                                                           |
+| - linkMo        | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                         |
+| - linkPc        | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                                               |
+| - schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                       |
+| - schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                         |
+
+<a id="request-to-register-commerce-type-template"></a>
+
+#### コマース型テンプレート登録リクエスト
+
+[Request body]
+
+```
+{
+  "templateName": String,
+  "chatBubbleType": "COMMERCE",
+  "pushAlarm": boolean,
+  "adult": boolean,
+  "additionalContent": String,
+  "image": {
+    "imageUrl": String,
+    "imageLink": String
+  },
+  "commerce": {
+    "title": String,
+    "regularPrice": Integer,
+    "discountPrice": Integer,
+    "discountRate": Integer,
+    "discountFixed": Integer
+  },
+  "buttons": [
+    {
+      "name": String,
+      "type": String,
+      "linkMo": String,
+      "linkPc": String,
+      "schemeAndroid": String,
+      "schemeIos": String,
+      "bizFormKey": String
+    }
+  ],
+  "coupon": {
+    "title": String,
+    "description": String,
+    "linkMo": String,
+    "linkPc": String,
+    "schemeAndroid": String,
+    "schemeIos": String
+  }
+}
+```
+
+| 名前              | タイプ    | 必須 | 説明                                                                                                                                                                                                                              |
+|-------------------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| templateName      | String  | O  | テンプレート名(最大200文字)                                                                                                                                                                                                                   |
+| chatBubbleType    | String  | O  | メッセージタイプ(TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE)                                                                                                                             |
+| adult             | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                           |
+| additionalContent | String  | X  | 付加情報(最大34文字、改行:最大1回)、コマース形式でのみ使用可能                                                                                                                                                                                         |
+| image             | Object  | O  | 画像要素<br>- IMAGE、WIDE、COMMERCEタイプの場合、必須フィールド                                                                                                                                                                                   |
+| - imageUrl        | String  | O  | 画像URL、一般画像としてアップロードされた画像URLを使用<br>プレースホルダー使用不可                                                                                                                                                                                    |
+| - imageLink       | String  | X  | 画像をクリックした際に移動するURL、1,000文字制限<br>未設定の場合、カカオトーク内の画像ビューアを使用<br>プレースホルダー使用不可                                                                                                                                                                 |
+| commerce          | Object  | O  | コマース(COMMERCEタイプでのみ使用可能)                                                                                                                                                                                                        |
+| title             | String  | O  | 商品名(最大30文字、改行:不可)                                                                                                                                                                                                           |
+| regularPrice      | Integer | O  | 通常価格(0 ～ 99,999,999)<br>プレースホルダーのユーザー指定は不可能、値を空にすると固定プレースホルダー`#{通常価格}`で保存されます                                                                                                                                                         |
+| discountPrice     | Integer | X  | 割引価格(0 ～ 99,999,999)<br>プレースホルダーのユーザー指定は不可能、値を空にすると固定プレースホルダー`#{割引価格}`で保存されます                                                                                                                                                           |
+| discountRate      | Integer | X  | 割引率(0 ～ 100)、割引価格が存在する場合、割引率、定額割引価格のいずれかは必須<br>プレースホルダーのユーザー指定は不可能、値を空にすると固定プレースホルダー`#{割引率}`で保存されます                                                                                                                                     |
+| discountFixed     | Integer | X  | 定額割引価格(0 ～ 999,999)、割引価格が存在する場合、割引率、定額割引価格のいずれかは必須<br>プレースホルダーのユーザー指定は不可能、値を空にすると固定プレースホルダー`#{定額割引価格}`で保存されます                                                                                                                           |
+| buttons           | List    | O  | ボタンリスト<br>- TEXT、IMAGEタイプの場合、クーポン適用時は最大4件、それ以外は最大5件<br>- WIDE、WIDE_ITEM_LISTタイプの場合、最大2件<br>- PREMIUM_VIDEOタイプの場合、最大1件<br>- COMMERCEタイプの場合、最小1件、最大2件                                                                    |
+| - name            | String  | O  | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字<br>プレースホルダー使用不可                                                                                                                                                         |
+| - type          | String  | O  | ボタンタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- ACタイプはTEXT、IMAGEの場合は最初のボタンとして、それ以外のメッセージタイプの場合は最後のボタンとして登録する必要がある                   |
+| - linkMo          | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                            |
+| - linkPc          | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                             |
+| - schemeAndroid   | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                          |
+| - schemeIos       | String  | X  | iOSアプリリンク(ALタイプの場合は必須フィールド)、500文字制限                                                                                                                                                                                            |
+| - bizFormKey      | String  | X  | BFタイプのボタンの場合、ビズフォームキー                                                                                                                                                                                                               |
+| coupon            | Object  | X  | クーポン要素                                                                                                                                                                                                                           |
+| - title           | String  | O  | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」                                                                |
+| - description     | String  | O  | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字、改行:不可<br>- その他のタイプの場合、最大12文字、改行:不可                                                                                                                         |
+| - linkMo          | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                       |
+| - linkPc          | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                             |
+| - schemeAndroid   | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                     |
+| - schemeIos       | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                       |
+
+<a id="request-to-register-carousel-feed-type-template"></a>
+
+#### カルーセルフィード型テンプレート登録リクエスト
+
+[Request body]
+
+```
+{
+  "templateName": String,
+  "chatBubbleType": "CAROUSEL_FEED",
+  "adult": boolean,
+  "carousel": {
+    "list": [
+      {
+        "header": String,
+        "message": String,
+        "imageUrl": String,
+        "imageLink": String,
+        "buttons": [
+          {
+            "name": String,
+            "type": String,
+            "linkMo": String,
+            "linkPc": String,
+            "schemeAndroid": String,
+            "schemeIos": String,
+            "chatExtra": String,
+            "chatEvent": String,
+            "bizFormKey": String
+          }
+        ],
+        "coupon": {
+          "title": String,
+          "description": String,
+          "linkMo": String,
+          "linkPc": String,
+          "schemeAndroid": String,
+          "schemeIos": String
+        }
+      },
+      {
+        "header": String,
+        "message": String,
+        "imageUrl": String,
+        "imageLink": String,
+        "buttons": [
+          {
+            "name": String,
+            "type": String,
+            "linkMo": String,
+            "linkPc": String,
+            "schemeAndroid": String,
+            "schemeIos": String,
+            "bizFormKey": String
+          }
+        ],
+        "coupon": {
+          "title": String,
+          "description": String,
+          "linkMo": String,
+          "linkPc": String,
+          "schemeAndroid": String,
+          "schemeIos": String
+        }
+      }
+    ],
+    "tail": {
+      "linkMo": String,
+      "linkPc": String,
+      "schemeAndroid": String,
+      "schemeIos": String
+    }
+  }
+}
+```
+
+| 名前              | タイプ    | 必須 | 説明                                                                                                                                                                                                                              |
+|-------------------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| templateName      | String  | O  | テンプレート名(最大200文字)                                                                                                                                                                                                                   |
+| chatBubbleType    | String  | O  | メッセージタイプ(TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE)                                                                                                                             |
+| pushAlarm         | boolean | X  | メッセージプッシュ通知の送信有無(デフォルト: true)                                                                                                                                                                                                       |
+| adult             | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                           |
+| carousel          | Object  | O  | カルーセル                                                                                                                                                                                                                             |
+| - list            | List    | O  | カルーセルリスト(最小2件、最大6件)                                                                                                                                                                                                            |
+| -- header         | String  | O  | カルーセルアイテムのタイトル(最大20文字)、カルーセルフィード型でのみ使用可能                                                                                                                                                                                             |
+| -- message        | String  | O  | カルーセルアイテムのタイトル(最大20文字)、カルーセルアイテムのメッセージ(最大180文字)、カルーセルフィード型でのみ使用可能。                                                                                                                                                                        |
+| -- imageUrl       | String  | O  | 画像URL (カルーセルフィード型の画像としてアップロードされた画像のみ使用可能)<br>プレースホルダーは使用不可。                                                                                                                                                                              |
+| -- imageLink      | String  | X  | 画像リンク、1,000文字制限<br>プレースホルダーは使用不可。                                                                                                                                                                                                    |
+| -- buttons        | List    | O  | カルーセルリストのボタンリスト最小1件、最大2件                                                                                                                                                                                                       |
+| --- name          | String  | O  | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字<br>プレースホルダーは使用不可。                                                                                                                                                          |
+| - type            | String  | O  | ボタンタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- ACタイプはTEXT、IMAGEの場合は最初のボタンとして、それ以外のメッセージタイプの場合は最後のボタンとして登録する必要がある |
+| --- linkMo        | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                            |
+| --- linkPc        | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                             |
+| --- schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                          |
+| --- schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合は必須フィールド)、500文字制限                                                                                                                                                                                            |
+| --- bizFormKey    | String  | X  | BFタイプのボタンの場合、ビズフォームキー                                                                                                                                                                                                               |
+| -- coupon         | Object  | X  | クーポン要素                                                                                                                                                                                                                           |
+| --- title         | String  | O  | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」                                                                |
+| --- description   | String  | O  | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字、改行:不可<br>- その他のタイプの場合、最大12文字、改行:不可                                                                                                                         |
+| --- linkMo        | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                       |
+| --- linkPc        | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                             |
+| --- schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                     |
+| --- schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                       |
+| - tail            | Object  | X  | もっと見るボタン情報                                                                                                                                                                                                                        |
+| -- linkMo         | String  | O  | モバイルWebリンク、500文字制限<br>プレースホルダーは使用不可。                                                                                                                                                                                                 |
+| -- linkPc         | String  | X  | PC Webリンク、500文字制限<br>プレースホルダーは使用不可。                                                                                                                                                                                                  |
+| -- schemeAndroid  | String  | X  | Androidアプリリンク、500文字制限<br>プレースホルダーは使用不可。                                                                                                                                                                                               |
+| -- schemeIos      | String  | X  | iOSアプリリンク、500文字制限<br>プレースホルダーは使用不可。                                                                                                                                                                                                 |
+| recipientList     | List    | O  | 受信者リスト(最大1,000人)                                                                                                                                                                                                                 |
+| - recipientNo     | String  | O  | 受信番号                                                                                                                                                                                                                           |
+| createUser        | String  | X  | 登録者(コンソールから送信した場合、ユーザーUUIDで保存)                                                                                                                                                                                                       |
+
+<a id="request-to-register-carousel-commerce-type-template"></a>
+
+#### カルーセルコマース型テンプレート登録リクエスト
+
+[Request body]
+
+```
+{
+  "templateName": String,
+  "chatBubbleType": "CAROUSEL_COMMERCE",
+  "adult": boolean,
+  "carousel": {
+    "head": {
+      "header": String,
+      "content": String,
+      "imageUrl": String,
+      "linkMo": String,
+      "linkPc": String,
+      "schemeAndroid": String,
+      "schemeIos": String
+    },
+    "list": [
+      {
+        "additionalContent": String,
+        "imageUrl": String,
+        "imageLink": String,
+        "buttons": [
+          {
+            "name": String,
+            "type": String,
+            "linkMo": String,
+            "linkPc": String,
+            "schemeAndroid": String,
+            "schemeIos": String,
+            "bizFormKey": String
+          }
+        ],
+        "coupon": {
+          "title": String,
+          "description": String,
+          "linkMo": String,
+          "linkPc": String,
+          "schemeAndroid": String,
+          "schemeIos": String
+        },
+        "commerce": {
+          "title": String,
+          "regularPrice": Integer,
+          "discountPrice": Integer,
+          "discountRate": Integer,
+          "discountFixed": Integer
+        },
+      }
+    ],
+    "tail": {
+      "linkMo": String,
+      "linkPc": String,
+      "schemeAndroid": String,
+      "schemeIos": String
+    }
+  }
+}
+```
+
+| 名前                 | タイプ    | 必須 | 説明                                                                                                                                                                                                                              |
+|----------------------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| templateName         | String  | O  | テンプレート名(最大200文字)                                                                                                                                                                                                                   |
+| chatBubbleType       | String  | O  | メッセージタイプ(TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE)                                                                                                                             |
+| pushAlarm            | boolean | X  | メッセージプッシュ通知の送信有無(デフォルト: true)                                                                                                                                                                                                       |
+| adult                | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                           |
+| carousel             | Object  | O  | カルーセル                                                                                                                                                                                                                             |
+| - head               | Object  | X  | カルーセルイントロ                                                                                                                                                                                                                         |
+| -- header            | String  | O  | カルーセルイントロヘッダ(最大20文字)                                                                                                                                                                                                                |
+| -- content           | String  | O  | カルーセルイントロ内容(最大50文字)                                                                                                                                                                                                                |
+| -- imageUrl          | String  | O  | カルーセルイントロ画像のURL(カルーセルコマース型の画像としてアップロードされた画像を使用、使用する画像はカルーセルの画像と比率が同一である必要があります)<br>プレースホルダーは使用不可。                                                                                                                                          |
+| -- linkMo            | String  | X  | モバイルWebリンク(linkMo、linkPc、schemeAndroid、schemeIosのいずれかを使用する場合、linkMoは必須値)、500文字制限                                                                                                                                       |
+| -- linkPc            | String  | X  | PC Webリンク、500文字制限                                                                                                                                                                                                             |
+| -- schemeAndroid     | String  | X  | Androidアプリリンク、500文字制限                                                                                                                                                                                                           |
+| -- schemeIos         | String  | X  | iOSアプリリンク、500文字制限                                                                                                                                                                                                             |
+| - list               | List    | O  | カルーセルリスト(headが存在する場合、最小1件、最大5件 / それ以外は最小2件、最大6件)                                                                                                                                                                          |
+| -- additionalContent | String  | X  | 付加情報(最大34文字)、カルーセルコマース形式でのみ使用可能                                                                                                                                                                                                 |
+| -- imageUrl          | String  | O  | 画像URL (カルーセルコマース型の画像としてアップロードされた画像を使用)<br>プレースホルダーは使用不可。                                                                                                                                                                                 |
+| -- imageLink         | String  | X  | 画像リンク、1,000文字制限<br>プレースホルダーは使用不可。                                                                                                                                                                                                    |
+| -- commerce          | Object  | O  | コマース(CAROUSEL_COMMERCEタイプでのみ使用可能)                                                                                                                                                                                               |
+| --- title            | String  | O  | 商品名(最大30文字、改行:不可)                                                                                                                                                                                                           |
+| --- regularPrice     | Integer | O  | 通常価格(0～99,999,999)<br>プレースホルダーのユーザー指定は不可能、値を空にすると固定プレースホルダー`#{通常価格}`で保存されます                                                                                                                                                         |
+| --- discountPrice    | Integer | X  | 割引価格(0 ～ 99,999,999)<br>プレースホルダーのユーザー指定は不可能、値を空にすると固定プレースホルダー`#{割引価格}`で保存されます                                                                                                                                                           |
+| --- discountRate     | Integer | X  | 割引率(0 ～ 100)、割引価格が存在する場合、割引率、定額割引価格のいずれかは必須<br>プレースホルダーのユーザー指定は不可能、値を空にすると固定プレースホルダー`#{割引率}`で保存されます                                                                                                                                     |
+| --- discountFixed    | Integer | X  | 定額割引価格(0 ～ 999,999)、割引価格が存在する場合、割引率、定額割引価格のいずれかは必須<br>プレースホルダーのユーザー指定は不可能、値を空にすると固定プレースホルダー`#{定額割引価格}`で保存されます                                                                                                                           |
+| -- buttons           | List    | O  | カルーセルリストのボタンリスト最小1件、最大2件                                                                                                                                                                                                       |
+| --- name             | String  | O  | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字<br>プレースホルダーは使用不可。                                                                                                                                                          |
+| --- type             | String  | O  | ボタンタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- ACタイプはTEXT、IMAGEの場合は最初のボタンとして、それ以外のメッセージタイプの場合は最後のボタンとして登録する必要がある |
+| --- linkMo           | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                            |
+| --- linkPc           | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                             |
+| --- schemeAndroid    | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                          |
+| --- schemeIos        | String  | X  | iOSアプリリンク(ALタイプの場合は必須フィールド)、500文字制限                                                                                                                                                                                            |
+| --- bizFormKey       | String  | X  | BFタイプのボタンの場合、ビズフォームキー                                                                                                                                                                                                               |
+| -- coupon            | Object  | X  | クーポン要素                                                                                                                                                                                                                           |
+| --- title            | String  | O  | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」                                                                |
+| --- description      | String  | O  | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字、改行:不可<br>- その他のタイプの場合、最大12文字、改行:不可                                                                                                                         |
+| --- linkMo           | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                       |
+| --- linkPc           | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                             |
+| --- schemeAndroid    | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                     |
+| --- schemeIos        | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                       |
+| - tail               | Object  | X  | もっと見るボタン情報                                                                                                                                                                                                                        |
+| -- linkMo            | String  | O  | モバイルWebリンク、500文字制限<br>プレースホルダーは使用不可。                                                                                                                                                                                                 |
+| -- linkPc            | String  | X  | PC Webリンク、500文字制限<br>プレースホルダーは使用不可。                                                                                                                                                                                                  |
+| -- schemeAndroid     | String  | X  | Androidアプリリンク、500文字制限<br>プレースホルダーは使用不可。                                                                                                                                                                                               |
+| -- schemeIos         | String  | X  | iOSアプリリンク、500文字制限<br>プレースホルダーは使用不可。                                                                                                                                                                                                 |
+
+<a id="response-10"></a>
+
+#### レスポンス
+
+```
+{
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
+  },
+  "template": {
+    "templateCode": String
+  }
+}
+```
+
+| 名前            | タイプ    | Not Null | 説明   |
+|:----------------|:--------|:---------|:-------|
+| header          | Object  | O        | ヘッダ領域 |
+| - resultCode    | Integer | O        | 結果コード |
+| - resultMessage | String  | O        | 結果メッセージ |
+| - isSuccessful  | boolean | O        | 成否 |
+| template        | Object  | X        | テンプレート情報 |
+| - templateCode  | String  | O        | テンプレートコード |
+
+<a id="modify-template"></a>
+
+### テンプレート修正
+
+<a id="requested-10"></a>
+
+#### リクエスト
+
+[URL]
+
+```
+PUT  /brand-message/v1.0/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 名前         | タイプ   | 説明   |
+|--------------|--------|--------|
+| appkey       | String | 固有のアプリキー |
+| senderKey    | String | 発信キー |
+| templateCode | String | テンプレートコード |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前         | タイプ   | 必須 | 説明             |
+|--------------|--------|----|------------------|
+| X-Secret-Key | String | O  | コンソールで作成できます。 |
+
+[Request Body]
+
+* テンプレート登録と仕様は同じです
+
+<a id="response-11"></a>
+
+#### レスポンス
+
+```
+{
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
+  }
+}
+```
+
+| 名前            | タイプ    | Not Null | 説明   |
+|:----------------|:--------|:---------|:-------|
+| header          | Object  | O        | ヘッダ領域 |
+| - resultCode    | Integer | O        | 結果コード |
+| - resultMessage | String  | O        | 結果メッセージ |
+| - isSuccessful  | boolean | O        | 成否 |
+
+<a id="delete-template"></a>
+
+### テンプレート削除
+
+<a id="requested-11"></a>
+
+#### リクエスト
+
+[URL]
+
+```
+DELETE  /brand-message/v1.0/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 名前         | タイプ   | 説明   |
+|--------------|--------|--------|
+| appkey       | String | 固有のアプリキー |
+| senderKey    | String | 発信キー |
+| templateCode | String | テンプレートコード |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前         | タイプ   | 必須 | 説明             |
+|--------------|--------|----|------------------|
+| X-Secret-Key | String | O  | コンソールで作成できます。 |
+
+<a id="response-12"></a>
+
+#### レスポンス
+
+```
+{
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
+  }
+}
+```
+
+| 名前            | タイプ    | Not Null | 説明   |
+|:----------------|:--------|:---------|:-------|
+| header          | Object  | O        | ヘッダ領域 |
+| - resultCode    | Integer | O        | 結果コード |
+| - resultMessage | String  | O        | 結果メッセージ |
+| - isSuccessful  | boolean | O        | 成否 |
+
+<a id="manage-image"></a>
+
+## 画像管理
+
+<a id="upload-image"></a>
+
+### 画像アップロード
+
+<a id="requested-12"></a>
+
+#### リクエスト
+
+[URL]
+
+```
+POST  /brand-message/v1.0/appkeys/{appKey}/images
+Content-Type: multipart/form-data
+```
+
+[Path parameter]
+
+| 名前   | タイプ   | 説明   |
+|--------|--------|--------|
+| appkey | String | 固有のアプリキー |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前         | タイプ   | 必須 | 説明             |
+|--------------|--------|----|------------------|
+| X-Secret-Key | String | O  | コンソールで作成できます。 |
+
+[Request parameter]
+
+| 名前      | タイプ   | 必須 | 説明                                                                                                                           |
+|-----------|--------|----|--------------------------------------------------------------------------------------------------------------------------------|
+| image     | File   | O  | 画像                                                                                                                           |
+| imageType | String | O  | 画像タイプ <br>(IMAGE, WIDE_IMAGE,MAIN_WIDE_ITEMLIST_IMAGE,NORMAL_WIDE_ITEMLIST_IMAGE,CAROUSEL_FEED_IMAGE,CAROUSEL_COMMERCE_IMAGE) |
+
+<a id="response-13"></a>
+
+#### レスポンス
+
+```
+{
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
+  }, 
+  "image": {
+      "imageSeq": Integer,
+      "imageUrl": String,
+      "imageName": String,
+  }
+}
+```
+
+| 名前            | タイプ    | Not Null | 説明    |
+|:----------------|:--------|:---------|:--------|
+| header          | Object  | O        | ヘッダ領域 |
+| - resultCode    | Integer | O        | 結果コード |
+| - resultMessage | String  | O        | 結果メッセージ |
+| - isSuccessful  | boolean | O        | 成否 |
+| image           | Object  | X        | 画像領域 |
+| - imageSeq      | Integer | O        | 画像シーケンス |
+| - imageUrl      | String  | O        | 画像のURL |
+| - imageName     | String  | X        | 画像名   |
+
+<a id="upload-image-specifications"></a>
+
+#### アップロード画像規格
+| 画像タイプ                      | 使用先                                                 | アップロード画像規格                                                                                                         |
+| :------------------------- | :-------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------- |
+| IMAGE                      | 画像形式の送信リクエスト、コマース形式の送信リクエスト、プレミアム動画形式の送信リクエストのサムネイル | **推奨サイズ：**800 × 400px（横500px以上）<br/>**画像比率：**0.5 ≤ 縦 ÷ 横 ≤ 1.333<br/>**ファイル形式／容量制限：**jpg、png／最大5MB                 |
+| WIDE_IMAGE                 | ワイド画像形式の送信リクエスト                                     | **推奨サイズ：**800 × 600px（横500px以上）<br/>**画像比率：**0.5 ≤ 縦 ÷ 横 ≤ 1<br/>**ファイル形式／容量制限：**jpg、png／最大5MB                     |
+| MAIN_WIDE_ITEMLIST_IMAGE   | ワイドアイテムリスト形式の送信リクエストの1番目アイテム画像                      | **制限サイズ：**横500px以上<br/>**画像比率：**縦 ÷ 横 = 0.5<br/>**ファイル形式／容量制限：**jpg、png／最大5MB                                      |
+| NORMAL_WIDE_ITEMLIST_IMAGE | ワイドアイテムリスト形式の送信リクエストの2〜4番目アイテム画像                    | **制限サイズ：**横500px以上<br/>**画像比率：**縦 ÷ 横 = 1<br/>**ファイル形式／容量制限：**jpg、png／各ファイル最大5MB                                   |
+| CAROUSEL_FEED_IMAGE        | カルーセルフィード形式の送信リクエストのセル別画像                           | **推奨サイズ：**800 × 600px または 800 × 400px（横500px以上）<br/>**画像比率：**0.5 ≤ 縦 ÷ 横 ≤ 1.333<br/>**ファイル形式／容量制限：**jpg、png／最大5MB |
+| CAROUSEL_COMMERCE_IMAGE    | コマース形式の送信リクエスト（カルーセルコマース形式）のイントロ画像、セル別画像            | **推奨サイズ：**800 × 600px または 800 × 400px（横500px以上）<br/>**画像比率：**0.5 ≤ 縦 ÷ 横 ≤ 1.333<br/>**ファイル形式／容量制限：**jpg、png／最大5MB |
+
+<!-- pre-align: ko에 대응 섹션 없음 — 검토 필요 (duplicate of t62 — アップロード画像規格 appears twice in target; ko has only one counterpart (k65)) -->
+#### アップロード画像規格
+| 画像タイプ                     | 使用箇所                                                     | アップロード画像規格                                                                                                                              |
+|:---------------------------|:--------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------|
+| IMAGE                      | 画像型画像、コマース型画像、プレミアム動画型サムネイル                       | 推奨サイズ: 800 X 400px (横500px以上)<br/>画像比率: 0.5 ≤ 縦 ÷ 横 ≤ 1.333<br/>ファイル形式及び容量制限: jpg, png / 最大5MB                                |
+| WIDE_IMAGE                 | ワイド画像型画像                                                  | 推奨サイズ: 800 X 600px (横500px以上)<br/>画像比率: 0.5 ≤ 縦 ÷ 横 ≤ 1<br>ファイル形式及び容量制限: jpg, png / 最大5MB                                     |
+| MAIN_WIDE_ITEMLIST_IMAGE   | ワイドアイテムリスト型1番目のアイテム画像                                | 制限サイズ: 横500px以上<br/>画像比率: 縦 ÷ 横 = 0.5<br/>ファイル形式及び容量制限: jpg, png / 最大5MB                                                      |
+| NORMAL_WIDE_ITEMLIST_IMAGE | ワイドアイテムリスト型2～4番目のアイテム画像                              | 制限サイズ: 横500px以上<br/>画像比率: 縦 ÷ 横 = 1<br/>ファイル形式及びサイズ: jpg, png / 各ファイル最大5MB                                                      |
+| CAROUSEL_FEED_IMAGE        | カルーセルフィード型セル別画像                                          | 推奨サイズ: 800 X 600px または 800 X 400px (横500px以上)<br/>画像比率: 0.5 ≤ 縦 ÷ 横 ≤ 1.333<br/>ファイル形式及び容量制限: jpg, png / 最大5MB                 |
+| CAROUSEL_COMMERCE_IMAGE    | カルーセルコマース型イントロ画像、カルーセルコマース型セル別画像 | 推奨サイズ: 800 X 600px または 800 X 400px (横500px以上)<br/>画像比率: 0.5 ≤ 縦 ÷ 横 ≤ 1.333<br/>ファイル形式及び容量制限: jpg, png / 最大5MB                 |
+
+* アップロードされた画像を参照するテンプレートが全て削除されるか、別の画像に変更されると、Kakao CDNから該当の画像が削除され、URLが無効になります。画像照会APIでは画像情報が維持されますが、実際の画像にはアクセスできないため、オリジナルファイルは自社サーバーに別途保管することを推奨します。
+
+<a id="view-image"></a>
+
+### 画像照会
+
+<a id="requested-13"></a>
+
+#### リクエスト
+
+[URL]
+
+```
+GET  /brand-message/v1.0/appkeys/{appKey}/images
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 名前   | タイプ   | 説明   |
+|--------|--------|--------|
+| appkey | String | 固有のアプリキー |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前         | タイプ   | 必須 | 説明             |
+|--------------|--------|----|------------------|
+| X-Secret-Key | String | O  | コンソールで作成できます。 |
+
+[Request parameter]
+
+| 名前       | タイプ   | 必須 | 説明                                                                                                                           |
+|------------|--------|----|--------------------------------------------------------------------------------------------------------------------------------|
+| imageTypes | List   | O  | 画像タイプ <br>(IMAGE, WIDE_IMAGE,MAIN_WIDE_ITEMLIST_IMAGE,NORMAL_WIDE_ITEMLIST_IMAGE,CAROUSEL_FEED_IMAGE,CAROUSEL_COMMERCE_IMAGE) |
+| pageNum    | String | X  | ページ番号(基本: 1)                                                                                                                  |
+| pageSize   | String | X  | 照会件数(基本: 15)                                                                                                                  |
+
+<a id="response-14"></a>
+
+#### レスポンス
+
+```
+{
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
+  },
+  "image": {
+    "imageSeq": Integer,
+    "imageUrl": String,
+    "imageName": String
+  }
+}
+```
+
+| 名前            | タイプ    | Not Null | 説明    |
+|:----------------|:--------|:---------|:--------|
+| header          | Object  | O        | ヘッダ領域 |
+| - resultCode    | Integer | O        | 結果コード |
+| - resultMessage | String  | O        | 結果メッセージ |
+| - isSuccessful  | boolean | O        | 成否 |
+| image           | Object  | X        | 画像領域 |
+| - imageSeq      | Integer | O        | 画像シーケンス |
+| - imageUrl      | String  | O        | 画像のURL |
+| - imageName     | String  | X        | 画像名   |
+
+<a id="delete-image"></a>
+
+### 画像削除
+
+<a id="requested-14"></a>
+
+#### リクエスト
+
+[URL]
+
+```
+DELETE  /brand-message/v1.0/appkeys/{appKey}/images
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 名前   | タイプ   | 説明   |
+|--------|--------|--------|
+| appkey | String | 固有のアプリキー |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前         | タイプ   | 必須 | 説明             |
+|--------------|--------|----|------------------|
+| X-Secret-Key | String | O  | コンソールで作成できます。 |
+
+[Query parameter]
+
+| 名前     | タイプ   | 必須 | 説明   |
+|----------|--------|----|--------|
+| imageSeq | String | O  | 画像番号 |
+
+<a id="response-15"></a>
+
+#### レスポンス
+
+```
+{
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
+  }
+}
+```
+
+| 名前            | タイプ    | Not Null | 説明   |
+|:----------------|:--------|:---------|:-------|
+| header          | Object  | O        | ヘッダ領域 |
+| - resultCode    | Integer | O        | 結果コード |
+| - resultMessage | String  | O        | 結果メッセージ |
+| - isSuccessful  | boolean | O        | 成否 |
+
+<a id="upload"></a>
+
+## アップロード
+
+<a id="upload-bizform-key"></a>
+
+### ビズフォームキーのアップロード
+
+<a id="requested-15"></a>
+
+#### リクエスト
+
+[URL]
+
+```
+POST /brand-message/v1.0/appkeys/{appKey}/senders/{senderKey}/biz-form
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 名前      | タイプ   | 説明   |
+|-----------|--------|--------|
+| appkey    | String | 固有のアプリキー |
+| senderKey | String | 発信キー |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前         | タイプ   | 必須 | 説明             |
+|--------------|--------|----|------------------|
+| X-Secret-Key | String | O  | コンソールで作成できます。 |
+
+<a id="response-16"></a>
+
+#### レスポンス
+
+```
+{
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
+  }
+}
+```
+
+| 名前            | タイプ    | Not Null | 説明   |
+|:----------------|:--------|:---------|:-------|
+| header          | Object  | O        | ヘッダ領域 |
+| - resultCode    | Integer | O        | 結果コード |
+| - resultMessage | String  | O        | 結果メッセージ |
+| - isSuccessful  | boolean | O        | 成否 |
+
+<a id="manage-outgoing-profiles"></a>
+
+## 送信プロフィール管理
+
+<a id="view-outgoing-profile"></a>
+
+### 送信プロフィール照会
+
+<a id="requested-16"></a>
+
+#### リクエスト
+
+[URL]
+
+```
+GET  /brand-message/v1.0/appkeys/{appKey}/senders/{senderKey}
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 名前      | タイプ   | 説明   |
+|-----------|--------|--------|
+| appkey    | String | 固有のアプリキー |
+| senderKey | String | 発信キー |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前         | タイプ   | 必須 | 説明             |
+|--------------|--------|----|------------------|
+| X-Secret-Key | String | O  | コンソールで作成できます。 |
+
+<a id="response-17"></a>
+
+#### レスポンス
+
+```
+{
+  "header":{
+    "resultCode" :  Integer,
+    "resultMessage" :  String,
+    "isSuccessful" :  boolean
+  },
+  "sender":{
+    "plusFriendId" : String,
+    "senderKey" : String,
+    "categoryCode" : String,
+    "unsubscribePhoneNumber": String,
+    "unsubscribeAuthNumber": String,
+    "status" : String,
+    "statusName" : String,
+    "kakaoStatus" : String,
+    "kakaoStatusName" : String,
+    "kakaoProfileStatus" : String,
+    "kakaoProfileStatusName" : String,
+    "profileSpamLevel" : String,
+    "profileMessageSpamLevel" : String,
+    "brandMessage" : {
+      "resendAppKey": String,
+      "isResend": boolean,
+      "resendSendNo": String,
+      "resendUnsubscribeNo": String
+    },
+    "dormant" : boolean,
+    "marketingAgreement" : boolean,
+    "block" : boolean,
+    "createDate" : String,
+    "initialUserRestriction" : boolean
+  }
+}
+```
+
+| 名前                      | タイプ    | Not Null | 説明                                                                                                                  |
+|:--------------------------|:--------|:---------|:----------------------------------------------------------------------------------------------------------------------|
+| header                    | Object  | O        | ヘッダ領域                                                                                                               |
+| - resultCode              | Integer | O        | 結果コード                                                                                                               |
+| - resultMessage           | String  | O        | 結果メッセージ                                                                                                              |
+| - isSuccessful            | boolean | O        | 成否                                                                                                               |
+| sender                    | Object  | X        | 送信プロフィール                                                                                                               |
+| - plusFriendId            | String  | O        | プラスフレンドID                                                                                                              |
+| - senderKey               | String  | O        | 発信キー                                                                                                                |
+| - categoryCode            | String  | X        | カテゴリーコード                                                                                                              |
+| - unsubscribePhoneNumber  | String  | X        | 無料受信拒否電話番号                                                                                                          |
+| - unsubscribeAuthNumber   | String  | X        | 無料受信拒否認証番号                                                                                                          |
+| - status                  | String  | X        | NHN Cloudプラスフレンドステータスコード <br>(YSC02:登録待機中、YSC03:正常登録)                                                              |
+| - statusName              | String  | X        | NHN Cloudプラスフレンド状態名(登録待機中、正常登録)                                                                                   |
+| - kakaoStatus             | String  | X        | カカオプラスフレンドステータスコード<br>(A:正常、S:ブロック)<br>statusがYSC02の場合、kakaoStatusはnull値になります。                                     |
+| - kakaoStatusName         | String  | X        | カカオプラスフレンドステータス名(正常、ブロック)<br>statusがYSC02の場合、kakaoStatusNameはnull値になります。                                             |
+| - kakaoProfileStatus      | String  | X        | カカオプラスフレンドプロフィールステータスコード<br>(A:有効、B:ブロック、C:無効、D:削除、E:削除処理中)<br>statusがYSC02の場合、kakaoProfileStatusはnull値になります。 |
+| - kakaoProfileStatusName  | String  | X        | カカオプラスフレンドプロフィールステータス名(有効、無効、ブロック、削除処理中、削除)<br>statusがYSC02の場合、kakaoProfileStatusNameはnull値になります。              |
+| - profileSpamLevel        | String  | X        | カカオトークチャネルのスパムステータス名(永久制限、警告制限、正常)<br>送信プロフィールのステータスが正常でない場合、null値になることがあります。                                           |
+| - profileMessageSpamLevel | String  | X        | カカオトークメッセージのスパムステータス名(活動制限、警告制限、正常)<br>送信プロフィールのステータスが正常でない場合、null値になることがあります。                                          |
+| - block                   | boolean | O        | 送信プロフィールのブロック有無                                                                                                         |
+| - brandMessage            | Object  | X        | ブランドメッセージ設定情報                                                                                                        |
+| -- resendAppKey           | String  | X        | 代替送信として設定するSMSサービスのアプリキー                                                                                               |
+| -- isResend               | boolean | O        | 代替送信設定(再送信)の有無                                                                                                     |
+| -- resendSendNo           | String  | X        | 再送信時、tc-smsの送信番号                                                                                                  |
+| -- resendUnsubscribeNo    | String  | X        | 再送信時、tc-smsの080受信拒否番号                                                                                           |
+| - dormant                 | boolean | O        | 送信プロフィールの休眠状態の有無                                                                                                         |
+| - marketingAgreement      | boolean | O        | M/Nタイプの利用申請の有無                                                                                                      |
+| - createDate              | String  | X        | 登録日                                                                                                                |
+| - initialUserRestriction  | boolean | O        | 初回ユーザー制限の有無                                                                                                         |
+
+<a id="modify-outgoing-profile-080-opt-out-number"></a>
+
+### 送信プロフィールの080受信拒否番号の修正
+
+<a id="requested-17"></a>
+
+#### リクエスト
+
+[URL]
+
+```
+PUT /brand-message/v1.0/appkeys/{appKey}/senders/{senderKey}/unsubscribe-content
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 名前      | タイプ   | 説明   |
+|-----------|--------|--------|
+| appkey    | String | 固有のアプリキー |
+| senderKey | String | 発信キー |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前         | タイプ   | 必須 | 説明             |
+|--------------|--------|----|------------------|
+| X-Secret-Key | String | O  | コンソールで作成できます。 |
+
+[Request body]
+
+```
+{
+    "unsubscribeNo": String,
+    "unsubscribeAuthNo": String
+}
+```
+
+| 名前              | 	タイプ   | 	必須 | 	説明                                                                                                                          |
+|-------------------|---------|-----|--------------------------------------------------------------------------------------------------------------------------------|
+| unsubscribeNo     | 	String | 	O  | 080無料受信拒否電話番号(両方とも未入力の場合、送信プロフィールに登録された無料受信拒否情報で送信されます)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx  |
+| unsubscribeAuthNo | 	String | 	X  | 080無料受信拒否認証番号(両方とも未入力の場合、送信プロフィールに登録された無料受信拒否情報で送信されます)<br>unsubscribe_phone_numberなしでunsubscribe_auth_numberのみの入力は不可<br>ex) 1234 |
+
+<a id="response-18"></a>
+
+#### レスポンス
+
+```
+{
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
+  }
+}
+```
+
+| 名前            | タイプ    | Not Null | 説明   |
+|:----------------|:--------|:---------|:-------|
+| header          | Object  | O        | ヘッダ領域 |
+| - resultCode    | Integer | O        | 結果コード |
+| - resultMessage | String  | O        | 結果メッセージ |
+| - isSuccessful  | boolean | O        | 成否 |
+
+<a id="manage-fallback"></a>
+
+## 代替送信管理
+
+<a id="register-sms-appkey"></a>
+
+### SMS AppKeyの登録
+
+[URL]
+
+```
+POST  /brand-message/v1.0/appkeys/{appkey}/failback/appkey
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 名前   | 	タイプ   | 	説明   |
+|--------|---------|---------|
+| appkey | 	String | 	固有のアプリキー |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前         | 	タイプ   | 	必須 | 	説明            |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | コンソールで作成できます。 |
+
+[Request body]
+
+```
+{
+    "resendAppKey": String
+}
+```
+
+| 名前         | 	タイプ   | 	必須 | 	説明                  |
+|--------------|---------|-----|------------------------|
+| resendAppKey | 	String | 	O  | 代替送信として設定するSMSサービスのアプリキー |
+
+[例]
+
+```
+curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
+```
+
+<a id="response-19"></a>
+
+#### レスポンス
+
+```
+
+{
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
+  }
+}
+```
+
+<a id="register-fallback-settings"></a>
+
+### 代替送信設定の登録
+
+[URL]
+
+```
+POST  /brand-message/v1.0/appkeys/{appkey}/failback
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 名前   | 	タイプ   | 	説明   |
+|--------|---------|---------|
+| appkey | 	String | 	固有のアプリキー |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前         | 	タイプ   | 	必須 | 	説明            |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | コンソールで作成できます。 |
+
+[Request body]
+
+```
+{  
+   "senderKey": String,
+   "isResend": Boolean,
+   "resendSendNo": String,
+   "resendUnsubscribeNo": String
+}
+```
+
+| 名前                | 	タイプ    | 	必須 | 	説明                                                                                                      |
+|---------------------|----------|-----|------------------------------------------------------------------------------------------------------------|
+| senderKey           | 	String  | 	O  | 発信キー                                                                                                     |
+| isResend            | 	Boolean | 	O  | 送信に失敗した場合、SMSでの代替送信の有無<br>Consoleで代替送信を設定した場合、デフォルトで代替送信されます。                                           |
+| resendSendNo        | 	String  | 	X  | 代替送信の送信番号<br><span style="color:red">(SMS商品に登録されている送信番号ではない場合、代替送信に失敗することがあります。)</span>                 |
+| resendUnsubscribeNo | 	String  | 	X  | 代替送信の080受信拒否番号<br><span style="color:red">(SMSサービスに登録されている080受信拒否番号ではない場合、代替送信に失敗することがあります。)</span> |
+
+[例]
+
+```
+curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/failback/appkey -d '{"senderKey": "0be23c29de88d6888798aeda57062516354d74ba","isResend": true,"resendSendNo": "01012341234" }
+```
+
+<a id="response-20"></a>
+
+#### レスポンス
+
+```
+{
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
+  }
+}
+```
+
+| 名前            | タイプ    | Not Null | 説明   |
+|:----------------|:--------|:---------|:-------|
+| header          | Object  | O        | ヘッダ領域 |
+| - resultCode    | Integer | O        | 結果コード |
+| - resultMessage | String  | O        | 結果メッセージ |
+| - isSuccessful  | boolean | O        | 成否 |

--- a/ja/friendtalkupgrade-api-guide.md
+++ b/ja/friendtalkupgrade-api-guide.md
@@ -1,6 +1,10 @@
 ## Notification > KakaoTalk Bizmessage > ブランドメッセージ > API v1.0 Guide
 
+<a id="brand-message"></a>
+
 ## ブランドメッセージ
+
+<a id="api-domain"></a>
 
 #### [APIドメイン]
 
@@ -8,7 +12,11 @@
 |------------------------------------------------------------------------------|
 | [https://kakaotalk-bizmessage.api.nhncloudservice.com](https://kakaotalk-bizmessage.api.nhncloudservice.com) |
 
+<a id="introduce-v10-api"></a>
+
 ## v1.0 API紹介
+
+<a id="manage-non-friend-message-sending-targeting-m-n"></a>
 
 ## 非友だちメッセージ送信(ターゲティングM、N)管理
 
@@ -20,7 +28,11 @@
   - チャンネルの友だち数が5万以上
   - 3か月以内にお知らせトークの送信成功履歴を保有
 
+<a id="upload-marketing-consent-evidence"></a>
+
 ### マーケティング受信同意の証明資料のアップロード
+
+<a id="requested"></a>
 
 #### リクエスト
 
@@ -56,6 +68,8 @@ Content-Type: multipart/form-data
 |------|------|----|---------------|
 | file | File | O | マーケティング受信同意の証明資料 |
 
+<a id="response"></a>
+
 #### レスポンス
 
 ```
@@ -75,7 +89,11 @@ Content-Type: multipart/form-data
 | - resultMessage | String  | O        | 結果メッセージ |
 | - isSuccessful  | boolean | O        | 成否 |
 
+<a id="apply-for-using-non-friend-message-sending-targeting-m-n"></a>
+
 ### 非友だちメッセージ送信(ターゲティングM、N)の使用申請
+
+<a id="requested-2"></a>
 
 #### リクエスト
 
@@ -105,6 +123,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
 
+<a id="response-2"></a>
+
 #### レスポンス
 
 ```
@@ -123,6 +143,8 @@ Content-Type: application/json;charset=UTF-8
 | - resultCode    | Integer | O        | 結果コード |
 | - resultMessage | String  | O        | 結果メッセージ |
 | - isSuccessful  | boolean | O        | 成否 |
+
+<a id="request-to-send-a-free-form-message"></a>
 
 ## メッセージ自由形送信リクエスト
 
@@ -145,6 +167,8 @@ Content-Type: application/json;charset=UTF-8
 * 代替送信は、受信者ごとにresendParameterを介して設定できます。
 * 代替送信をご利用になる場合、代替送信管理APIを介してSMS Appkeyの登録及び送信設定が必要です。
 * **夜間送信制限(20:50～翌日08:00)**
+
+<a id="requested-3"></a>
 
 #### リクエスト
 
@@ -172,6 +196,8 @@ Content-Type: application/json;charset=UTF-8
 | 名前         | タイプ   | 必須 | 説明             |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
+
+<a id="request-text-type-sending"></a>
 
 #### テキスト型送信リクエスト
 
@@ -259,6 +285,8 @@ Content-Type: application/json;charset=UTF-8
 | -- resendUnsubscribeNo | String | X | 代替送信080受信拒否番号<br><span style="color:red">(SMSサービスに登録された080受信拒否番号ではない場合、代替送信に失敗することがあります。)</span> |
 | createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
 | statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
+
+<a id="request-image-type-sending"></a>
 
 #### 画像形式の送信リクエスト
 
@@ -353,6 +381,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
 | statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
 
+<a id="request-wide-image-type-sending"></a>
+
 #### ワイド画像形式の送信リクエスト
 
 [Request body]
@@ -445,6 +475,8 @@ Content-Type: application/json;charset=UTF-8
 | -- resendUnsubscribeNo | String | X | 代替送信080受信拒否番号<br><span style="color:red">(SMSサービスに登録された080受信拒否番号ではない場合、代替送信に失敗することがあります。)</span> |
 | createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
 | statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
+
+<a id="request-to-send-wide-item-list-type"></a>
 
 #### ワイドアイテムリスト形式の送信リクエスト
 
@@ -568,6 +600,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
 | statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
 
+<a id="request-to-send-premium-video-type"></a>
+
 #### プレミアム動画形式の送信リクエスト
 
 [Request body]
@@ -662,6 +696,8 @@ Content-Type: application/json;charset=UTF-8
 | -- resendUnsubscribeNo | String | X | 代替送信080受信拒否番号<br><span style="color:red">(SMSサービスに登録された080受信拒否番号ではない場合、代替送信に失敗することがあります。)</span> |
 | createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
 | statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
+
+<a id="request-to-send-commerce"></a>
 
 #### コマース形式の送信リクエスト
 
@@ -768,6 +804,8 @@ Content-Type: application/json;charset=UTF-8
 | -- resendUnsubscribeNo | String | X | 代替送信080受信拒否番号<br><span style="color:red">(SMSサービスに登録された080受信拒否番号ではない場合、代替送信に失敗することがあります。)</span> |
 | createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
 | statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
+
+<a id="request-to-send-carousel-feed-type"></a>
 
 #### カルーセルフィード形式の送信リクエスト
 
@@ -1066,6 +1104,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser | String | X  | 登録者(コンソールで送信時にユーザーUUIDとして保存) |
 | statsId | String | X  | 統計ID(送信検索条件には含まれません、最大8文字) |
 
+<a id="response-3"></a>
+
 #### レスポンス
 
 ```
@@ -1103,6 +1143,8 @@ Content-Type: application/json;charset=UTF-8
 | -- resultCode | Integer | O | 受信者別の送信結果コード(成功及び様々な失敗コードが存在する可能性があります) |
 | -- resultMessage | String | O | 受信者別の送信結果メッセージ(成功時は「success」または関連メッセージ、失敗時は失敗原因の詳細メッセージ) |
 
+<a id="request-to-send-basic-message"></a>
+
 ## メッセージ基本形送信リクエスト
 
 * テンプレートを利用した送信です。
@@ -1118,6 +1160,8 @@ Content-Type: application/json;charset=UTF-8
 * 代替送信は、受信者ごとにresendParameterを介して設定できます。
 * 代替送信をご利用になる場合、代替送信管理APIを介してSMS Appkeyの登録及び送信設定が必要です。
 * **夜間送信制限(20:50～翌日08:00)**
+
+<a id="cautions-for-use"></a>
 
 ### 使用時の注意事項
 
@@ -1150,6 +1194,8 @@ Content-Type: application/json;charset=UTF-8
 | 名前         | タイプ   | 必須 | 説明             |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
+
+<a id="requested-4"></a>
 
 #### 送信リクエスト
 
@@ -1219,6 +1265,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser | String | X | 登録者(コンソールから送信時、ユーザーUUIDとして保存) |
 | statsId | String | X | 統計ID(送信検索条件には含まれません。最大8文字) |
 
+<a id="response-4"></a>
+
 #### レスポンス
 
 ```
@@ -1256,7 +1304,11 @@ Content-Type: application/json;charset=UTF-8
 | -- resultCode | Integer | O | 受信者別の送信結果コード(成功及び様々な失敗コードが存在する可能性があります) |
 | -- resultMessage | String | O | 受信者別の送信結果メッセージ(成功時は「success」または関連メッセージ、失敗時は失敗原因の詳細メッセージ) |
 
+<a id="view-sending-list"></a>
+
 ## 送信リストの照会
+
+<a id="requested-5"></a>
 
 #### リクエスト
 
@@ -1299,6 +1351,8 @@ Content-Type: application/json;charset=UTF-8
 | resultCode       | String | X         | 送信結果(MRC01:成功MRC02:失敗)      |
 | pageNum          | String | X         | ページ番号(Default: 1)               |
 | pageSize | String | X | 照会件数(Default: 15、Max: 1,000) |
+
+<a id="response-5"></a>
 
 #### レスポンス
 
@@ -1371,7 +1425,11 @@ Content-Type: application/json;charset=UTF-8
 | -- createUser | String | X | 登録者(コンソールで送信時にユーザーUUIDとして保存) |
 | - totalCount | Integer | O | 合計数 |
 
+<a id="view-single-sending"></a>
+
 ## 送信単件照会
+
+<a id="requested-6"></a>
 
 #### リクエスト
 
@@ -1401,6 +1459,8 @@ Content-Type: application/json;charset=UTF-8
 | 名前         | タイプ   | 必須 | 説明             |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
+
+<a id="response-6"></a>
 
 #### レスポンス
 
@@ -1658,9 +1718,33 @@ Content-Type: application/json;charset=UTF-8
 | - resendRequestId     | String  | X        | 代替送信リクエストID                                                                                      | 
 | - createUser          | String  | X        | 登録者(コンソールから送信した場合、ユーザーUUIDで保存)                                                                      |
 
+<a id="cancel-message-sending"></a>
+
+## メッセージ送信取消
+
+<!-- TODO: translate body -->
+
+<a id="requested-7"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="response-7"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="manage-templates"></a>
+
 ## テンプレート管理
 
+<a id="view-template-list"></a>
+
 ### テンプレートリスト照会
+
+<a id="requested-8"></a>
 
 #### リクエスト
 
@@ -1699,6 +1783,8 @@ Content-Type: application/json;charset=UTF-8
 | status       | String  | X  | テンプレートステータスコード                   |
 | pageNum      | Integer | X  | ページ番号(Default: 1)            |
 | pageSize     | Integer | X  | 照会件数(Default: 15, Max: 1,000) |
+
+<a id="response-8"></a>
 
 #### レスポンス
 
@@ -1927,6 +2013,8 @@ Content-Type: application/json;charset=UTF-8
 | --- updateDate          | String  | X        | 修正日時                                |
 | - totalCount            | Integer | O        | 合計数                                  |
 
+<a id="view-single-template"></a>
+
 ### テンプレートの個別照会
 
 [URL]
@@ -1956,6 +2044,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
 |X-NC-API-IDEMPOTENCY-KEY| String| X | 重複メッセージ送信リクエストの基準key<br>10分間同じkeyでリクエストした場合、該当リクエストは失敗として処理します。 |
+
+<a id="response-9"></a>
 
 #### レスポンス
 
@@ -2178,7 +2268,11 @@ Content-Type: application/json;charset=UTF-8
 | - createDate          | String  | O        | 登録日時              |
 | - updateDate          | String  | X        | 修正日時              |
 
+<a id="register-template"></a>
+
 ### テンプレート登録
+
+<a id="requested-9"></a>
 
 #### リクエスト
 
@@ -2208,6 +2302,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
 
+<a id="note"></a>
+
 #### 注意事項
 
 * クーポン名にプレースホルダーを適用する場合、次のような固定プレースホルダーを使用する必要があります。
@@ -2226,6 +2322,8 @@ Content-Type: application/json;charset=UTF-8
     * discountPrice -> #{割引価格}
     * discountRate -> #{割引率}
     * discountFixed -> #{定額割引価格}
+
+<a id="request-to-register-text-type-template"></a>
 
 #### テキスト型テンプレート登録リクエスト
 
@@ -2280,6 +2378,8 @@ Content-Type: application/json;charset=UTF-8
 | - linkPc        | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                                               |
 | - schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                       |
 | - schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                         |
+
+<a id="request-to-register-image-type-template"></a>
 
 #### 画像型テンプレート登録リクエスト
 
@@ -2342,6 +2442,8 @@ Content-Type: application/json;charset=UTF-8
 | - schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                       |
 | - schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                         |
 
+<a id="request-to-register-wide-image-type-template"></a>
+
 #### ワイド画像型テンプレート登録リクエスト
 
 [Request body]
@@ -2402,6 +2504,8 @@ Content-Type: application/json;charset=UTF-8
 | - linkPc        | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                                               |
 | - schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                       |
 | - schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                         |
+
+<a id="request-to-register-wide-item-list-type-template"></a>
 
 #### ワイドアイテムリスト型テンプレート登録リクエスト
 
@@ -2493,6 +2597,8 @@ Content-Type: application/json;charset=UTF-8
 | - schemeAndroid  | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                     |
 | - schemeIos      | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                       |
 
+<a id="request-to-register-premium-video-type-template"></a>
+
 #### プレミアム動画型テンプレート登録リクエスト
 
 [Request body]
@@ -2555,6 +2661,8 @@ Content-Type: application/json;charset=UTF-8
 | - linkPc        | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                                               |
 | - schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                       |
 | - schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                         |
+
+<a id="request-to-register-commerce-type-template"></a>
 
 #### コマース型テンプレート登録リクエスト
 
@@ -2630,6 +2738,8 @@ Content-Type: application/json;charset=UTF-8
 | - linkPc          | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                             |
 | - schemeAndroid   | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                     |
 | - schemeIos       | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                       |
+
+<a id="request-to-register-carousel-feed-type-template"></a>
 
 #### カルーセルフィード型テンプレート登録リクエスト
 
@@ -2741,6 +2851,8 @@ Content-Type: application/json;charset=UTF-8
 | - recipientNo     | String  | O  | 受信番号                                                                                                                                                                                                                           |
 | createUser        | String  | X  | 登録者(コンソールから送信した場合、ユーザーUUIDで保存)                                                                                                                                                                                                       |
 
+<a id="request-to-register-carousel-commerce-type-template"></a>
+
 #### カルーセルコマース型テンプレート登録リクエスト
 
 [Request body]
@@ -2849,6 +2961,8 @@ Content-Type: application/json;charset=UTF-8
 | -- schemeAndroid     | String  | X  | Androidアプリリンク、500文字制限<br>プレースホルダーは使用不可。                                                                                                                                                                                               |
 | -- schemeIos         | String  | X  | iOSアプリリンク、500文字制限<br>プレースホルダーは使用不可。                                                                                                                                                                                                 |
 
+<a id="response-10"></a>
+
 #### レスポンス
 
 ```
@@ -2873,7 +2987,11 @@ Content-Type: application/json;charset=UTF-8
 | template        | Object  | X        | テンプレート情報 |
 | - templateCode  | String  | O        | テンプレートコード |
 
+<a id="modify-template"></a>
+
 ### テンプレート修正
+
+<a id="requested-10"></a>
 
 #### リクエスト
 
@@ -2908,6 +3026,8 @@ Content-Type: application/json;charset=UTF-8
 
 * テンプレート登録と仕様は同じです
 
+<a id="response-11"></a>
+
 #### レスポンス
 
 ```
@@ -2927,7 +3047,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 結果メッセージ |
 | - isSuccessful  | boolean | O        | 成否 |
 
+<a id="delete-template"></a>
+
 ### テンプレート削除
+
+<a id="requested-11"></a>
 
 #### リクエスト
 
@@ -2958,6 +3082,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
 
+<a id="response-12"></a>
+
 #### レスポンス
 
 ```
@@ -2977,9 +3103,15 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 結果メッセージ |
 | - isSuccessful  | boolean | O        | 成否 |
 
+<a id="manage-image"></a>
+
 ## 画像管理
 
+<a id="upload-image"></a>
+
 ### 画像アップロード
+
+<a id="requested-12"></a>
 
 #### リクエスト
 
@@ -3015,6 +3147,8 @@ Content-Type: multipart/form-data
 | image     | File   | O  | 画像                                                                                                                           |
 | imageType | String | O  | 画像タイプ <br>(IMAGE, WIDE_IMAGE,MAIN_WIDE_ITEMLIST_IMAGE,NORMAL_WIDE_ITEMLIST_IMAGE,CAROUSEL_FEED_IMAGE,CAROUSEL_COMMERCE_IMAGE) |
 
+<a id="response-13"></a>
+
 #### レスポンス
 
 ```
@@ -3043,6 +3177,8 @@ Content-Type: multipart/form-data
 | - imageUrl      | String  | O        | 画像のURL |
 | - imageName     | String  | X        | 画像名   |
 
+<a id="upload-image-specifications"></a>
+
 #### アップロード画像規格
 | 画像タイプ                      | 使用先                                                 | アップロード画像規格                                                                                                         |
 | :------------------------- | :-------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------- |
@@ -3053,6 +3189,7 @@ Content-Type: multipart/form-data
 | CAROUSEL_FEED_IMAGE        | カルーセルフィード形式の送信リクエストのセル別画像                           | **推奨サイズ：**800 × 600px または 800 × 400px（横500px以上）<br/>**画像比率：**0.5 ≤ 縦 ÷ 横 ≤ 1.333<br/>**ファイル形式／容量制限：**jpg、png／最大5MB |
 | CAROUSEL_COMMERCE_IMAGE    | コマース形式の送信リクエスト（カルーセルコマース形式）のイントロ画像、セル別画像            | **推奨サイズ：**800 × 600px または 800 × 400px（横500px以上）<br/>**画像比率：**0.5 ≤ 縦 ÷ 横 ≤ 1.333<br/>**ファイル形式／容量制限：**jpg、png／最大5MB |
 
+<!-- pre-align: ko에 대응 섹션 없음 — 검토 필요 (duplicate of t62 — アップロード画像規格 appears twice in target; ko has only one counterpart (k65)) -->
 #### アップロード画像規格
 | 画像タイプ                     | 使用箇所                                                     | アップロード画像規格                                                                                                                              |
 |:---------------------------|:--------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------|
@@ -3065,7 +3202,11 @@ Content-Type: multipart/form-data
 
 * アップロードされた画像を参照するテンプレートが全て削除されるか、別の画像に変更されると、Kakao CDNから該当の画像が削除され、URLが無効になります。画像照会APIでは画像情報が維持されますが、実際の画像にはアクセスできないため、オリジナルファイルは自社サーバーに別途保管することを推奨します。
 
+<a id="view-image"></a>
+
 ### 画像照会
+
+<a id="requested-13"></a>
 
 #### リクエスト
 
@@ -3102,6 +3243,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum    | String | X  | ページ番号(基本: 1)                                                                                                                  |
 | pageSize   | String | X  | 照会件数(基本: 15)                                                                                                                  |
 
+<a id="response-14"></a>
+
 #### レスポンス
 
 ```
@@ -3130,7 +3273,11 @@ Content-Type: application/json;charset=UTF-8
 | - imageUrl      | String  | O        | 画像のURL |
 | - imageName     | String  | X        | 画像名   |
 
+<a id="delete-image"></a>
+
 ### 画像削除
+
+<a id="requested-14"></a>
 
 #### リクエスト
 
@@ -3165,6 +3312,8 @@ Content-Type: application/json;charset=UTF-8
 |----------|--------|----|--------|
 | imageSeq | String | O  | 画像番号 |
 
+<a id="response-15"></a>
+
 #### レスポンス
 
 ```
@@ -3184,9 +3333,15 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 結果メッセージ |
 | - isSuccessful  | boolean | O        | 成否 |
 
+<a id="upload"></a>
+
 ## アップロード
 
+<a id="upload-bizform-key"></a>
+
 ### ビズフォームキーのアップロード
+
+<a id="requested-15"></a>
 
 #### リクエスト
 
@@ -3216,6 +3371,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
 
+<a id="response-16"></a>
+
 #### レスポンス
 
 ```
@@ -3235,9 +3392,15 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 結果メッセージ |
 | - isSuccessful  | boolean | O        | 成否 |
 
+<a id="manage-outgoing-profiles"></a>
+
 ## 送信プロフィール管理
 
+<a id="view-outgoing-profile"></a>
+
 ### 送信プロフィール照会
+
+<a id="requested-16"></a>
 
 #### リクエスト
 
@@ -3266,6 +3429,8 @@ Content-Type: application/json;charset=UTF-8
 | 名前         | タイプ   | 必須 | 説明             |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
+
+<a id="response-17"></a>
 
 #### レスポンス
 
@@ -3336,7 +3501,11 @@ Content-Type: application/json;charset=UTF-8
 | - createDate              | String  | X        | 登録日                                                                                                                |
 | - initialUserRestriction  | boolean | O        | 初回ユーザー制限の有無                                                                                                         |
 
+<a id="modify-outgoing-profile-080-opt-out-number"></a>
+
 ### 送信プロフィールの080受信拒否番号の修正
+
+<a id="requested-17"></a>
 
 #### リクエスト
 
@@ -3380,6 +3549,8 @@ Content-Type: application/json;charset=UTF-8
 | unsubscribeNo     | 	String | 	O  | 080無料受信拒否電話番号(両方とも未入力の場合、送信プロフィールに登録された無料受信拒否情報で送信されます)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx  |
 | unsubscribeAuthNo | 	String | 	X  | 080無料受信拒否認証番号(両方とも未入力の場合、送信プロフィールに登録された無料受信拒否情報で送信されます)<br>unsubscribe_phone_numberなしでunsubscribe_auth_numberのみの入力は不可<br>ex) 1234 |
 
+<a id="response-18"></a>
+
 #### レスポンス
 
 ```
@@ -3399,7 +3570,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 結果メッセージ |
 | - isSuccessful  | boolean | O        | 成否 |
 
+<a id="manage-fallback"></a>
+
 ## 代替送信管理
+
+<a id="register-sms-appkey"></a>
 
 ### SMS AppKeyの登録
 
@@ -3446,6 +3621,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
 ```
 
+<a id="response-19"></a>
+
 #### レスポンス
 
 ```
@@ -3458,6 +3635,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
   }
 }
 ```
+
+<a id="register-fallback-settings"></a>
 
 ### 代替送信設定の登録
 
@@ -3509,6 +3688,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/failback/appkey -d '{"senderKey": "0be23c29de88d6888798aeda57062516354d74ba","isResend": true,"resendSendNo": "01012341234" }
 ```
+
+<a id="response-20"></a>
 
 #### レスポンス
 

--- a/ko/friendtalkupgrade-api-guide.md
+++ b/ko/friendtalkupgrade-api-guide.md
@@ -1,6 +1,10 @@
 ## Notification > KakaoTalk Bizmessage > 브랜드 메시지 > API v1.0 Guide
 
+<a id="brand-message"></a>
+
 ## 브랜드 메시지
+
+<a id="api-domain"></a>
 
 #### [API 도메인]
 
@@ -8,7 +12,11 @@
 |------------------------------------------------------------------------------|
 | [https://kakaotalk-bizmessage.api.nhncloudservice.com](https://kakaotalk-bizmessage.api.nhncloudservice.com) |
 
+<a id="introduce-v10-api"></a>
+
 ## v1.0 API 소개
+
+<a id="manage-non-friend-message-sending-targeting-m-n"></a>
 
 ## 비친구 메시지 발송(타겟팅 M, N) 관리
 
@@ -20,7 +28,11 @@
 - 채널 친구 수 5만 이상
 - 3개월 내 알림톡 발송 성공 이력 보유
 
+<a id="upload-marketing-consent-evidence"></a>
+
 ### 마케팅 수신 동의 증적 자료 업로드
+
+<a id="requested"></a>
 
 #### 요청
 
@@ -56,6 +68,8 @@ Content-Type: multipart/form-data
 |------|------|----|---------------|
 | file | File | O  | 마케팅 수신 동의 증적 자료 |
 
+<a id="response"></a>
+
 #### 응답
 
 ```
@@ -75,7 +89,11 @@ Content-Type: multipart/form-data
 | - resultMessage | String  | O        | 결과 메시지 |
 | - isSuccessful  | boolean | O        | 성공 여부  |
 
+<a id="apply-for-using-non-friend-message-sending-targeting-m-n"></a>
+
 ### 비친구 메시지 발송(타겟팅 M, N) 사용 신청
+
+<a id="requested-2"></a>
 
 #### 요청
 
@@ -105,6 +123,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | 콘솔에서 생성할 수 있습니다. |
 
+<a id="response-2"></a>
+
 #### 응답
 
 ```
@@ -123,6 +143,8 @@ Content-Type: application/json;charset=UTF-8
 | - resultCode    | Integer | O        | 결과 코드  |
 | - resultMessage | String  | O        | 결과 메시지 |
 | - isSuccessful  | boolean | O        | 성공 여부  |
+
+<a id="request-to-send-a-free-form-message"></a>
 
 ## 메시지 자유형 발송 요청
 
@@ -145,6 +167,8 @@ Content-Type: application/json;charset=UTF-8
 * 대체 발송은 수신자별 resendParameter를 통해 설정할 수 있습니다.
     * 대체 발송을 이용할 경우 대체 발송 관리 API를 통해 SMS Appkey 등록 및 발송 설정이 필요합니다.
 * **야간 발송 제한(20:50~다음 날 08:00)**
+
+<a id="requested-3"></a>
 
 #### 요청
 
@@ -172,6 +196,8 @@ Content-Type: application/json;charset=UTF-8
 | 이름           | 타입     | 필수 | 설명               |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | 콘솔에서 생성할 수 있습니다. |
+
+<a id="request-text-type-sending"></a>
 
 #### 텍스트형 발송 요청
 
@@ -276,6 +302,8 @@ Content-Type: application/json;charset=UTF-8
 | resellerCode          | String  | X  | 리셀러 코드(리셀러가 발송 시 사용)                                                                                                                                                                                                                                                       |
 | createUser             | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                                                                   |
 | statsId                | String  | 	X | 통계 ID(발신 검색 조건에는 포함되지 않습니다. 최대 8자)                                                                                                                                                                                                                                            |
+
+<a id="request-image-type-sending"></a>
 
 #### 이미지형 발송 요청
 
@@ -388,6 +416,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser             | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                                                                   |
 | statsId                | String  | 	X | 통계 ID(발신 검색 조건에는 포함되지 않습니다. 최대 8자)                                                                                                                                                                                                                                            |
 
+<a id="request-wide-image-type-sending"></a>
+
 #### 와이드 이미지형 발송 요청
 
 [Request body]
@@ -498,6 +528,8 @@ Content-Type: application/json;charset=UTF-8
 | resellerCode          | String  | X  | 리셀러 코드(리셀러가 발송 시 사용)                                                                                                                                                                                                                                                       |
 | createUser             | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                                                                   |
 | statsId                | String  | 	X | 통계 ID(발신 검색 조건에는 포함되지 않습니다. 최대 8자)                                                                                                                                                                                                                                            |
+
+<a id="request-to-send-wide-item-list-type"></a>
 
 #### 와이드 아이템리스트형 발송 요청
 
@@ -639,6 +671,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser             | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                                                                   |
 | statsId                | String  | 	X | 통계 ID(발신 검색 조건에는 포함되지 않습니다. 최대 8자)                                                                                                                                                                                                                                            |
 
+<a id="request-to-send-premium-video-type"></a>
+
 #### 프리미엄 동영상형 발송 요청
 
 [Request body]
@@ -751,6 +785,8 @@ Content-Type: application/json;charset=UTF-8
 | resellerCode          | String  | X  | 리셀러 코드(리셀러가 발송 시 사용)                                                                                                                                                                                                                                                       |
 | createUser             | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                                                                   |
 | statsId                | String  | 	X | 통계 ID(발신 검색 조건에는 포함되지 않습니다. 최대 8자)                                                                                                                                                                                                                                            |
+
+<a id="request-to-send-commerce"></a>
 
 #### 커머스형 발송 요청
 
@@ -875,6 +911,8 @@ Content-Type: application/json;charset=UTF-8
 | resellerCode          | String  | X  | 리셀러 코드(리셀러가 발송 시 사용)                                                                                                                                                                                                                                                       |
 | createUser             | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                                                                   |
 | statsId                | String  | 	X | 통계 ID(발신 검색 조건에는 포함되지 않습니다. 최대 8자)                                                                                                                                                                                                                                            |
+
+<a id="request-to-send-carousel-feed-type"></a>
 
 #### 캐러셀 피드형 발송 요청
 
@@ -1053,6 +1091,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser             | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                                                                   |
 | statsId                | String  | 	X | 통계 ID(발신 검색 조건에는 포함되지 않습니다. 최대 8자)                                                                                                                                                                                                                                            |
 
+<a id="request-to-send-carousel-commerce-type"></a>
+
 #### 캐러셀 커머스형 발송 요청
 
 [Request body]
@@ -1209,6 +1249,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser           | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                                                                   |
 | statsId              | String  | 	X | 통계 ID(발신 검색 조건에는 포함되지 않습니다. 최대 8자)                                                                                                                                                                                                                                            |
 
+<a id="response-3"></a>
+
 #### 응답
 
 ```
@@ -1246,6 +1288,8 @@ Content-Type: application/json;charset=UTF-8
 | -- resultCode    | Integer | O        | 수신자별 발송 결과 코드(성공 및 다양한 실패 코드가 존재할 수 있음)                     |
 | -- resultMessage | String  | O        | 수신자별 발송 결과 메시지(성공 시 "success" 또는 관련 메시지, 실패 시 실패 원인 상세 메시지) |
 
+<a id="request-to-send-basic-message"></a>
+
 ## 메시지 기본형 발송 요청
 
 * 템플릿을 이용한 발송입니다.
@@ -1261,6 +1305,8 @@ Content-Type: application/json;charset=UTF-8
 * 대체 발송은 수신자별 resendParameter를 통해 설정할 수 있습니다.
     * 대체 발송을 이용할 경우 대체 발송 관리 API를 통해 SMS Appkey 등록 및 발송 설정이 필요합니다.
 * **야간 발송 제한(20:50~다음 날 08:00)**
+
+<a id="cautions-for-use"></a>
 
 ### 사용 시 주의사항
 
@@ -1293,6 +1339,8 @@ Content-Type: application/json;charset=UTF-8
 | 이름           | 타입     | 필수 | 설명               |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | 콘솔에서 생성할 수 있습니다. |
+
+<a id="requested-4"></a>
 
 #### 발송 요청
 
@@ -1363,6 +1411,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser             | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                             |
 | statsId                | String  | X  | 통계 ID(발신 검색 조건에는 포함되지 않습니다. 최대 8자)                                                                                                                                                                                                      |
 
+<a id="response-4"></a>
+
 #### 응답
 
 ```
@@ -1400,7 +1450,11 @@ Content-Type: application/json;charset=UTF-8
 | -- resultCode    | Integer | O        | 수신자별 발송 결과 코드(성공 및 다양한 실패 코드가 존재할 수 있음)                     |
 | -- resultMessage | String  | O        | 수신자별 발송 결과 메시지(성공 시 "success" 또는 관련 메시지, 실패 시 실패 원인 상세 메시지) |
 
+<a id="view-sending-list"></a>
+
 ## 발송 목록 조회
+
+<a id="requested-5"></a>
 
 #### 요청
 
@@ -1445,6 +1499,8 @@ Content-Type: application/json;charset=UTF-8
 | recipientGroupingKey | 	String  | 	X         | 수신자 그룹핑 키                        |
 | pageNum          | String | X         | 페이지 번호(Default: 1)               |
 | pageSize         | String | X         | 조회 건수(Default: 15, Max: 1000)    |
+
+<a id="response-5"></a>
 
 #### 응답
 
@@ -1521,7 +1577,11 @@ Content-Type: application/json;charset=UTF-8
 | -- recipientGroupingKey     | String  | X        | 수신자 그룹핑 키                                           |
 | - totalCount                | Integer | O        | 총 개수                                                                  |
 
+<a id="view-single-sending"></a>
+
 ## 발송 단건 조회
+
+<a id="requested-6"></a>
 
 #### 요청
 
@@ -1551,6 +1611,8 @@ Content-Type: application/json;charset=UTF-8
 | 이름           | 타입     | 필수 | 설명               |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | 콘솔에서 생성할 수 있습니다. |
+
+<a id="response-6"></a>
 
 #### 응답
 
@@ -1812,7 +1874,11 @@ Content-Type: application/json;charset=UTF-8
 | - senderGroupingKey   | String  | X        | 발신 그룹핑 키                                                 |
 | - recipientGroupingKey | String  | X        | 수신자 그룹핑 키                                           |
 
+<a id="cancel-message-sending"></a>
+
 ## 메시지 발송 취소
+
+<a id="requested-7"></a>
 
 #### 요청
 
@@ -1848,6 +1914,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|---------|-----|---------------------------------------------|
 | recipientSeq | 	String | 	X  | 수신자 시퀀스 번호<br>(입력하지 않으면 요청 ID의 모든 발송 건을 취소) |
 
+<a id="response-7"></a>
+
 #### 응답
 
 ```
@@ -1872,9 +1940,15 @@ Content-Type: application/json;charset=UTF-8
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
 ```
 
+<a id="manage-templates"></a>
+
 ## 템플릿 관리
 
+<a id="view-template-list"></a>
+
 ### 템플릿 리스트 조회
+
+<a id="requested-8"></a>
 
 #### 요청
 
@@ -1913,6 +1987,8 @@ Content-Type: application/json;charset=UTF-8
 | status       | String  | X  | 템플릿 상태 코드                     |
 | pageNum      | Integer | X  | 페이지 번호(Default: 1)            |
 | pageSize     | Integer | X  | 조회 건수(Default: 15, Max: 1000) |
+
+<a id="response-8"></a>
 
 #### 응답
 
@@ -2141,6 +2217,8 @@ Content-Type: application/json;charset=UTF-8
 | --- updateDate          | String  | X        | 수정 일시                                  |
 | - totalCount            | Integer | O        | 총 개수                                   |
 
+<a id="view-single-template"></a>
+
 ### 템플릿 단건 조회
 
 [URL]
@@ -2170,6 +2248,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | 콘솔에서 생성할 수 있습니다. |
 |X-NC-API-IDEMPOTENCY-KEY|	String| X | 중복 메시지 발송 요청 기준 key<br>10분간 동일한 key로 요청 시 해당 요청을 실패 처리합니다. |
+
+<a id="response-9"></a>
 
 #### 응답
 
@@ -2392,7 +2472,11 @@ Content-Type: application/json;charset=UTF-8
 | - createDate          | String  | O        | 등록 일시                |
 | - updateDate          | String  | X        | 수정 일시                |
 
+<a id="register-template"></a>
+
 ### 템플릿 등록
+
+<a id="requested-9"></a>
 
 #### 요청
 
@@ -2422,6 +2506,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | 콘솔에서 생성할 수 있습니다. |
 
+<a id="note"></a>
+
 #### 유의 사항
 
 * 쿠폰 제목에 치환자를 적용할 경우 다음과 같은 고정 치환자를 사용해야 합니다.
@@ -2440,6 +2526,8 @@ Content-Type: application/json;charset=UTF-8
     * discountPrice -> #{할인가격}
     * discountRate -> #{할인율}
     * discountFixed -> #{정액할인가격}
+
+<a id="request-to-register-text-type-template"></a>
 
 #### 텍스트형 템플릿 등록 요청
 
@@ -2494,6 +2582,8 @@ Content-Type: application/json;charset=UTF-8
 | - linkPc        | String  | X  | PC 웹 링크(WL 타입일 경우 선택 필드), 500자 제한                                                                                                                                                                                                            |
 | - schemeAndroid | String  | X  | 안드로이드 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                                   |
 | - schemeIos     | String  | X  | iOS 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                                     |
+
+<a id="request-to-register-image-type-template"></a>
 
 #### 이미지형 템플릿 등록 요청
 
@@ -2556,6 +2646,8 @@ Content-Type: application/json;charset=UTF-8
 | - schemeAndroid | String  | X  | 안드로이드 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                                       |
 | - schemeIos     | String  | X  | iOS 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                                         |
 
+<a id="request-to-register-wide-image-type-template"></a>
+
 #### 와이드 이미지형 템플릿 등록 요청
 
 [Request body]
@@ -2616,6 +2708,8 @@ Content-Type: application/json;charset=UTF-8
 | - linkPc        | String  | X  | PC 웹 링크(WL 타입일 경우 선택 필드), 500자 제한                                                                                                                                                                                                                |
 | - schemeAndroid | String  | X  | 안드로이드 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                                       |
 | - schemeIos     | String  | X  | iOS 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                                         |
+
+<a id="request-to-register-wide-item-list-type-template"></a>
 
 #### 와이드 아이템리스트형 템플릿 등록 요청
 
@@ -2707,6 +2801,8 @@ Content-Type: application/json;charset=UTF-8
 | - schemeAndroid  | String  | X  | 안드로이드 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                     |
 | - schemeIos      | String  | X  | iOS 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                       |
 
+<a id="request-to-register-premium-video-type-template"></a>
+
 #### 프리미엄 동영상형 템플릿 등록 요청
 
 [Request body]
@@ -2769,6 +2865,8 @@ Content-Type: application/json;charset=UTF-8
 | - linkPc        | String  | X  | PC 웹 링크(WL 타입일 경우 선택 필드), 500자 제한                                                                                                                                                                                                                |
 | - schemeAndroid | String  | X  | 안드로이드 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                                       |
 | - schemeIos     | String  | X  | iOS 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                                         |
+
+<a id="request-to-register-commerce-type-template"></a>
 
 #### 커머스형 템플릿 등록 요청
 
@@ -2844,6 +2942,8 @@ Content-Type: application/json;charset=UTF-8
 | - linkPc          | String  | X  | PC 웹 링크(WL 타입일 경우 선택 필드), 500자 제한                                                                                                                                                                                              |
 | - schemeAndroid   | String  | X  | 안드로이드 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                     |
 | - schemeIos       | String  | X  | iOS 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                       |
+
+<a id="request-to-register-carousel-feed-type-template"></a>
 
 #### 캐러셀 피드형 템플릿 등록 요청
 
@@ -2955,6 +3055,8 @@ Content-Type: application/json;charset=UTF-8
 | - recipientNo     | String  | O  | 수신 번호                                                                                                                                                                                                                             |
 | createUser        | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                       |
 
+<a id="request-to-register-carousel-commerce-type-template"></a>
+
 #### 캐러셀 커머스형 템플릿 등록 요청
 
 [Request body]
@@ -3063,6 +3165,8 @@ Content-Type: application/json;charset=UTF-8
 | -- schemeAndroid     | String  | X  | 안드로이드 앱 링크, 500자 제한<br>치환자 사용 불가능                                                                                                                                                                                               |
 | -- schemeIos         | String  | X  | iOS 앱 링크, 500자 제한<br>치환자 사용 불가능                                                                                                                                                                                                 |
 
+<a id="response-10"></a>
+
 #### 응답
 
 ```
@@ -3087,7 +3191,11 @@ Content-Type: application/json;charset=UTF-8
 | template        | Object  | X        | 템플릿 정보 |
 | - templateCode  | String  | O        | 템플릿 코드 |
 
+<a id="modify-template"></a>
+
 ### 템플릿 수정
+
+<a id="requested-10"></a>
 
 #### 요청
 
@@ -3122,6 +3230,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 템플릿 등록과 스펙이 같음
 
+<a id="response-11"></a>
+
 #### 응답
 
 ```
@@ -3141,7 +3251,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 결과 메시지 |
 | - isSuccessful  | boolean | O        | 성공 여부  |
 
+<a id="delete-template"></a>
+
 ### 템플릿 삭제
+
+<a id="requested-11"></a>
 
 #### 요청
 
@@ -3172,6 +3286,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | 콘솔에서 생성할 수 있습니다. |
 
+<a id="response-12"></a>
+
 #### 응답
 
 ```
@@ -3191,9 +3307,15 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 결과 메시지 |
 | - isSuccessful  | boolean | O        | 성공 여부  |
 
+<a id="manage-image"></a>
+
 ## 이미지 관리
 
+<a id="upload-image"></a>
+
 ### 이미지 업로드
+
+<a id="requested-12"></a>
 
 #### 요청
 
@@ -3229,6 +3351,8 @@ Content-Type: multipart/form-data
 | image     | File   | O  | 이미지                                                                                                                            |
 | imageType | String | O  | 이미지 타입 <br>(IMAGE, WIDE_IMAGE,MAIN_WIDE_ITEMLIST_IMAGE,NORMAL_WIDE_ITEMLIST_IMAGE,CAROUSEL_FEED_IMAGE,CAROUSEL_COMMERCE_IMAGE) |
 
+<a id="response-13"></a>
+
 #### 응답
 
 ```
@@ -3257,6 +3381,8 @@ Content-Type: multipart/form-data
 | - imageUrl      | String  | O        | 이미지 URL |
 | - imageName     | String  | X        | 이미지명    |
 
+<a id="upload-image-specifications"></a>
+
 #### 업로드 이미지 규격
 | 이미지 타입                     | 사용처                                                     | 업로드 이미지 규격                                                                                                                              |
 |:---------------------------|:--------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------|
@@ -3269,7 +3395,11 @@ Content-Type: multipart/form-data
 
 * 템플릿 수정 시 이미지를 다른 이미지로 변경하면 기존 이미지가 카카오 CDN에서 삭제되어 URL이 유효하지 않게 됩니다. 동일한 이미지를 사용하는 다른 템플릿도 영향을 받으므로 주의가 필요합니다. 이미지 조회 API에서는 이미지 정보가 유지되지만, 실제 이미지에는 접근할 수 없으므로 원본 파일은 자체 서버에 별도로 보관하는 것을 권장합니다.
 
+<a id="view-image"></a>
+
 ### 이미지 조회
+
+<a id="requested-13"></a>
 
 #### 요청
 
@@ -3306,6 +3436,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum    | String | X  | 페이지 번호(기본: 1)                                                                                                                  |
 | pageSize   | String | X  | 조회 건수(기본: 15)                                                                                                                  |
 
+<a id="response-14"></a>
+
 #### 응답
 
 ```
@@ -3334,7 +3466,11 @@ Content-Type: application/json;charset=UTF-8
 | - imageUrl      | String  | O        | 이미지 URL |
 | - imageName     | String  | X        | 이미지명    |
 
+<a id="delete-image"></a>
+
 ### 이미지 삭제
+
+<a id="requested-14"></a>
 
 #### 요청
 
@@ -3369,6 +3505,8 @@ Content-Type: application/json;charset=UTF-8
 |----------|--------|----|--------|
 | imageSeq | String | O  | 이미지 번호 |
 
+<a id="response-15"></a>
+
 #### 응답
 
 ```
@@ -3388,9 +3526,15 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 결과 메시지 |
 | - isSuccessful  | boolean | O        | 성공 여부  |
 
+<a id="upload"></a>
+
 ## 업로드
 
+<a id="upload-bizform-key"></a>
+
 ### 비즈폼 키 업로드
+
+<a id="requested-15"></a>
 
 #### 요청
 
@@ -3420,6 +3564,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | 콘솔에서 생성할 수 있습니다. |
 
+<a id="response-16"></a>
+
 #### 응답
 
 ```
@@ -3439,9 +3585,15 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 결과 메시지 |
 | - isSuccessful  | boolean | O        | 성공 여부  |
 
+<a id="manage-outgoing-profiles"></a>
+
 ## 발신 프로필 관리
 
+<a id="view-outgoing-profile"></a>
+
 ### 발신 프로필 조회
+
+<a id="requested-16"></a>
 
 #### 요청
 
@@ -3470,6 +3622,8 @@ Content-Type: application/json;charset=UTF-8
 | 이름           | 타입     | 필수 | 설명               |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | 콘솔에서 생성할 수 있습니다. |
+
+<a id="response-17"></a>
 
 #### 응답
 
@@ -3540,7 +3694,11 @@ Content-Type: application/json;charset=UTF-8
 | - createDate              | String  | X        | 등록 일자                                                                                                                 |
 | - initialUserRestriction  | boolean | O        | 최초 사용자 제한 여부                                                                                                          |
 
+<a id="modify-outgoing-profile-080-opt-out-number"></a>
+
 ### 발신 프로필 080 수신거부번호 수정
+
+<a id="requested-17"></a>
 
 #### 요청
 
@@ -3584,6 +3742,8 @@ Content-Type: application/json;charset=UTF-8
 | unsubscribeNo     | 	String | 	O  | 080 무료수신거부 전화번호(모두 미입력 시 발신 프로필에 등록된 무료수신거부 정보로 발송됨)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx  |
 | unsubscribeAuthNo | 	String | 	X  | 080 무료수신거부 인증번호(모두 미입력 시 발신 프로필에 등록된 무료수신거부 정보로 발송됨)<br>unsubscribeNo 없이 unsubscribeAuthNo만 입력 불가<br>예: 1234 |
 
+<a id="response-18"></a>
+
 #### 응답
 
 ```
@@ -3603,7 +3763,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 결과 메시지 |
 | - isSuccessful  | boolean | O        | 성공 여부  |
 
+<a id="manage-fallback"></a>
+
 ## 대체 발송 관리
+
+<a id="register-sms-appkey"></a>
 
 ### SMS AppKey 등록
 
@@ -3650,6 +3814,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
 ```
 
+<a id="response-19"></a>
+
 #### 응답
 
 ```
@@ -3662,6 +3828,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
   }
 }
 ```
+
+<a id="register-fallback-settings"></a>
 
 ### 대체 발송 설정 등록
 
@@ -3713,6 +3881,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/failback/appkey -d '{"senderKey": "0be23c29de88d6888798aeda57062516354d74ba","isResend": true,"resendSendNo": "01012341234" }
 ```
+
+<a id="response-20"></a>
 
 #### 응답
 


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Body text is never modified.** The model only sees heading outlines; edits apply to heading lines (and `<!-- TODO: translate body -->` stubs for missing sections) only.

## Analysis

| | |
| --- | --- |
| Engine | `claude-code (CLI)` |
| Model | `claude-sonnet-4-6` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `pre-align/fix-headings-20260615-080708` |
| Scope | 1 doc(s) scanned · 4 file(s) changed |
| Self-verify | ⚠️ 6 mismatch(es) remain |
| Jenkins build | http://testlab.cloud.toastoven.net:8080/job/user-guide-agent/job/align-heading/job/260521/77/ |
| Generated | 2026-06-15T10:30:13 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`pre-align/fix-headings-20260615-080708`): [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FAlimtalk%2Fblob%2Fpre-align%2Ffix-headings-20260615-080708%2Fko%2Ffriendtalkupgrade-api-guide.md&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FAlimtalk%2Fpull%2F224&source=ko&langs=en%2Cja)

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra demoted | extra removed | verify |
| --- | --: | --: | --: | --: | --: | --: | --: | :--: |
| `ko/friendtalkupgrade-api-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/friendtalkupgrade-api-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/friendtalkupgrade-api-guide.md` | 0 | 3 | 0 | 0 | 1 | 0 | 0 | ⚠️ 3 |
| `ja/friendtalkupgrade-api-guide-align-v2.md` | 0 | 0 | 0 | 1 | 0 | 0 | 0 | ⚠️ 3 |

<details><summary>남은 불일치 (검토 필요)</summary>

- `ja/friendtalkupgrade-api-guide.md`:
  - extra_in_target (ko#None/ja#21)
  - missing_in_target (ko#22/ja#None)
  - extra_in_target (ko#None/ja#66)
- `ja/friendtalkupgrade-api-guide-align-v2.md`:
  - missing_in_target (ko#21/ja#None)
  - extra_in_target (ko#None/ja#22)
  - extra_in_target (ko#None/ja#66)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/Alimtalk`