### PR TITLE
chore(pre-align): align-v2 heading structure (friendtalkupgrade-api-guide.md) with ko

### DIFF
--- a/en/friendtalkupgrade-api-guide.md
+++ b/en/friendtalkupgrade-api-guide.md
@@ -1,6 +1,10 @@
 ## Notification > KakaoTalk Bizmessage > Brand Message > API v1.0 Guide
 
+<a id="brand-message"></a>
+
 ## Brand Message
+
+<a id="api-domain"></a>
 
 #### \[API Domain]
 
@@ -8,7 +12,11 @@
 |----------|
 | [https://kakaotalk-bizmessage.api.nhncloudservice.com](https://kakaotalk-bizmessage.api.nhncloudservice.com)|
 
+<a id="introduce-v10-api"></a>
+
 ## Introduce v1.0 API
+
+<a id="manage-non-friend-message-sending-targeting-m-n"></a>
 
 ## Manage non-friend message sending (targeting M, N)
 
@@ -20,7 +28,11 @@ Non-friend message sending (targeting M, N) can be sent if all the conditions be
 - 50,000 or more channel friends
 - Successfully send notification messages within the past three months
 
+<a id="upload-marketing-consent-evidence"></a>
+
 ### Upload marketing consent evidence
+
+<a id="requested"></a>
 
 #### Requested
 
@@ -56,6 +68,8 @@ Content-Type: multipart/form-data
 |----------|----------|----------|----------|
 | file| File| O| Marketing consent evidence|
 
+<a id="response"></a>
+
 #### Response
 
 ```
@@ -75,7 +89,11 @@ Content-Type: multipart/form-data
 | \- resultMessage| String| O| Result message|
 | \- isSuccessful| boolean| O| Success status|
 
+<a id="apply-for-using-non-friend-message-sending-targeting-m-n"></a>
+
 ### Apply for using non-friend message sending (targeting M, N)
+
+<a id="requested-2"></a>
 
 #### Requested
 
@@ -105,6 +123,8 @@ Content-Type: application/json;charset=UTF-8
 |----------|----------|----------|----------|
 | X-Secret-Key| String| O| Available to create from the console.|
 
+<a id="response-2"></a>
+
 #### Response
 
 ```
@@ -123,6 +143,8 @@ Content-Type: application/json;charset=UTF-8
 | \- resultCode| Integer| O| Result code|
 | \- resultMessage| String| O| Result message|
 | \- isSuccessful| boolean| O| Success status|
+
+<a id="request-to-send-a-free-form-message"></a>
 
 ## Request to send a free-form message
 
@@ -145,6 +167,8 @@ Content-Type: application/json;charset=UTF-8
 * Fallback can be set via resendParameter for each recipient.
   * When using fallback, you need to register the SMS Appkey and set its sending through the fallback management API.
   * **Nighttime delivery restrictions(8:50 PM - 8:00 AM the next day)**
+
+<a id="requested-3"></a>
 
 #### Requested
 
@@ -172,6 +196,8 @@ Content-Type: application/json;charset=UTF-8
 | Name| Type| Required| Description|
 |----------|----------|----------|----------|
 | X-Secret-Key| String| O| Available to create from the console.|
+
+<a id="request-text-type-sending"></a>
 
 #### Request text-type sending
 
@@ -276,6 +302,8 @@ Content-Type: application/json;charset=UTF-8
 | resellerCode| String| X| Reseller code (used by resellers when sending)|
 | createUser| String| X| Registrant (stored as user UUID when sent from console)|
 | statsId| String| X| Statistics ID (not included in the outgoing search conditions. Up 8 characters)|
+
+<a id="request-image-type-sending"></a>
 
 #### Request image-type sending
 
@@ -388,6 +416,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser| String| X| Registrant (stored as user UUID when sent from console)|
 | statsId| String| X| Statistics ID (not included in the outgoing search conditions. Up 8 characters)|
 
+<a id="request-wide-image-type-sending"></a>
+
 #### Request wide image-type sending
 
 \[Request body]
@@ -498,6 +528,8 @@ Content-Type: application/json;charset=UTF-8
 | resellerCode| String| X| Reseller code (used by resellers when sending)|
 | createUser| String| X| Registrant (stored as user UUID when sent from console)|
 | statsId| String| X| Statistics ID (not included in the outgoing search conditions. Up 8 characters)|
+
+<a id="request-to-send-wide-item-list-type"></a>
 
 #### Request to send wide item list type
 
@@ -639,6 +671,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser| String| X| Registrant (stored as user UUID when sent from console)|
 | statsId| String| X| Statistics ID (not included in the outgoing search conditions. Up 8 characters)|
 
+<a id="request-to-send-premium-video-type"></a>
+
 #### Request to send premium video type
 
 \[Request body]
@@ -751,6 +785,8 @@ Content-Type: application/json;charset=UTF-8
 | resellerCode| String| X| Reseller code (used by resellers when sending)|
 | createUser| String| X| Registrant (stored as user UUID when sent from console)|
 | statsId| String| X| Statistics ID (not included in the outgoing search conditions. Up 8 characters)|
+
+<a id="request-to-send-commerce"></a>
 
 #### Request to send commerce
 
@@ -875,6 +911,8 @@ Content-Type: application/json;charset=UTF-8
 | resellerCode| String| X| Reseller code (used by resellers when sending)|
 | createUser| String| X| Registrant (stored as user UUID when sent from console)|
 | statsId| String| X| Statistics ID (not included in the outgoing search conditions. Up 8 characters)|
+
+<a id="request-to-send-carousel-feed-type"></a>
 
 #### Request to send carousel feed type
 ##### Carousel fixed placeholders (path-based template parameter)
@@ -1052,6 +1090,8 @@ Allow unique placeholder values for each item in a carousel-type template.
 | createUser| String| X        | Registrant (stored as user UUID when sent from console)|
 | statsId| String| X        | Statistics ID (not included in the outgoing search conditions. Up 8 characters)|
 
+<a id="request-to-send-carousel-commerce-type"></a>
+
 #### Request to send carousel commerce type
 
 \[Request body]
@@ -1208,6 +1248,8 @@ Allow unique placeholder values for each item in a carousel-type template.
 | createUser| String| X        | Registrant (stored as user UUID when sent from console)|
 | statsId| String| X        | Statistics ID (not included in the outgoing search conditions, up to 8 characters)|
 
+<a id="response-3"></a>
+
 #### Response
 
 ```
@@ -1245,6 +1287,8 @@ Allow unique placeholder values for each item in a carousel-type template.
 | \-- resultCode| Integer| O| Recipient-specific sending result code (success and various failure codes may exist)|
 | \-- resultMessage| String| O| Recipient-specific sending result message ("success" or a related message on success, detailed message on failure, cause on failure)|
 
+<a id="request-to-send-basic-message"></a>
+
 ## Request to send basic message
 
 * A sending using a template.
@@ -1260,6 +1304,8 @@ Allow unique placeholder values for each item in a carousel-type template.
 * Fallback can be set via resendParameter for each recipient.
   * When using fallback, you need to register the SMS Appkey and set its send through the fallback management API.
 * **Nighttime delivery restrictions(8:50 PM - 8:00 AM the next day)**
+
+<a id="cautions-for-use"></a>
 
 ### Cautions for use
 
@@ -1292,6 +1338,8 @@ Content-Type: application/json;charset=UTF-8
 | Name| Type| Required| Description|
 |----------|----------|----------|----------|
 | X-Secret-Key| String| O| Available to create from the console.|
+
+<a id="requested-4"></a>
 
 #### Requested
 
@@ -1359,6 +1407,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser| String| X| Registrant (stored as user UUID when sent from console)|
 | statsId| String| X| Statistics ID (not included in the outgoing search conditions, up to 8 characters)|
 
+<a id="response-4"></a>
+
 #### Response
 
 ```
@@ -1396,7 +1446,11 @@ Content-Type: application/json;charset=UTF-8
 | \-- resultCode| Integer| O| Recipient-specific sending result code (success and various failure codes may exist)|
 | \-- resultMessage| String| O| Recipient-specific sending result message ("success" or a related message on success, detailed message on failure, cause on failure)|
 
+<a id="view-sending-list"></a>
+
 ## View sending list
+
+<a id="requested-5"></a>
 
 #### Requested
 
@@ -1441,6 +1495,8 @@ Content-Type: application/json;charset=UTF-8
 | recipientGroupingKey| String| X| Recipient grouping key|
 | pageNum| String| X| Page number (default: 1\)|
 | pageSize| String| X| Number of views (default: 15, Max: 1,000)|
+
+<a id="response-5"></a>
 
 #### Response
 
@@ -1517,7 +1573,11 @@ Content-Type: application/json;charset=UTF-8
 | \-- recipientGroupingKey| String| X| Recipient grouping key|
 | \- totalCount| Integer| O| Total|
 
+<a id="view-single-sending"></a>
+
 ## View single sending
+
+<a id="requested-6"></a>
 
 #### Requested
 
@@ -1547,6 +1607,8 @@ Content-Type: application/json;charset=UTF-8
 | Name| Type| Required| Description|
 |----------|----------|----------|----------|
 | X-Secret-Key| String| O| Available to create from the console.|
+
+<a id="response-6"></a>
 
 #### Response
 
@@ -1808,7 +1870,11 @@ Content-Type: application/json;charset=UTF-8
 | \- senderGroupingKey| String| X| Outgoing grouping key|
 | \- recipientGroupingKey| String| X| Recipient grouping key|
 
+<a id="cancel-message-sending"></a>
+
 ## Cancel message sending
+
+<a id="requested-7"></a>
 
 #### Requested
 
@@ -1844,6 +1910,8 @@ Content-Type: application/json;charset=UTF-8
 |----------|----------|----------|----------|
 | recipientSeq| String| X| Recipient sequence number<br>(If you do not enter any information, all requests for that request ID will be canceled)|
 
+<a id="response-7"></a>
+
 #### Response
 
 ```
@@ -1869,9 +1937,15 @@ Content-Type: application/json;charset=UTF-8
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
 ```
 
+<a id="manage-templates"></a>
+
 ## Manage Templates
 
+<a id="view-template-list"></a>
+
 ### View template list
+
+<a id="requested-8"></a>
 
 #### Requested
 
@@ -1910,6 +1984,8 @@ Content-Type: application/json;charset=UTF-8
 | status| String| X| Template status code|
 | pageNum| Integer| X| Page number (Default: 1\)|
 | pageSize| Integer| X| Number of views (default: 15, Max: 1,000)|
+
+<a id="response-8"></a>
 
 #### Response
 
@@ -2138,6 +2214,8 @@ Content-Type: application/json;charset=UTF-8
 | \--- updateDate| String| X| Modified on|
 | \- totalCount| Integer| O| Total|
 
+<a id="view-single-template"></a>
+
 ### View single template
 
 \[URL]
@@ -2167,6 +2245,8 @@ Content-Type: application/json;charset=UTF-8
 |----------|----------|----------|----------|
 | X-Secret-Key| String| O| Available to create from the console.|
 | X-NC-API-IDEMPOTENCY-KEY | String | X | Key used as the basis for duplicate message delivery request detection<br>If a request is made with the same key within 10 minutes, the request will be treated as failed. |
+
+<a id="response-9"></a>
 
 #### Response
 
@@ -2389,7 +2469,11 @@ Content-Type: application/json;charset=UTF-8
 | \- createDate| String| O| Registered on|
 | \- updateDate| String| X| Modified on|
 
+<a id="register-template"></a>
+
 ### Register Template
+
+<a id="requested-9"></a>
 
 #### Requested
 
@@ -2419,6 +2503,8 @@ Content-Type: application/json;charset=UTF-8
 |----------|----------|----------|----------|
 | X-Secret-Key| String| O| Available to create from the console.|
 
+<a id="note"></a>
+
 #### Note
 
 * If applying placeholders to coupon titles, you must use the following fixed placeholders:
@@ -2437,6 +2523,8 @@ Content-Type: application/json;charset=UTF-8
   * discountPrice -> #{discount price}
   * discountRate -> #{discount rate}
   * discountFixed -> #{fixed discount price}
+
+<a id="request-to-register-text-type-template"></a>
 
 #### Request to register text type template
 
@@ -2491,6 +2579,8 @@ Content-Type: application/json;charset=UTF-8
 | \- linkPc| String| X| PC web link (optional for WL type), limited to 500 characters|
 | \- schemeAndroid| String| X| Android app link (required for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
 | \- schemeIos| String| X| iOS app link (required field for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
+
+<a id="request-to-register-image-type-template"></a>
 
 #### Request to register image type template
 
@@ -2553,6 +2643,8 @@ Content-Type: application/json;charset=UTF-8
 | \- schemeAndroid| String| X        | Android app link (required for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
 | \- schemeIos| String| X        | iOS app link (required field for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
 
+<a id="request-to-register-wide-image-type-template"></a>
+
 #### Request to register wide image type template
 
 \[Request body]
@@ -2613,6 +2705,8 @@ Content-Type: application/json;charset=UTF-8
 | \- linkPc| String| X        | PC web link (optional for WL type), limited to 500 characters|
 | \- schemeAndroid| String| X        | Android app link (required for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
 | \- schemeIos| String| X        | iOS app link (required field for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
+
+<a id="request-to-register-wide-item-list-type-template"></a>
 
 #### Request to register wide item list type template
 
@@ -2704,6 +2798,8 @@ Content-Type: application/json;charset=UTF-8
 | \- schemeAndroid| String| X| Android app link (required for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
 | \- schemeIos| String| X| iOS app link (required field for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
 
+<a id="request-to-register-premium-video-type-template"></a>
+
 #### Request to register premium video type template
 
 \[Request body]
@@ -2766,6 +2862,8 @@ Content-Type: application/json;charset=UTF-8
 | \- linkPc| String| X| PC web link (optional for WL type), limited to 500 characters|
 | \- schemeAndroid| String| X| Android app link (required for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
 | \- schemeIos| String| X| iOS app link (required field for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
+
+<a id="request-to-register-commerce-type-template"></a>
 
 #### Request to register commerce type template
 
@@ -2841,6 +2939,8 @@ Content-Type: application/json;charset=UTF-8
 | \- linkPc| String| X        | PC web link (optional for WL type), limited to 500 characters|
 | \- schemeAndroid| String| X        | Android app link (required for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
 | \- schemeIos| String| X        | iOS app link (required field for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
+
+<a id="request-to-register-carousel-feed-type-template"></a>
 
 #### Request to register carousel feed type template
 
@@ -2952,6 +3052,8 @@ Content-Type: application/json;charset=UTF-8
 | \- recipientNo| String| O        | Incoming number|
 | createUser| String| X        | Registrant (stored as user UUID when sent from console)|
 
+<a id="request-to-register-carousel-commerce-type-template"></a>
+
 #### Request to register carousel commerce type template
 
 \[Request body]
@@ -3060,6 +3162,8 @@ Content-Type: application/json;charset=UTF-8
 | \-- schemeAndroid| String| X        | Android app link, limited to 500 characters<br>No placeholders available|
 | \-- schemeIos| String| X        | iOS app link, limited to 500 characters<br>No placeholders available|
 
+<a id="response-10"></a>
+
 #### Response
 
 ```
@@ -3084,7 +3188,11 @@ Content-Type: application/json;charset=UTF-8
 | template| Object| X| Template Info|
 | \- templateCode| String| O| Template Code|
 
+<a id="modify-template"></a>
+
 ### Modify Template
+
+<a id="requested-10"></a>
 
 #### Requested
 
@@ -3119,6 +3227,8 @@ Content-Type: application/json;charset=UTF-8
 
 * Same specifications as template registration
 
+<a id="response-11"></a>
+
 #### Response
 
 ```
@@ -3138,7 +3248,11 @@ Content-Type: application/json;charset=UTF-8
 | \- resultMessage| String| O| Result message|
 | \- isSuccessful| boolean| O| Success status|
 
+<a id="delete-template"></a>
+
 ### Delete Template
+
+<a id="requested-11"></a>
 
 #### Requested
 
@@ -3169,6 +3283,8 @@ Content-Type: application/json;charset=UTF-8
 |----------|----------|----------|----------|
 | X-Secret-Key| String| O| Available to create from the console.|
 
+<a id="response-12"></a>
+
 #### Response
 
 ```
@@ -3188,9 +3304,15 @@ Content-Type: application/json;charset=UTF-8
 | \- resultMessage| String| O| Result message|
 | \- isSuccessful| boolean| O| Success status|
 
+<a id="manage-image"></a>
+
 ## Manage Image
 
+<a id="upload-image"></a>
+
 ### Upload image
+
+<a id="requested-12"></a>
 
 #### Requested
 
@@ -3226,6 +3348,8 @@ Content-Type: multipart/form-data
 | image| File| O| Image|
 | imageType| String| O| Image type <br>(IMAGE, WIDE_IMAGE,MAIN_WIDE_ITEMLIST_IMAGE,NORMAL_WIDE_ITEMLIST_IMAGE,CAROUSEL_FEED_IMAGE,CAROUSEL_COMMERCE_IMAGE)|
 
+<a id="response-13"></a>
+
 #### Response
 
 ```
@@ -3254,6 +3378,8 @@ Content-Type: multipart/form-data
 | \- imageUrl| String| O| Image URL|
 | \- imageName| String| X| Image Name|
 
+<a id="upload-image-specifications"></a>
+
 #### Upload Image Specifications
 | Image Type                 | Usage                                                                   | Upload Image Specifications                                                                                                                                                      |
 | :------------------------- | :---------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -3266,7 +3392,11 @@ Content-Type: multipart/form-data
 
 * If all templates referencing an uploaded image are deleted or changed to a different image, the image will be removed from the Kakao CDN, making the URL invalid. While image information is retained in the Image Retrieval API, the actual image cannot be accessed. It is recommended to store the original file separately on your own server.
 
+<a id="view-image"></a>
+
 ### View image
+
+<a id="requested-13"></a>
 
 #### Requested
 
@@ -3303,6 +3433,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum| String| X| Page number (default: 1\)|
 | pageSize| String| X| Number of views (default: 15\)|
 
+<a id="response-14"></a>
+
 #### Response
 
 ```
@@ -3331,7 +3463,11 @@ Content-Type: application/json;charset=UTF-8
 | \- imageUrl| String| O| Image URL|
 | \- imageName| String| X| Image Name|
 
+<a id="delete-image"></a>
+
 ### Delete Image
+
+<a id="requested-14"></a>
 
 #### Requested
 
@@ -3366,6 +3502,8 @@ Content-Type: application/json;charset=UTF-8
 |----------|----------|----------|----------|
 | imageSeq| String| O| Image number|
 
+<a id="response-15"></a>
+
 #### Response
 
 ```
@@ -3385,9 +3523,15 @@ Content-Type: application/json;charset=UTF-8
 | \- resultMessage| String| O| Result message|
 | \- isSuccessful| boolean| O| Success status|
 
+<a id="upload"></a>
+
 ## Upload
 
+<a id="upload-bizform-key"></a>
+
 ### Upload Bizform key
+
+<a id="requested-15"></a>
 
 #### Requested
 
@@ -3417,6 +3561,8 @@ Content-Type: application/json;charset=UTF-8
 |----------|----------|----------|----------|
 | X-Secret-Key| String| O| Available to create from the console.|
 
+<a id="response-16"></a>
+
 #### Response
 
 ```
@@ -3436,9 +3582,15 @@ Content-Type: application/json;charset=UTF-8
 | \- resultMessage| String| O| Result message|
 | \- isSuccessful| boolean| O| Success status|
 
+<a id="manage-outgoing-profiles"></a>
+
 ## Manage Outgoing Profiles
 
+<a id="view-outgoing-profile"></a>
+
 ### View outgoing profile
+
+<a id="requested-16"></a>
 
 #### Requested
 
@@ -3467,6 +3619,8 @@ Content-Type: application/json;charset=UTF-8
 | Name| Type| Required| Description|
 |----------|----------|----------|----------|
 | X-Secret-Key| String| O| Available to create from the console.|
+
+<a id="response-17"></a>
 
 #### Response
 
@@ -3537,7 +3691,11 @@ Content-Type: application/json;charset=UTF-8
 | \- createDate| String| X| Registered Date|
 | \- initialUserRestriction| boolean| O| First-time user restriction status|
 
+<a id="modify-outgoing-profile-080-opt-out-number"></a>
+
 ### Modify outgoing profile 080 opt-out number
+
+<a id="requested-17"></a>
 
 #### Requested
 
@@ -3581,6 +3739,8 @@ Content-Type: application/json;charset=UTF-8
 | unsubscribeNo| String| O| 080 toll-free opt-out phone number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx|
 | unsubscribeAuthNo| String| X| 080 toll-free opt-out verification number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>unsubscribeAuthNo cannot be entered without unsubscribeNo<br>ex) 1234|
 
+<a id="response-18"></a>
+
 #### Response
 
 ```
@@ -3600,7 +3760,11 @@ Content-Type: application/json;charset=UTF-8
 | \- resultMessage| String| O| Result message|
 | \- isSuccessful| boolean| O| Success status|
 
+<a id="manage-fallback"></a>
+
 ## Manage Fallback
+
+<a id="register-sms-appkey"></a>
 
 ### Register SMS AppKey
 
@@ -3647,6 +3811,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
 ```
 
+<a id="response-19"></a>
+
 #### Response
 
 ```
@@ -3659,6 +3825,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
   }
 }
 ```
+
+<a id="register-fallback-settings"></a>
 
 ### Register fallback settings
 
@@ -3710,6 +3878,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/failback/appkey -d '{"senderKey": "0be23c29de88d6888798aeda57062516354d74ba","isResend": true,"resendSendNo": "01012341234" }
 ```
+
+<a id="response-20"></a>
 
 #### Response
 

--- a/ja/friendtalkupgrade-api-guide.md
+++ b/ja/friendtalkupgrade-api-guide.md
@@ -1,6 +1,10 @@
 ## Notification > KakaoTalk Bizmessage > ブランドメッセージ > API v1.0 Guide
 
+<a id="brand-message"></a>
+
 ## ブランドメッセージ
+
+<a id="api-domain"></a>
 
 #### [APIドメイン]
 
@@ -8,7 +12,11 @@
 |------------------------------------------------------------------------------|
 | [https://kakaotalk-bizmessage.api.nhncloudservice.com](https://kakaotalk-bizmessage.api.nhncloudservice.com) |
 
+<a id="introduce-v10-api"></a>
+
 ## v1.0 API紹介
+
+<a id="manage-non-friend-message-sending-targeting-m-n"></a>
 
 ## 非友だちメッセージ送信(ターゲティングM、N)管理
 
@@ -20,7 +28,11 @@
   - チャンネルの友だち数が5万以上
   - 3か月以内にお知らせトークの送信成功履歴を保有
 
+<a id="upload-marketing-consent-evidence"></a>
+
 ### マーケティング受信同意の証明資料のアップロード
+
+<a id="requested"></a>
 
 #### リクエスト
 
@@ -56,6 +68,8 @@ Content-Type: multipart/form-data
 |------|------|----|---------------|
 | file | File | O | マーケティング受信同意の証明資料 |
 
+<a id="response"></a>
+
 #### レスポンス
 
 ```
@@ -75,7 +89,11 @@ Content-Type: multipart/form-data
 | - resultMessage | String  | O        | 結果メッセージ |
 | - isSuccessful  | boolean | O        | 成否 |
 
+<a id="apply-for-using-non-friend-message-sending-targeting-m-n"></a>
+
 ### 非友だちメッセージ送信(ターゲティングM、N)の使用申請
+
+<a id="requested-2"></a>
 
 #### リクエスト
 
@@ -105,6 +123,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
 
+<a id="response-2"></a>
+
 #### レスポンス
 
 ```
@@ -123,6 +143,8 @@ Content-Type: application/json;charset=UTF-8
 | - resultCode    | Integer | O        | 結果コード |
 | - resultMessage | String  | O        | 結果メッセージ |
 | - isSuccessful  | boolean | O        | 成否 |
+
+<a id="request-to-send-a-free-form-message"></a>
 
 ## メッセージ自由形送信リクエスト
 
@@ -145,6 +167,8 @@ Content-Type: application/json;charset=UTF-8
 * 代替送信は、受信者ごとにresendParameterを介して設定できます。
 * 代替送信をご利用になる場合、代替送信管理APIを介してSMS Appkeyの登録及び送信設定が必要です。
 * **夜間送信制限(20:50～翌日08:00)**
+
+<a id="requested-3"></a>
 
 #### リクエスト
 
@@ -172,6 +196,8 @@ Content-Type: application/json;charset=UTF-8
 | 名前         | タイプ   | 必須 | 説明             |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
+
+<a id="request-text-type-sending"></a>
 
 #### テキスト型送信リクエスト
 
@@ -259,6 +285,8 @@ Content-Type: application/json;charset=UTF-8
 | -- resendUnsubscribeNo | String | X | 代替送信080受信拒否番号<br><span style="color:red">(SMSサービスに登録された080受信拒否番号ではない場合、代替送信に失敗することがあります。)</span> |
 | createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
 | statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
+
+<a id="request-image-type-sending"></a>
 
 #### 画像形式の送信リクエスト
 
@@ -353,6 +381,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
 | statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
 
+<a id="request-wide-image-type-sending"></a>
+
 #### ワイド画像形式の送信リクエスト
 
 [Request body]
@@ -445,6 +475,8 @@ Content-Type: application/json;charset=UTF-8
 | -- resendUnsubscribeNo | String | X | 代替送信080受信拒否番号<br><span style="color:red">(SMSサービスに登録された080受信拒否番号ではない場合、代替送信に失敗することがあります。)</span> |
 | createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
 | statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
+
+<a id="request-to-send-wide-item-list-type"></a>
 
 #### ワイドアイテムリスト形式の送信リクエスト
 
@@ -568,6 +600,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
 | statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
 
+<a id="request-to-send-premium-video-type"></a>
+
 #### プレミアム動画形式の送信リクエスト
 
 [Request body]
@@ -662,6 +696,8 @@ Content-Type: application/json;charset=UTF-8
 | -- resendUnsubscribeNo | String | X | 代替送信080受信拒否番号<br><span style="color:red">(SMSサービスに登録された080受信拒否番号ではない場合、代替送信に失敗することがあります。)</span> |
 | createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
 | statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
+
+<a id="request-to-send-commerce"></a>
 
 #### コマース形式の送信リクエスト
 
@@ -768,6 +804,8 @@ Content-Type: application/json;charset=UTF-8
 | -- resendUnsubscribeNo | String | X | 代替送信080受信拒否番号<br><span style="color:red">(SMSサービスに登録された080受信拒否番号ではない場合、代替送信に失敗することがあります。)</span> |
 | createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
 | statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
+
+<a id="request-to-send-carousel-feed-type"></a>
 
 #### カルーセルフィード形式の送信リクエスト
 
@@ -906,6 +944,8 @@ Content-Type: application/json;charset=UTF-8
 | -- resendUnsubscribeNo | String | X | 代替送信080受信拒否番号<br><span style="color:red">(SMSサービスに登録された080受信拒否番号ではない場合、代替送信に失敗することがあります。)</span> |
 | createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
 | statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
+
+<a id="request-to-send-carousel-commerce-type"></a>
 
 #### カルーセルコマース形式の送信リクエスト
 
@@ -1066,6 +1106,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser | String | X  | 登録者(コンソールで送信時にユーザーUUIDとして保存) |
 | statsId | String | X  | 統計ID(送信検索条件には含まれません、最大8文字) |
 
+<a id="response-3"></a>
+
 #### レスポンス
 
 ```
@@ -1103,6 +1145,8 @@ Content-Type: application/json;charset=UTF-8
 | -- resultCode | Integer | O | 受信者別の送信結果コード(成功及び様々な失敗コードが存在する可能性があります) |
 | -- resultMessage | String | O | 受信者別の送信結果メッセージ(成功時は「success」または関連メッセージ、失敗時は失敗原因の詳細メッセージ) |
 
+<a id="request-to-send-basic-message"></a>
+
 ## メッセージ基本形送信リクエスト
 
 * テンプレートを利用した送信です。
@@ -1118,6 +1162,8 @@ Content-Type: application/json;charset=UTF-8
 * 代替送信は、受信者ごとにresendParameterを介して設定できます。
 * 代替送信をご利用になる場合、代替送信管理APIを介してSMS Appkeyの登録及び送信設定が必要です。
 * **夜間送信制限(20:50～翌日08:00)**
+
+<a id="cautions-for-use"></a>
 
 ### 使用時の注意事項
 
@@ -1150,6 +1196,8 @@ Content-Type: application/json;charset=UTF-8
 | 名前         | タイプ   | 必須 | 説明             |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
+
+<a id="requested-4"></a>
 
 #### 送信リクエスト
 
@@ -1219,6 +1267,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser | String | X | 登録者(コンソールから送信時、ユーザーUUIDとして保存) |
 | statsId | String | X | 統計ID(送信検索条件には含まれません。最大8文字) |
 
+<a id="response-4"></a>
+
 #### レスポンス
 
 ```
@@ -1256,7 +1306,11 @@ Content-Type: application/json;charset=UTF-8
 | -- resultCode | Integer | O | 受信者別の送信結果コード(成功及び様々な失敗コードが存在する可能性があります) |
 | -- resultMessage | String | O | 受信者別の送信結果メッセージ(成功時は「success」または関連メッセージ、失敗時は失敗原因の詳細メッセージ) |
 
+<a id="view-sending-list"></a>
+
 ## 送信リストの照会
+
+<a id="requested-5"></a>
 
 #### リクエスト
 
@@ -1299,6 +1353,8 @@ Content-Type: application/json;charset=UTF-8
 | resultCode       | String | X         | 送信結果(MRC01:成功MRC02:失敗)      |
 | pageNum          | String | X         | ページ番号(Default: 1)               |
 | pageSize | String | X | 照会件数(Default: 15、Max: 1,000) |
+
+<a id="response-5"></a>
 
 #### レスポンス
 
@@ -1371,7 +1427,11 @@ Content-Type: application/json;charset=UTF-8
 | -- createUser | String | X | 登録者(コンソールで送信時にユーザーUUIDとして保存) |
 | - totalCount | Integer | O | 合計数 |
 
+<a id="view-single-sending"></a>
+
 ## 送信単件照会
+
+<a id="requested-6"></a>
 
 #### リクエスト
 
@@ -1401,6 +1461,8 @@ Content-Type: application/json;charset=UTF-8
 | 名前         | タイプ   | 必須 | 説明             |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
+
+<a id="response-6"></a>
 
 #### レスポンス
 
@@ -1658,9 +1720,33 @@ Content-Type: application/json;charset=UTF-8
 | - resendRequestId     | String  | X        | 代替送信リクエストID                                                                                      | 
 | - createUser          | String  | X        | 登録者(コンソールから送信した場合、ユーザーUUIDで保存)                                                                      |
 
+<a id="cancel-message-sending"></a>
+
+## メッセージ送信取消
+
+<!-- TODO: translate body -->
+
+<a id="requested-7"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="response-7"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="manage-templates"></a>
+
 ## テンプレート管理
 
+<a id="view-template-list"></a>
+
 ### テンプレートリスト照会
+
+<a id="requested-8"></a>
 
 #### リクエスト
 
@@ -1699,6 +1785,8 @@ Content-Type: application/json;charset=UTF-8
 | status       | String  | X  | テンプレートステータスコード                   |
 | pageNum      | Integer | X  | ページ番号(Default: 1)            |
 | pageSize     | Integer | X  | 照会件数(Default: 15, Max: 1,000) |
+
+<a id="response-8"></a>
 
 #### レスポンス
 
@@ -1927,6 +2015,8 @@ Content-Type: application/json;charset=UTF-8
 | --- updateDate          | String  | X        | 修正日時                                |
 | - totalCount            | Integer | O        | 合計数                                  |
 
+<a id="view-single-template"></a>
+
 ### テンプレートの個別照会
 
 [URL]
@@ -1956,6 +2046,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
 |X-NC-API-IDEMPOTENCY-KEY| String| X | 重複メッセージ送信リクエストの基準key<br>10分間同じkeyでリクエストした場合、該当リクエストは失敗として処理します。 |
+
+<a id="response-9"></a>
 
 #### レスポンス
 
@@ -2178,7 +2270,11 @@ Content-Type: application/json;charset=UTF-8
 | - createDate          | String  | O        | 登録日時              |
 | - updateDate          | String  | X        | 修正日時              |
 
+<a id="register-template"></a>
+
 ### テンプレート登録
+
+<a id="requested-9"></a>
 
 #### リクエスト
 
@@ -2208,6 +2304,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
 
+<a id="note"></a>
+
 #### 注意事項
 
 * クーポン名にプレースホルダーを適用する場合、次のような固定プレースホルダーを使用する必要があります。
@@ -2226,6 +2324,8 @@ Content-Type: application/json;charset=UTF-8
     * discountPrice -> #{割引価格}
     * discountRate -> #{割引率}
     * discountFixed -> #{定額割引価格}
+
+<a id="request-to-register-text-type-template"></a>
 
 #### テキスト型テンプレート登録リクエスト
 
@@ -2280,6 +2380,8 @@ Content-Type: application/json;charset=UTF-8
 | - linkPc        | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                                               |
 | - schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                       |
 | - schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                         |
+
+<a id="request-to-register-image-type-template"></a>
 
 #### 画像型テンプレート登録リクエスト
 
@@ -2342,6 +2444,8 @@ Content-Type: application/json;charset=UTF-8
 | - schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                       |
 | - schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                         |
 
+<a id="request-to-register-wide-image-type-template"></a>
+
 #### ワイド画像型テンプレート登録リクエスト
 
 [Request body]
@@ -2402,6 +2506,8 @@ Content-Type: application/json;charset=UTF-8
 | - linkPc        | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                                               |
 | - schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                       |
 | - schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                         |
+
+<a id="request-to-register-wide-item-list-type-template"></a>
 
 #### ワイドアイテムリスト型テンプレート登録リクエスト
 
@@ -2493,6 +2599,8 @@ Content-Type: application/json;charset=UTF-8
 | - schemeAndroid  | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                     |
 | - schemeIos      | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                       |
 
+<a id="request-to-register-premium-video-type-template"></a>
+
 #### プレミアム動画型テンプレート登録リクエスト
 
 [Request body]
@@ -2555,6 +2663,8 @@ Content-Type: application/json;charset=UTF-8
 | - linkPc        | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                                               |
 | - schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                       |
 | - schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                         |
+
+<a id="request-to-register-commerce-type-template"></a>
 
 #### コマース型テンプレート登録リクエスト
 
@@ -2630,6 +2740,8 @@ Content-Type: application/json;charset=UTF-8
 | - linkPc          | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                             |
 | - schemeAndroid   | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                     |
 | - schemeIos       | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                       |
+
+<a id="request-to-register-carousel-feed-type-template"></a>
 
 #### カルーセルフィード型テンプレート登録リクエスト
 
@@ -2741,6 +2853,8 @@ Content-Type: application/json;charset=UTF-8
 | - recipientNo     | String  | O  | 受信番号                                                                                                                                                                                                                           |
 | createUser        | String  | X  | 登録者(コンソールから送信した場合、ユーザーUUIDで保存)                                                                                                                                                                                                       |
 
+<a id="request-to-register-carousel-commerce-type-template"></a>
+
 #### カルーセルコマース型テンプレート登録リクエスト
 
 [Request body]
@@ -2849,6 +2963,8 @@ Content-Type: application/json;charset=UTF-8
 | -- schemeAndroid     | String  | X  | Androidアプリリンク、500文字制限<br>プレースホルダーは使用不可。                                                                                                                                                                                               |
 | -- schemeIos         | String  | X  | iOSアプリリンク、500文字制限<br>プレースホルダーは使用不可。                                                                                                                                                                                                 |
 
+<a id="response-10"></a>
+
 #### レスポンス
 
 ```
@@ -2873,7 +2989,11 @@ Content-Type: application/json;charset=UTF-8
 | template        | Object  | X        | テンプレート情報 |
 | - templateCode  | String  | O        | テンプレートコード |
 
+<a id="modify-template"></a>
+
 ### テンプレート修正
+
+<a id="requested-10"></a>
 
 #### リクエスト
 
@@ -2908,6 +3028,8 @@ Content-Type: application/json;charset=UTF-8
 
 * テンプレート登録と仕様は同じです
 
+<a id="response-11"></a>
+
 #### レスポンス
 
 ```
@@ -2927,7 +3049,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 結果メッセージ |
 | - isSuccessful  | boolean | O        | 成否 |
 
+<a id="delete-template"></a>
+
 ### テンプレート削除
+
+<a id="requested-11"></a>
 
 #### リクエスト
 
@@ -2958,6 +3084,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
 
+<a id="response-12"></a>
+
 #### レスポンス
 
 ```
@@ -2977,9 +3105,15 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 結果メッセージ |
 | - isSuccessful  | boolean | O        | 成否 |
 
+<a id="manage-image"></a>
+
 ## 画像管理
 
+<a id="upload-image"></a>
+
 ### 画像アップロード
+
+<a id="requested-12"></a>
 
 #### リクエスト
 
@@ -3015,6 +3149,8 @@ Content-Type: multipart/form-data
 | image     | File   | O  | 画像                                                                                                                           |
 | imageType | String | O  | 画像タイプ <br>(IMAGE, WIDE_IMAGE,MAIN_WIDE_ITEMLIST_IMAGE,NORMAL_WIDE_ITEMLIST_IMAGE,CAROUSEL_FEED_IMAGE,CAROUSEL_COMMERCE_IMAGE) |
 
+<a id="response-13"></a>
+
 #### レスポンス
 
 ```
@@ -3043,6 +3179,8 @@ Content-Type: multipart/form-data
 | - imageUrl      | String  | O        | 画像のURL |
 | - imageName     | String  | X        | 画像名   |
 
+<a id="upload-image-specifications"></a>
+
 #### アップロード画像規格
 | 画像タイプ                      | 使用先                                                 | アップロード画像規格                                                                                                         |
 | :------------------------- | :-------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------- |
@@ -3053,7 +3191,7 @@ Content-Type: multipart/form-data
 | CAROUSEL_FEED_IMAGE        | カルーセルフィード形式の送信リクエストのセル別画像                           | **推奨サイズ：**800 × 600px または 800 × 400px（横500px以上）<br/>**画像比率：**0.5 ≤ 縦 ÷ 横 ≤ 1.333<br/>**ファイル形式／容量制限：**jpg、png／最大5MB |
 | CAROUSEL_COMMERCE_IMAGE    | コマース形式の送信リクエスト（カルーセルコマース形式）のイントロ画像、セル別画像            | **推奨サイズ：**800 × 600px または 800 × 400px（横500px以上）<br/>**画像比率：**0.5 ≤ 縦 ÷ 横 ≤ 1.333<br/>**ファイル形式／容量制限：**jpg、png／最大5MB |
 
-#### アップロード画像規格
+**アップロード画像規格**
 | 画像タイプ                     | 使用箇所                                                     | アップロード画像規格                                                                                                                              |
 |:---------------------------|:--------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------|
 | IMAGE                      | 画像型画像、コマース型画像、プレミアム動画型サムネイル                       | 推奨サイズ: 800 X 400px (横500px以上)<br/>画像比率: 0.5 ≤ 縦 ÷ 横 ≤ 1.333<br/>ファイル形式及び容量制限: jpg, png / 最大5MB                                |
@@ -3065,7 +3203,11 @@ Content-Type: multipart/form-data
 
 * アップロードされた画像を参照するテンプレートが全て削除されるか、別の画像に変更されると、Kakao CDNから該当の画像が削除され、URLが無効になります。画像照会APIでは画像情報が維持されますが、実際の画像にはアクセスできないため、オリジナルファイルは自社サーバーに別途保管することを推奨します。
 
+<a id="view-image"></a>
+
 ### 画像照会
+
+<a id="requested-13"></a>
 
 #### リクエスト
 
@@ -3102,6 +3244,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum    | String | X  | ページ番号(基本: 1)                                                                                                                  |
 | pageSize   | String | X  | 照会件数(基本: 15)                                                                                                                  |
 
+<a id="response-14"></a>
+
 #### レスポンス
 
 ```
@@ -3130,7 +3274,11 @@ Content-Type: application/json;charset=UTF-8
 | - imageUrl      | String  | O        | 画像のURL |
 | - imageName     | String  | X        | 画像名   |
 
+<a id="delete-image"></a>
+
 ### 画像削除
+
+<a id="requested-14"></a>
 
 #### リクエスト
 
@@ -3165,6 +3313,8 @@ Content-Type: application/json;charset=UTF-8
 |----------|--------|----|--------|
 | imageSeq | String | O  | 画像番号 |
 
+<a id="response-15"></a>
+
 #### レスポンス
 
 ```
@@ -3184,9 +3334,15 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 結果メッセージ |
 | - isSuccessful  | boolean | O        | 成否 |
 
+<a id="upload"></a>
+
 ## アップロード
 
+<a id="upload-bizform-key"></a>
+
 ### ビズフォームキーのアップロード
+
+<a id="requested-15"></a>
 
 #### リクエスト
 
@@ -3216,6 +3372,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
 
+<a id="response-16"></a>
+
 #### レスポンス
 
 ```
@@ -3235,9 +3393,15 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 結果メッセージ |
 | - isSuccessful  | boolean | O        | 成否 |
 
+<a id="manage-outgoing-profiles"></a>
+
 ## 送信プロフィール管理
 
+<a id="view-outgoing-profile"></a>
+
 ### 送信プロフィール照会
+
+<a id="requested-16"></a>
 
 #### リクエスト
 
@@ -3266,6 +3430,8 @@ Content-Type: application/json;charset=UTF-8
 | 名前         | タイプ   | 必須 | 説明             |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
+
+<a id="response-17"></a>
 
 #### レスポンス
 
@@ -3336,7 +3502,11 @@ Content-Type: application/json;charset=UTF-8
 | - createDate              | String  | X        | 登録日                                                                                                                |
 | - initialUserRestriction  | boolean | O        | 初回ユーザー制限の有無                                                                                                         |
 
+<a id="modify-outgoing-profile-080-opt-out-number"></a>
+
 ### 送信プロフィールの080受信拒否番号の修正
+
+<a id="requested-17"></a>
 
 #### リクエスト
 
@@ -3380,6 +3550,8 @@ Content-Type: application/json;charset=UTF-8
 | unsubscribeNo     | 	String | 	O  | 080無料受信拒否電話番号(両方とも未入力の場合、送信プロフィールに登録された無料受信拒否情報で送信されます)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx  |
 | unsubscribeAuthNo | 	String | 	X  | 080無料受信拒否認証番号(両方とも未入力の場合、送信プロフィールに登録された無料受信拒否情報で送信されます)<br>unsubscribe_phone_numberなしでunsubscribe_auth_numberのみの入力は不可<br>ex) 1234 |
 
+<a id="response-18"></a>
+
 #### レスポンス
 
 ```
@@ -3399,7 +3571,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 結果メッセージ |
 | - isSuccessful  | boolean | O        | 成否 |
 
+<a id="manage-fallback"></a>
+
 ## 代替送信管理
+
+<a id="register-sms-appkey"></a>
 
 ### SMS AppKeyの登録
 
@@ -3446,6 +3622,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
 ```
 
+<a id="response-19"></a>
+
 #### レスポンス
 
 ```
@@ -3458,6 +3636,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
   }
 }
 ```
+
+<a id="register-fallback-settings"></a>
 
 ### 代替送信設定の登録
 
@@ -3509,6 +3689,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/failback/appkey -d '{"senderKey": "0be23c29de88d6888798aeda57062516354d74ba","isResend": true,"resendSendNo": "01012341234" }
 ```
+
+<a id="response-20"></a>
 
 #### レスポンス
 

--- a/ko/friendtalkupgrade-api-guide.md
+++ b/ko/friendtalkupgrade-api-guide.md
@@ -1,6 +1,10 @@
 ## Notification > KakaoTalk Bizmessage > 브랜드 메시지 > API v1.0 Guide
 
+<a id="brand-message"></a>
+
 ## 브랜드 메시지
+
+<a id="api-domain"></a>
 
 #### [API 도메인]
 
@@ -8,7 +12,11 @@
 |------------------------------------------------------------------------------|
 | [https://kakaotalk-bizmessage.api.nhncloudservice.com](https://kakaotalk-bizmessage.api.nhncloudservice.com) |
 
+<a id="introduce-v10-api"></a>
+
 ## v1.0 API 소개
+
+<a id="manage-non-friend-message-sending-targeting-m-n"></a>
 
 ## 비친구 메시지 발송(타겟팅 M, N) 관리
 
@@ -20,7 +28,11 @@
 - 채널 친구 수 5만 이상
 - 3개월 내 알림톡 발송 성공 이력 보유
 
+<a id="upload-marketing-consent-evidence"></a>
+
 ### 마케팅 수신 동의 증적 자료 업로드
+
+<a id="requested"></a>
 
 #### 요청
 
@@ -56,6 +68,8 @@ Content-Type: multipart/form-data
 |------|------|----|---------------|
 | file | File | O  | 마케팅 수신 동의 증적 자료 |
 
+<a id="response"></a>
+
 #### 응답
 
 ```
@@ -75,7 +89,11 @@ Content-Type: multipart/form-data
 | - resultMessage | String  | O        | 결과 메시지 |
 | - isSuccessful  | boolean | O        | 성공 여부  |
 
+<a id="apply-for-using-non-friend-message-sending-targeting-m-n"></a>
+
 ### 비친구 메시지 발송(타겟팅 M, N) 사용 신청
+
+<a id="requested-2"></a>
 
 #### 요청
 
@@ -105,6 +123,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | 콘솔에서 생성할 수 있습니다. |
 
+<a id="response-2"></a>
+
 #### 응답
 
 ```
@@ -123,6 +143,8 @@ Content-Type: application/json;charset=UTF-8
 | - resultCode    | Integer | O        | 결과 코드  |
 | - resultMessage | String  | O        | 결과 메시지 |
 | - isSuccessful  | boolean | O        | 성공 여부  |
+
+<a id="request-to-send-a-free-form-message"></a>
 
 ## 메시지 자유형 발송 요청
 
@@ -145,6 +167,8 @@ Content-Type: application/json;charset=UTF-8
 * 대체 발송은 수신자별 resendParameter를 통해 설정할 수 있습니다.
     * 대체 발송을 이용할 경우 대체 발송 관리 API를 통해 SMS Appkey 등록 및 발송 설정이 필요합니다.
 * **야간 발송 제한(20:50~다음 날 08:00)**
+
+<a id="requested-3"></a>
 
 #### 요청
 
@@ -172,6 +196,8 @@ Content-Type: application/json;charset=UTF-8
 | 이름           | 타입     | 필수 | 설명               |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | 콘솔에서 생성할 수 있습니다. |
+
+<a id="request-text-type-sending"></a>
 
 #### 텍스트형 발송 요청
 
@@ -276,6 +302,8 @@ Content-Type: application/json;charset=UTF-8
 | resellerCode          | String  | X  | 리셀러 코드(리셀러가 발송 시 사용)                                                                                                                                                                                                                                                       |
 | createUser             | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                                                                   |
 | statsId                | String  | 	X | 통계 ID(발신 검색 조건에는 포함되지 않습니다. 최대 8자)                                                                                                                                                                                                                                            |
+
+<a id="request-image-type-sending"></a>
 
 #### 이미지형 발송 요청
 
@@ -388,6 +416,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser             | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                                                                   |
 | statsId                | String  | 	X | 통계 ID(발신 검색 조건에는 포함되지 않습니다. 최대 8자)                                                                                                                                                                                                                                            |
 
+<a id="request-wide-image-type-sending"></a>
+
 #### 와이드 이미지형 발송 요청
 
 [Request body]
@@ -498,6 +528,8 @@ Content-Type: application/json;charset=UTF-8
 | resellerCode          | String  | X  | 리셀러 코드(리셀러가 발송 시 사용)                                                                                                                                                                                                                                                       |
 | createUser             | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                                                                   |
 | statsId                | String  | 	X | 통계 ID(발신 검색 조건에는 포함되지 않습니다. 최대 8자)                                                                                                                                                                                                                                            |
+
+<a id="request-to-send-wide-item-list-type"></a>
 
 #### 와이드 아이템리스트형 발송 요청
 
@@ -639,6 +671,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser             | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                                                                   |
 | statsId                | String  | 	X | 통계 ID(발신 검색 조건에는 포함되지 않습니다. 최대 8자)                                                                                                                                                                                                                                            |
 
+<a id="request-to-send-premium-video-type"></a>
+
 #### 프리미엄 동영상형 발송 요청
 
 [Request body]
@@ -751,6 +785,8 @@ Content-Type: application/json;charset=UTF-8
 | resellerCode          | String  | X  | 리셀러 코드(리셀러가 발송 시 사용)                                                                                                                                                                                                                                                       |
 | createUser             | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                                                                   |
 | statsId                | String  | 	X | 통계 ID(발신 검색 조건에는 포함되지 않습니다. 최대 8자)                                                                                                                                                                                                                                            |
+
+<a id="request-to-send-commerce"></a>
 
 #### 커머스형 발송 요청
 
@@ -875,6 +911,8 @@ Content-Type: application/json;charset=UTF-8
 | resellerCode          | String  | X  | 리셀러 코드(리셀러가 발송 시 사용)                                                                                                                                                                                                                                                       |
 | createUser             | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                                                                   |
 | statsId                | String  | 	X | 통계 ID(발신 검색 조건에는 포함되지 않습니다. 최대 8자)                                                                                                                                                                                                                                            |
+
+<a id="request-to-send-carousel-feed-type"></a>
 
 #### 캐러셀 피드형 발송 요청
 
@@ -1053,6 +1091,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser             | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                                                                   |
 | statsId                | String  | 	X | 통계 ID(발신 검색 조건에는 포함되지 않습니다. 최대 8자)                                                                                                                                                                                                                                            |
 
+<a id="request-to-send-carousel-commerce-type"></a>
+
 #### 캐러셀 커머스형 발송 요청
 
 [Request body]
@@ -1209,6 +1249,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser           | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                                                                   |
 | statsId              | String  | 	X | 통계 ID(발신 검색 조건에는 포함되지 않습니다. 최대 8자)                                                                                                                                                                                                                                            |
 
+<a id="response-3"></a>
+
 #### 응답
 
 ```
@@ -1246,6 +1288,8 @@ Content-Type: application/json;charset=UTF-8
 | -- resultCode    | Integer | O        | 수신자별 발송 결과 코드(성공 및 다양한 실패 코드가 존재할 수 있음)                     |
 | -- resultMessage | String  | O        | 수신자별 발송 결과 메시지(성공 시 "success" 또는 관련 메시지, 실패 시 실패 원인 상세 메시지) |
 
+<a id="request-to-send-basic-message"></a>
+
 ## 메시지 기본형 발송 요청
 
 * 템플릿을 이용한 발송입니다.
@@ -1261,6 +1305,8 @@ Content-Type: application/json;charset=UTF-8
 * 대체 발송은 수신자별 resendParameter를 통해 설정할 수 있습니다.
     * 대체 발송을 이용할 경우 대체 발송 관리 API를 통해 SMS Appkey 등록 및 발송 설정이 필요합니다.
 * **야간 발송 제한(20:50~다음 날 08:00)**
+
+<a id="cautions-for-use"></a>
 
 ### 사용 시 주의사항
 
@@ -1293,6 +1339,8 @@ Content-Type: application/json;charset=UTF-8
 | 이름           | 타입     | 필수 | 설명               |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | 콘솔에서 생성할 수 있습니다. |
+
+<a id="requested-4"></a>
 
 #### 발송 요청
 
@@ -1363,6 +1411,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser             | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                             |
 | statsId                | String  | X  | 통계 ID(발신 검색 조건에는 포함되지 않습니다. 최대 8자)                                                                                                                                                                                                      |
 
+<a id="response-4"></a>
+
 #### 응답
 
 ```
@@ -1400,7 +1450,11 @@ Content-Type: application/json;charset=UTF-8
 | -- resultCode    | Integer | O        | 수신자별 발송 결과 코드(성공 및 다양한 실패 코드가 존재할 수 있음)                     |
 | -- resultMessage | String  | O        | 수신자별 발송 결과 메시지(성공 시 "success" 또는 관련 메시지, 실패 시 실패 원인 상세 메시지) |
 
+<a id="view-sending-list"></a>
+
 ## 발송 목록 조회
+
+<a id="requested-5"></a>
 
 #### 요청
 
@@ -1445,6 +1499,8 @@ Content-Type: application/json;charset=UTF-8
 | recipientGroupingKey | 	String  | 	X         | 수신자 그룹핑 키                        |
 | pageNum          | String | X         | 페이지 번호(Default: 1)               |
 | pageSize         | String | X         | 조회 건수(Default: 15, Max: 1000)    |
+
+<a id="response-5"></a>
 
 #### 응답
 
@@ -1521,7 +1577,11 @@ Content-Type: application/json;charset=UTF-8
 | -- recipientGroupingKey     | String  | X        | 수신자 그룹핑 키                                           |
 | - totalCount                | Integer | O        | 총 개수                                                                  |
 
+<a id="view-single-sending"></a>
+
 ## 발송 단건 조회
+
+<a id="requested-6"></a>
 
 #### 요청
 
@@ -1551,6 +1611,8 @@ Content-Type: application/json;charset=UTF-8
 | 이름           | 타입     | 필수 | 설명               |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | 콘솔에서 생성할 수 있습니다. |
+
+<a id="response-6"></a>
 
 #### 응답
 
@@ -1812,7 +1874,11 @@ Content-Type: application/json;charset=UTF-8
 | - senderGroupingKey   | String  | X        | 발신 그룹핑 키                                                 |
 | - recipientGroupingKey | String  | X        | 수신자 그룹핑 키                                           |
 
+<a id="cancel-message-sending"></a>
+
 ## 메시지 발송 취소
+
+<a id="requested-7"></a>
 
 #### 요청
 
@@ -1848,6 +1914,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|---------|-----|---------------------------------------------|
 | recipientSeq | 	String | 	X  | 수신자 시퀀스 번호<br>(입력하지 않으면 요청 ID의 모든 발송 건을 취소) |
 
+<a id="response-7"></a>
+
 #### 응답
 
 ```
@@ -1872,9 +1940,15 @@ Content-Type: application/json;charset=UTF-8
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
 ```
 
+<a id="manage-templates"></a>
+
 ## 템플릿 관리
 
+<a id="view-template-list"></a>
+
 ### 템플릿 리스트 조회
+
+<a id="requested-8"></a>
 
 #### 요청
 
@@ -1913,6 +1987,8 @@ Content-Type: application/json;charset=UTF-8
 | status       | String  | X  | 템플릿 상태 코드                     |
 | pageNum      | Integer | X  | 페이지 번호(Default: 1)            |
 | pageSize     | Integer | X  | 조회 건수(Default: 15, Max: 1000) |
+
+<a id="response-8"></a>
 
 #### 응답
 
@@ -2141,6 +2217,8 @@ Content-Type: application/json;charset=UTF-8
 | --- updateDate          | String  | X        | 수정 일시                                  |
 | - totalCount            | Integer | O        | 총 개수                                   |
 
+<a id="view-single-template"></a>
+
 ### 템플릿 단건 조회
 
 [URL]
@@ -2170,6 +2248,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | 콘솔에서 생성할 수 있습니다. |
 |X-NC-API-IDEMPOTENCY-KEY|	String| X | 중복 메시지 발송 요청 기준 key<br>10분간 동일한 key로 요청 시 해당 요청을 실패 처리합니다. |
+
+<a id="response-9"></a>
 
 #### 응답
 
@@ -2392,7 +2472,11 @@ Content-Type: application/json;charset=UTF-8
 | - createDate          | String  | O        | 등록 일시                |
 | - updateDate          | String  | X        | 수정 일시                |
 
+<a id="register-template"></a>
+
 ### 템플릿 등록
+
+<a id="requested-9"></a>
 
 #### 요청
 
@@ -2422,6 +2506,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | 콘솔에서 생성할 수 있습니다. |
 
+<a id="note"></a>
+
 #### 유의 사항
 
 * 쿠폰 제목에 치환자를 적용할 경우 다음과 같은 고정 치환자를 사용해야 합니다.
@@ -2440,6 +2526,8 @@ Content-Type: application/json;charset=UTF-8
     * discountPrice -> #{할인가격}
     * discountRate -> #{할인율}
     * discountFixed -> #{정액할인가격}
+
+<a id="request-to-register-text-type-template"></a>
 
 #### 텍스트형 템플릿 등록 요청
 
@@ -2494,6 +2582,8 @@ Content-Type: application/json;charset=UTF-8
 | - linkPc        | String  | X  | PC 웹 링크(WL 타입일 경우 선택 필드), 500자 제한                                                                                                                                                                                                            |
 | - schemeAndroid | String  | X  | 안드로이드 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                                   |
 | - schemeIos     | String  | X  | iOS 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                                     |
+
+<a id="request-to-register-image-type-template"></a>
 
 #### 이미지형 템플릿 등록 요청
 
@@ -2556,6 +2646,8 @@ Content-Type: application/json;charset=UTF-8
 | - schemeAndroid | String  | X  | 안드로이드 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                                       |
 | - schemeIos     | String  | X  | iOS 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                                         |
 
+<a id="request-to-register-wide-image-type-template"></a>
+
 #### 와이드 이미지형 템플릿 등록 요청
 
 [Request body]
@@ -2616,6 +2708,8 @@ Content-Type: application/json;charset=UTF-8
 | - linkPc        | String  | X  | PC 웹 링크(WL 타입일 경우 선택 필드), 500자 제한                                                                                                                                                                                                                |
 | - schemeAndroid | String  | X  | 안드로이드 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                                       |
 | - schemeIos     | String  | X  | iOS 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                                         |
+
+<a id="request-to-register-wide-item-list-type-template"></a>
 
 #### 와이드 아이템리스트형 템플릿 등록 요청
 
@@ -2707,6 +2801,8 @@ Content-Type: application/json;charset=UTF-8
 | - schemeAndroid  | String  | X  | 안드로이드 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                     |
 | - schemeIos      | String  | X  | iOS 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                       |
 
+<a id="request-to-register-premium-video-type-template"></a>
+
 #### 프리미엄 동영상형 템플릿 등록 요청
 
 [Request body]
@@ -2769,6 +2865,8 @@ Content-Type: application/json;charset=UTF-8
 | - linkPc        | String  | X  | PC 웹 링크(WL 타입일 경우 선택 필드), 500자 제한                                                                                                                                                                                                                |
 | - schemeAndroid | String  | X  | 안드로이드 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                                       |
 | - schemeIos     | String  | X  | iOS 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                                         |
+
+<a id="request-to-register-commerce-type-template"></a>
 
 #### 커머스형 템플릿 등록 요청
 
@@ -2844,6 +2942,8 @@ Content-Type: application/json;charset=UTF-8
 | - linkPc          | String  | X  | PC 웹 링크(WL 타입일 경우 선택 필드), 500자 제한                                                                                                                                                                                              |
 | - schemeAndroid   | String  | X  | 안드로이드 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                     |
 | - schemeIos       | String  | X  | iOS 앱 링크(AL 타입일 경우 필수 필드), 500자 제한<br>쿠폰에 linkMo 필드를 입력할 경우 나머지 필드는 선택 사항(옵션)이 되며,<br>scheme_android 또는 scheme_ios 필드에 채널 쿠폰 URL(형식: alimtalk=coupon://)을 입력할 경우 나머지 필드가 선택 사항(옵션)이 됩니다.                                       |
+
+<a id="request-to-register-carousel-feed-type-template"></a>
 
 #### 캐러셀 피드형 템플릿 등록 요청
 
@@ -2955,6 +3055,8 @@ Content-Type: application/json;charset=UTF-8
 | - recipientNo     | String  | O  | 수신 번호                                                                                                                                                                                                                             |
 | createUser        | String  | X  | 등록자(콘솔에서 발송 시 사용자 UUID로 저장)                                                                                                                                                                                                       |
 
+<a id="request-to-register-carousel-commerce-type-template"></a>
+
 #### 캐러셀 커머스형 템플릿 등록 요청
 
 [Request body]
@@ -3063,6 +3165,8 @@ Content-Type: application/json;charset=UTF-8
 | -- schemeAndroid     | String  | X  | 안드로이드 앱 링크, 500자 제한<br>치환자 사용 불가능                                                                                                                                                                                               |
 | -- schemeIos         | String  | X  | iOS 앱 링크, 500자 제한<br>치환자 사용 불가능                                                                                                                                                                                                 |
 
+<a id="response-10"></a>
+
 #### 응답
 
 ```
@@ -3087,7 +3191,11 @@ Content-Type: application/json;charset=UTF-8
 | template        | Object  | X        | 템플릿 정보 |
 | - templateCode  | String  | O        | 템플릿 코드 |
 
+<a id="modify-template"></a>
+
 ### 템플릿 수정
+
+<a id="requested-10"></a>
 
 #### 요청
 
@@ -3122,6 +3230,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 템플릿 등록과 스펙이 같음
 
+<a id="response-11"></a>
+
 #### 응답
 
 ```
@@ -3141,7 +3251,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 결과 메시지 |
 | - isSuccessful  | boolean | O        | 성공 여부  |
 
+<a id="delete-template"></a>
+
 ### 템플릿 삭제
+
+<a id="requested-11"></a>
 
 #### 요청
 
@@ -3172,6 +3286,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | 콘솔에서 생성할 수 있습니다. |
 
+<a id="response-12"></a>
+
 #### 응답
 
 ```
@@ -3191,9 +3307,15 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 결과 메시지 |
 | - isSuccessful  | boolean | O        | 성공 여부  |
 
+<a id="manage-image"></a>
+
 ## 이미지 관리
 
+<a id="upload-image"></a>
+
 ### 이미지 업로드
+
+<a id="requested-12"></a>
 
 #### 요청
 
@@ -3229,6 +3351,8 @@ Content-Type: multipart/form-data
 | image     | File   | O  | 이미지                                                                                                                            |
 | imageType | String | O  | 이미지 타입 <br>(IMAGE, WIDE_IMAGE,MAIN_WIDE_ITEMLIST_IMAGE,NORMAL_WIDE_ITEMLIST_IMAGE,CAROUSEL_FEED_IMAGE,CAROUSEL_COMMERCE_IMAGE) |
 
+<a id="response-13"></a>
+
 #### 응답
 
 ```
@@ -3257,6 +3381,8 @@ Content-Type: multipart/form-data
 | - imageUrl      | String  | O        | 이미지 URL |
 | - imageName     | String  | X        | 이미지명    |
 
+<a id="upload-image-specifications"></a>
+
 #### 업로드 이미지 규격
 | 이미지 타입                     | 사용처                                                     | 업로드 이미지 규격                                                                                                                              |
 |:---------------------------|:--------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------|
@@ -3269,7 +3395,11 @@ Content-Type: multipart/form-data
 
 * 템플릿 수정 시 이미지를 다른 이미지로 변경하면 기존 이미지가 카카오 CDN에서 삭제되어 URL이 유효하지 않게 됩니다. 동일한 이미지를 사용하는 다른 템플릿도 영향을 받으므로 주의가 필요합니다. 이미지 조회 API에서는 이미지 정보가 유지되지만, 실제 이미지에는 접근할 수 없으므로 원본 파일은 자체 서버에 별도로 보관하는 것을 권장합니다.
 
+<a id="view-image"></a>
+
 ### 이미지 조회
+
+<a id="requested-13"></a>
 
 #### 요청
 
@@ -3306,6 +3436,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum    | String | X  | 페이지 번호(기본: 1)                                                                                                                  |
 | pageSize   | String | X  | 조회 건수(기본: 15)                                                                                                                  |
 
+<a id="response-14"></a>
+
 #### 응답
 
 ```
@@ -3334,7 +3466,11 @@ Content-Type: application/json;charset=UTF-8
 | - imageUrl      | String  | O        | 이미지 URL |
 | - imageName     | String  | X        | 이미지명    |
 
+<a id="delete-image"></a>
+
 ### 이미지 삭제
+
+<a id="requested-14"></a>
 
 #### 요청
 
@@ -3369,6 +3505,8 @@ Content-Type: application/json;charset=UTF-8
 |----------|--------|----|--------|
 | imageSeq | String | O  | 이미지 번호 |
 
+<a id="response-15"></a>
+
 #### 응답
 
 ```
@@ -3388,9 +3526,15 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 결과 메시지 |
 | - isSuccessful  | boolean | O        | 성공 여부  |
 
+<a id="upload"></a>
+
 ## 업로드
 
+<a id="upload-bizform-key"></a>
+
 ### 비즈폼 키 업로드
+
+<a id="requested-15"></a>
 
 #### 요청
 
@@ -3420,6 +3564,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | 콘솔에서 생성할 수 있습니다. |
 
+<a id="response-16"></a>
+
 #### 응답
 
 ```
@@ -3439,9 +3585,15 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 결과 메시지 |
 | - isSuccessful  | boolean | O        | 성공 여부  |
 
+<a id="manage-outgoing-profiles"></a>
+
 ## 발신 프로필 관리
 
+<a id="view-outgoing-profile"></a>
+
 ### 발신 프로필 조회
+
+<a id="requested-16"></a>
 
 #### 요청
 
@@ -3470,6 +3622,8 @@ Content-Type: application/json;charset=UTF-8
 | 이름           | 타입     | 필수 | 설명               |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | 콘솔에서 생성할 수 있습니다. |
+
+<a id="response-17"></a>
 
 #### 응답
 
@@ -3540,7 +3694,11 @@ Content-Type: application/json;charset=UTF-8
 | - createDate              | String  | X        | 등록 일자                                                                                                                 |
 | - initialUserRestriction  | boolean | O        | 최초 사용자 제한 여부                                                                                                          |
 
+<a id="modify-outgoing-profile-080-opt-out-number"></a>
+
 ### 발신 프로필 080 수신거부번호 수정
+
+<a id="requested-17"></a>
 
 #### 요청
 
@@ -3584,6 +3742,8 @@ Content-Type: application/json;charset=UTF-8
 | unsubscribeNo     | 	String | 	O  | 080 무료수신거부 전화번호(모두 미입력 시 발신 프로필에 등록된 무료수신거부 정보로 발송됨)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx  |
 | unsubscribeAuthNo | 	String | 	X  | 080 무료수신거부 인증번호(모두 미입력 시 발신 프로필에 등록된 무료수신거부 정보로 발송됨)<br>unsubscribeNo 없이 unsubscribeAuthNo만 입력 불가<br>예: 1234 |
 
+<a id="response-18"></a>
+
 #### 응답
 
 ```
@@ -3603,7 +3763,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | O        | 결과 메시지 |
 | - isSuccessful  | boolean | O        | 성공 여부  |
 
+<a id="manage-fallback"></a>
+
 ## 대체 발송 관리
+
+<a id="register-sms-appkey"></a>
 
 ### SMS AppKey 등록
 
@@ -3650,6 +3814,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
 ```
 
+<a id="response-19"></a>
+
 #### 응답
 
 ```
@@ -3662,6 +3828,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
   }
 }
 ```
+
+<a id="register-fallback-settings"></a>
 
 ### 대체 발송 설정 등록
 
@@ -3713,6 +3881,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/failback/appkey -d '{"senderKey": "0be23c29de88d6888798aeda57062516354d74ba","isResend": true,"resendSendNo": "01012341234" }
 ```
+
+<a id="response-20"></a>
 
 #### 응답
 


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Body text is never modified.** The model only sees heading outlines; edits apply to heading lines (and `<!-- TODO: translate body -->` stubs for missing sections) only.

## Analysis

| | |
| --- | --- |
| Engine | `api (Anthropic SDK)` |
| Model | `claude-sonnet-4-20250514` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `pre-align/fix-headings-20260615-080708` |
| Scope | 1 doc(s) scanned · 3 file(s) changed |
| Self-verify | ⚠️ 2 mismatch(es) remain |
| Jenkins build | http://testlab.cloud.toastoven.net:8080/job/user-guide-agent/job/align-heading/job/260521/79/ |
| Generated | 2026-06-15T10:47:46 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`pre-align/fix-headings-20260615-080708`): [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FAlimtalk%2Fblob%2Fpre-align%2Ffix-headings-20260615-080708%2Fko%2Ffriendtalkupgrade-api-guide.md&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FAlimtalk%2Fpull%2F227&source=ko&langs=en%2Cja)

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra demoted | extra removed | verify |
| --- | --: | --: | --: | --: | --: | --: | --: | :--: |
| `ko/friendtalkupgrade-api-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/friendtalkupgrade-api-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/friendtalkupgrade-api-guide.md` | 0 | 0 | 0 | 1 | 0 | 0 | 0 | ⚠️ 2 |

<details><summary>남은 불일치 (검토 필요)</summary>

- `ja/friendtalkupgrade-api-guide.md`:
  - missing_in_target (ko#21/ja#None)
  - extra_in_target (ko#None/ja#22)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/Alimtalk`