### PR TITLE
chore(pre-align): align-v2 heading structure (alimtalk-api-guide.md) with ko

### DIFF
--- a/en/alimtalk-api-guide.md
+++ b/en/alimtalk-api-guide.md
@@ -1,6 +1,10 @@
 ## Notification > KakaoTalk Bizmessage > AlimTalk > API v2.3 Guide
 
+<a id="alimtalk"></a>
+
 ## AlimTalk
+
+<a id="api-domain"></a>
 
 #### [API Domain]
 
@@ -17,6 +21,8 @@
 </tbody>
 </table>
 
+<a id="overview-of-v23-api"></a>
+
 ## Overview of v2.3 API
 1. Added Quick Reply, Item List, Talk Biz plugin, Main Link, and Business Form button.
 
@@ -24,7 +30,11 @@
 3. Added APIs to register, modify, delete, and retrieve AlimTalk plugins.
 4. Removed the buttons field from the API to retrieve message list.
 
+<a id="general-messages"></a>
+
 ## General Messages
+
+<a id="request-of-sending-replaced-messages"></a>
 
 ### Request of Sending Replaced Messages
 
@@ -151,6 +161,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages -d '{"senderKey":"{outgoing key}","templateCode":"{template code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{incoming number}","templateParameter":{"{replacer field}":"{replacement data}"}}]}'
 ```
 
+<a id="response"></a>
+
 #### Response
 
 ```
@@ -191,6 +203,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 |-- resultCode | Integer | Result code of delivery request |
 |-- resultMessage | String | Result message of delivery request |
 |-- recipientGroupingKey | String | Recipient's grouping key |
+
+<a id="request-of-sending-full-text"></a>
 
 ### Request of Sending Full Text
 
@@ -384,6 +398,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/raw-messages -d '{"senderKey":"{outgoing key}","templateCode":"{template code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{incoming number}","content":"{content}","buttons":[{"ordering":"{button sequence}","type":"{button type}","name":"{button name}","linkMo":"{mobile web link}"}]}]}'
 ```
 
+<a id="response-2"></a>
+
 #### Response
 
 ```
@@ -425,7 +441,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 |-- resultMessage | String | Result message of delivery request |
 |-- recipientGroupingKey | String | Recipient's grouping key |
 
+<a id="list-messages"></a>
+
 ### List Messages
+
+<a id="request"></a>
 
 #### Request
 
@@ -474,6 +494,8 @@ Content-Type: application/json;charset=UTF-8
 
 * Cannot query data requested for delivery which are dated before 90 days.
 * The maximum available days for delivery request is 30 days.
+
+<a id="response-3"></a>
 
 #### Response
 ```
@@ -544,7 +566,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<a id="get-messages"></a>
+
 ### Get Messages
+
+<a id="request-2"></a>
 
 #### Request
 
@@ -577,6 +603,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-4"></a>
 
 #### Response
 ```
@@ -755,6 +783,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |- senderGroupingKey | String | Sender's grouping key                                                                                                                                                                                              |
 |- recipientGroupingKey | String | 	Recipient's grouping key                                                                                                                                                                                          |
 
+<a id="authentication-messages"></a>
+
 ## Authentication Messages
 
 <span id="precautions-authword"></span>
@@ -767,6 +797,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 - Example 1-1) Delivery shall fail if the full text(including template replacement) does not include authentication words, in the request of Authentication Messages API(for emergency)
 - Example 1-2) Validity for English words shall be checked regardless of small or capital letters
 
+
+<a id="request-of-sending-replaced-messages-2"></a>
 
 ### Request of Sending Replaced Messages
 
@@ -797,6 +829,8 @@ Content-Type: application/json;charset=UTF-8
 [Request body]
 [Same as the above](./alimtalk-api-guide/#request-of-sending-replaced-messages)
 
+<a id="request-of-sending-full-text-2"></a>
+
 ### Request of Sending Full Text
 
 [URL]
@@ -826,7 +860,11 @@ Content-Type: application/json;charset=UTF-8
 [Request Body]
 [Same as the above](./alimtalk-api-guide/#request-of-sending-full-text)
 
+<a id="list-messages-2"></a>
+
 ### List Messages
+
+<a id="request-3"></a>
 
 #### Request
 
@@ -856,7 +894,11 @@ Content-Type: application/json;charset=UTF-8
 [Query parameter]
 [Same as the above](./alimtalk-api-guide/#list-messages)
 
+<a id="get-messages-2"></a>
+
 ### Get Messages
+
+<a id="request-4"></a>
 
 #### Request
 
@@ -890,11 +932,19 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/messages/{requestId}/{recipientSeq}"
 ```
 
+<a id="response-5"></a>
+
 #### Response
 [Same as the above](./alimtalk-api-guide/#get-messages)
 
+<a id="message"></a>
+
 ## Message
+<a id="cancel-sending-messages"></a>
+
 ### Cancel Sending Messages
+
+<a id="request-5"></a>
 
 #### Request
 
@@ -930,6 +980,8 @@ Content-Type: application/json;charset=UTF-8
 
 * Both general and authentication messages can be canceled by the same API.
 
+<a id="response-6"></a>
+
 #### Response
 ```
 {
@@ -953,7 +1005,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
 ```
 
+<a id="query-updates-of-message-result"></a>
+
 ### Query Updates of Message Result
+
+<a id="request-6"></a>
 
 #### Request
 
@@ -989,6 +1045,8 @@ Content-Type: application/json;charset=UTF-8
 |alimtalkMessageType|	String| X |	AlimTalk message type(NORMAL, AUTH) |
 |pageNum|	Integer|	X|	Page number(default: 1)|
 |pageSize|	Integer|	X|	Number of queries(default: 15, Max: 1000)|
+
+<a id="response-7"></a>
 
 #### Response
 ```
@@ -1042,7 +1100,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/message-results?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
+<a id="query-the-number-of-message-result-updates"></a>
+
 ### Query the Number of Message Result Updates
+
+<a id="request-7"></a>
 
 #### Request
 
@@ -1079,6 +1141,8 @@ Content-Type: application/json;charset=UTF-8
 | endUpdateDate       | 	String  | O   | 	Result update query end time (yyyy-MM-dd HH:mm) |
 | alimtalkMessageType | 	String  | X   | 	AlimTalk message type (NORMAL, AUTH)           |
 
+<a id="response-8"></a>
+
 #### Response
 
 ```
@@ -1106,6 +1170,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/message-results/count?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
+<a id="status-code-of-smslms-resending"></a>
+
 ### Status Code of SMS/LMS Resending
 | Name |	Description|
 |---|---|
@@ -1115,8 +1181,14 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |RSC04|	Resending successful|
 |RSC05|	Resending failed|
 
+<a id="mass-delivery"></a>
+
 ## Mass Delivery
+<a id="list-mass-delivery-requests"></a>
+
 ### List Mass Delivery Requests
+
+<a id="request-8"></a>
 
 #### Request
 [URL]
@@ -1156,6 +1228,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum | optional, Integer | - | X | Page number |
 | pageSize | optional, Integer | 1000 | X | Search count |
 
+<a id="curl"></a>
+
 #### cURL
 ```
 curl -X GET \
@@ -1163,6 +1237,8 @@ curl -X GET \
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-9"></a>
 
 #### Response
 ```
@@ -1219,7 +1295,11 @@ curl -X GET \
 | - totalCount | Integer | Total count |
 
 
+<a id="list-mass-delivery-recipients"></a>
+
 ### List Mass Delivery Recipients
+
+<a id="request-9"></a>
 
 #### Request
 [URL]
@@ -1258,6 +1338,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum | optional, Integer | - | X | Page number |
 | pageSize | optional, Integer | 1000 | X | Search count |
 
+<a id="curl-2"></a>
+
 #### cURL
 ```
 curl -X GET \
@@ -1265,6 +1347,8 @@ curl -X GET \
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-10"></a>
 
 #### Response
 ```
@@ -1310,7 +1394,11 @@ curl -X GET \
 | -- resultCodeName | String | Result code content |
 | - totalCount | Integer | Total count |
 
+<a id="get-a-mass-delivery-recipient"></a>
+
 ### Get a Mass Delivery Recipient
+
+<a id="request-10"></a>
 
 #### Request
 [URL]
@@ -1350,6 +1438,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum | optional, Integer | - | X | Page number |
 | pageSize | optional, Integer | 1000 | X | Search count |
 
+<a id="curl-3"></a>
+
 #### cURL
 ```
 curl -X GET \
@@ -1357,6 +1447,8 @@ curl -X GET \
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-11"></a>
 
 #### Response
 ```
@@ -1524,9 +1616,15 @@ curl -X GET \
 | -- bizFormId|	String| 	Plugin ID(up to 24 characters) |
 | -- target|	String| 	In the case of a web link type, out link used when adding "target":"out" attribute<br>Send with the default in-app link |
 
+<a id="templates"></a>
+
 ## Templates
 
+<a id="list-template-categories"></a>
+
 ### List Template Categories
+<a id="request-11"></a>
+
 #### Request
 [URL]
 
@@ -1550,6 +1648,8 @@ Content-Type: application/json;charset=UTF-8
 | Name |	Type|	Required|	Description|
 |---|---|---|---|
 |X-Secret-Key|	String| O | Can be created on console.   |
+
+<a id="response-12"></a>
 
 #### Response
 ```
@@ -1592,7 +1692,11 @@ Content-Type: application/json;charset=UTF-8
 |-- inclusion | String |	Description of templates to which the category applies |
 |-- exclusion| String| Description of templates to which the category does not apply |
 
+<a id="register-templates"></a>
+
 ### Register Templates
+<a id="request-12"></a>
+
 #### Request
 [URL]
 
@@ -1744,6 +1848,8 @@ Content-Type: application/json;charset=UTF-8
 * The Add Channel(AC) button must be registered with a fixed button name of "Add Channel".
 
 
+<a id="response-13"></a>
+
 #### Response
 ```
 {
@@ -1762,7 +1868,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="modify-templates"></a>
+
 ### Modify Templates
+<a id="request-13"></a>
+
 #### Request
 [URL]
 
@@ -1909,6 +2019,8 @@ Content-Type: application/json;charset=UTF-8
 * The Add Chanel button must be in the first when modifying the AD included(AD) or Mixed Purposes(MI) message type template.
 * The Add Channel(AC) button must be modified with a fixed button name of "Add Channel".
 
+<a id="response-14"></a>
+
 #### Response
 ```
 {
@@ -1927,7 +2039,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="delete-templates"></a>
+
 ### Delete Templates
+<a id="request-14"></a>
+
 #### Request
 [URL]
 
@@ -1955,6 +2071,8 @@ Content-Type: application/json;charset=UTF-8
 * A template remaining in Kakao becomes dormant if it is not used for 1 year, and gets deleted if it remains dormant for 1 year.(If a template becomes dormant or gets deleted on Kakao, the person in charge will be notified.)
 
 
+<a id="response-15"></a>
+
 #### Response
 ```
 {
@@ -1973,7 +2091,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="inquire-of-templates"></a>
+
 ### Inquire of Templates
+<a id="request-15"></a>
+
 #### Request
 [URL]
 
@@ -2014,6 +2136,8 @@ Content-Type: application/json;charset=UTF-8
 
 * When commenting a template in the REJ status, it will be changed to the REQ status.
 
+<a id="response-16"></a>
+
 #### Response
 ```
 {
@@ -2032,7 +2156,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="send-inquiry-on-templates-with-file-attachment"></a>
+
 ### Send Inquiry on Templates with File Attachment
+<a id="request-16"></a>
+
 #### Request
 [URL]
 
@@ -2075,6 +2203,8 @@ Content-Type: application/json;charset=UTF-8
 
 * When commenting a template in the REJ status, it will be changed to the REQ status.
 
+<a id="response-17"></a>
+
 #### Response
 ```
 {
@@ -2093,7 +2223,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="change-template-to-channel-add-type"></a>
+
 ### Change Template to Channel-Add Type
+
+<a id="request-17"></a>
 
 #### Request
 [URL]
@@ -2122,6 +2256,8 @@ Content-Type: application/json;charset=UTF-8
 
 * The template registered in sender group cannot be converted to a add-channel type.
 
+<a id="response-18"></a>
+
 #### Response
 ```
 {
@@ -2140,7 +2276,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="single-query-for-template"></a>
+
 ### Single Query for Template
+
+<a id="request-18"></a>
 
 #### Request
 
@@ -2183,6 +2323,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}"
 ```
+
+<a id="response-19"></a>
 
 #### Response
 
@@ -2362,7 +2504,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - createDate | String | O | Created at |
 | - updateDate | String | X | Modified at |
 
+<a id="list-templates"></a>
+
 ### List Templates
+
+<a id="request-19"></a>
 
 #### Request
 
@@ -2411,6 +2557,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates?templateStatus={template status code}"
 ```
+
+<a id="response-20"></a>
 
 #### Response
 ```
@@ -2587,7 +2735,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- updateDate            | String | Date of modification                                                                                                                                                                                                                                                                                   |
 | - totalCount             | Integer | Total count                                                                                                                                                                                                                                                                                            |
 
+<a id="list-template-modifications"></a>
+
 ### List Template modifications
+
+<a id="request-20"></a>
 
 #### Request
 
@@ -2620,6 +2772,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}/modifications"
 ```
+
+<a id="response-21"></a>
 
 #### Response
 ```
@@ -2772,7 +2926,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |-- updateDate | String | Date of modification |
 |- totalCount | Integer | Total count |
 
+<a id="register-template-image"></a>
+
 ### Register Template Image
+<a id="request-21"></a>
+
 #### Request
 [URL]
 
@@ -2808,6 +2966,8 @@ Content-Type: multipart/form-data
 curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/template-image" -F "file=@alimtalk-template-image.jpeg"
 ```
 
+<a id="response-22"></a>
+
 #### Response
 ```
 {
@@ -2833,7 +2993,11 @@ curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}
 |- templateImageName | String |	Image name(name of uploaded file) |
 |- templateImageUrl | String |	Image URL |
 
+<a id="register-template-item-highlight-images"></a>
+
 ### Register Template Item Highlight Images
+<a id="request-22"></a>
+
 #### Request
 [URL]
 
@@ -2869,6 +3033,8 @@ Content-Type: multipart/form-data
 curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/template-image/item-highlight" -F "file=@alimtalk-template-image.jpeg"
 ```
 
+<a id="response-23"></a>
+
 #### Response
 ```
 {
@@ -2894,7 +3060,11 @@ curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}
 |- templateImageName | String |	Image name(name of uploaded file) |
 |- templateImageUrl | String |	Image URL |
 
+<a id="register-template-plugin"></a>
+
 ### Register Template Plugin
+<a id="request-23"></a>
+
 #### Request
 [URL]
 
@@ -2936,6 +3106,8 @@ Content-Type: application/json;charset=UTF-8
 |pluginId|	String |	O | Plugin ID |
 |callbackUrl|	String |	O | The callback URL to receive when the plugin button is clicked |
 
+<a id="response-24"></a>
+
 #### Response
 ```
 {
@@ -2954,7 +3126,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="modify-template-plugin"></a>
+
 ### Modify Template Plugin
+<a id="request-24"></a>
+
 #### Request
 [URL]
 
@@ -2995,6 +3171,8 @@ Content-Type: application/json;charset=UTF-8
 |pluginType|	String |	O | Plugin type(SECURE_IMAGE: secure image transmission, ONE_TIME_PROFILE: personal information use) |
 |callbackUrl|	String |	O | The callback URL to receive when the plugin button is clicked |
 
+<a id="response-25"></a>
+
 #### Response
 ```
 {
@@ -3013,7 +3191,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="modify-template-plugin-2"></a>
+
 ### Modify Template Plugin
+<a id="request-25"></a>
+
 #### Request
 [URL]
 
@@ -3040,6 +3222,8 @@ Content-Type: application/json;charset=UTF-8
 |---|---|---|---|
 |X-Secret-Key|	String| O | Can be created on console.   |
 
+<a id="response-26"></a>
+
 #### Response
 ```
 {
@@ -3058,7 +3242,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="retrieve-template-plugin"></a>
+
 ### Retrieve Template Plugin
+<a id="request-26"></a>
+
 #### Request
 [URL]
 
@@ -3083,6 +3271,8 @@ Content-Type: application/json;charset=UTF-8
 | Name |	Type|	Required|	Description|
 |---|---|---|---|
 |X-Secret-Key|	String| O | Can be created on console.   |
+
+<a id="response-27"></a>
 
 #### Response
 ```
@@ -3120,7 +3310,11 @@ Content-Type: application/json;charset=UTF-8
 |- modifiable|	Boolean| Modifiable |
 |- deletable|	Boolean| Deletable |
 
+<a id="manage-alternative-delivery"></a>
+
 ## Manage Alternative Delivery
+<a id="register-an-sms-appkey"></a>
+
 ### Register an SMS AppKey
 
 [URL]
@@ -3164,6 +3358,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
 ```
 
+<a id="response-28"></a>
+
 #### Response
 ```
 
@@ -3175,6 +3371,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
   }
 }
 ```
+
+<a id="register-alternative-delivery-settings"></a>
 
 ### Register Alternative Delivery Settings
 
@@ -3222,6 +3420,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/failback/appkey -d '{"senderKey": "0be23c29de88d6888798aeda57062516354d74ba","isResend": true,"resendSendNo": "01012341234" }
 ```
+
+<a id="response-29"></a>
 
 #### Response
 ```

--- a/ja/alimtalk-api-guide.md
+++ b/ja/alimtalk-api-guide.md
@@ -1,6 +1,10 @@
 ## Notification > KakaoTalk Bizmessage > お知らせトーク > API v2.3 Guide
 
+<a id="alimtalk"></a>
+
 ## お知らせトーク
+
+<a id="api-domain"></a>
 
 #### [APIドメイン]
 
@@ -17,13 +21,19 @@
 </tbody>
 </table>
 
+<a id="overview-of-v23-api"></a>
+
 ## v2.3 API紹介
 1. お知らせトーク大量送信照会、統計照会APIが追加されました。
 2. 置換メッセージ送信時、buttonsフィールドが追加されました。
 3. 専門メッセージ送信時、buttonsフィールドにchatExtra、chatEvent、targetフィールドが追加されました。
 4. メッセージ照会時、buttonsフィールドにchatExtra、chatEvent、targetフィールドが追加されました。
 
+<a id="general-messages"></a>
+
 ## 一般メッセージ
+
+<a id="request-of-sending-replaced-messages"></a>
 
 ### メッセージ置換送信リクエスト
 
@@ -143,6 +153,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","templateParameter":{"{日本語識別子フィールド}":"{置換データ}"}}]}'
 ```
 
+<a id="response"></a>
+
 #### レスポンス
 
 ```
@@ -183,6 +195,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultCode           | Integer | 送信リクエスト結果コード |
 | -- resultMessage        | String  | 送信リクエスト結果メッセージ |
 | -- recipientGroupingKey | String  | 受信者グルーピングキー |
+
+<a id="request-of-sending-full-text"></a>
 
 ### メッセージ全文送信リクエスト
 
@@ -346,6 +360,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/raw-messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","content":"{内容}","buttons":[{"ordering":"{ボタン順序}","type":"{ボタンタイプ}","name":"{ボタン名}","linkMo":"{モバイルWebリンク}"}]}]}'
 ```
 
+<a id="response-2"></a>
+
 #### レスポンス
 
 ```
@@ -387,7 +403,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultMessage        | String  | 送信リクエスト結果メッセージ |
 | -- recipientGroupingKey | String  | 受信者グルーピングキー |
 
+<a id="list-messages"></a>
+
 ### メッセージリストの照会
+
+<a id="request"></a>
 
 #### リクエスト
 
@@ -436,6 +456,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 90日以上前の送信リクエストデータは照会されません。
 * 送信リクエスト日時の範囲は最大30日です。
+
+<a id="response-3"></a>
 
 #### レスポンス
 ```
@@ -518,7 +540,9 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
-#### SMS/LMS再送信ステータス
+<a id="status-code-of-smslms-resending"></a>
+
+### SMS/LMS再送信ステータス
 | 値 | 説明                      |
 | ----- | ------------------------------- |
 | RSC01 | 再送信の対象ではない                 |
@@ -527,7 +551,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | RSC04 | 再送信成功                  |
 | RSC05 | 再送信失敗                  |
 
+<a id="get-messages"></a>
+
 ### メッセージ単件照会
+
+<a id="request-2"></a>
 
 #### リクエスト
 
@@ -560,6 +588,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-4"></a>
 
 #### レスポンス
 ```
@@ -738,6 +768,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - senderGroupingKey    | String  | 発信グルーピングキー                            |
 | - recipientGroupingKey | String  | 受信者グルーピングキー                           |
 
+<a id="authentication-messages"></a>
+
 ## 認証メッセージ
 
 <span id="precautions-authword"></span>
@@ -750,6 +782,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 - 例1)認証メッセージAPI送信リクエストした時、全文(テンプレート日本語識別子含む)に認証文言が含まれていない場合は、送信に失敗します。
 - 例2)認証文言が英文の場合、大文字/小文字の区別なしで有効性チェックが行われます。
 
+
+<a id="request-of-sending-replaced-messages-2"></a>
 
 ### メッセージ置換送信リクエスト
 
@@ -853,7 +887,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","templateParameter":{"{日本語識別子フィールド}":"{置換データ}"}}]}'
 ```
 
-#### レスポンス
+**レスポンス**
 
 ```
 {
@@ -896,6 +930,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultCode           | Integer | 送信リクエスト結果コード |
 | -- resultMessage        | String  | 送信リクエスト結果メッセージ |
 | -- recipientGroupingKey | String  | 受信者グルーピングキー |
+
+<a id="request-of-sending-full-text-2"></a>
 
 ### メッセージ全文送信リクエスト
 
@@ -1011,7 +1047,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/raw-messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","content":"{内容}","buttons":[{"ordering":"{ボタン順序}","type":"{ボタンタイプ}","name":"{ボタン名}","linkMo":"{モバイルWebリンク}"}]}]}'
 ```
 
-#### レスポンス
+**レスポンス**
 
 ```
 {
@@ -1058,7 +1094,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultMessage        | String  | 送信リクエスト結果メッセージ |
 | -- recipientGroupingKey | String  | 受信者グルーピングキー |
 
+<a id="list-messages-2"></a>
+
 ### メッセージリストの照会
+
+<a id="request-3"></a>
 
 #### リクエスト
 
@@ -1108,7 +1148,7 @@ Content-Type: application/json;charset=UTF-8
 * 90日以上前の送信リクエストデータは照会されません。
 * 送信リクエスト日時の範囲は最大30日です。
 
-#### レスポンス
+**レスポンス**
 ```
 {
   "header" : {
@@ -1202,7 +1242,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<a id="query-the-number-of-message-result-updates"></a>
+
 ### メッセージ結果アップデート件数の照会
+
+<a id="request-7"></a>
 
 #### リクエスト
 
@@ -1239,6 +1283,8 @@ Content-Type: application/json;charset=UTF-8
 | endUpdateDate       | 	String  | O   | 	結果アップデート照会終了時間(yyyy-MM-dd HH:mm) |
 | alimtalkMessageType | 	String  | X   | 	お知らせトークのメッセージタイプ(NORMAL, AUTH)           |
 
+<a id="response-8"></a>
+
 #### レスポンス
 
 ```
@@ -1266,7 +1312,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/message-results/count?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
-#### SMS/LMS再送信ステータス
+**SMS/LMS再送信ステータス**
 | 値 | 説明                      |
 | ----- | ------------------------------- |
 | RSC01 | 再送信の対象ではない                 |
@@ -1275,7 +1321,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | RSC04 | 再送信成功                  |
 | RSC05 | 再送信失敗                  |
 
+<a id="get-messages-2"></a>
+
 ### メッセージ単件照会
+
+<a id="request-4"></a>
 
 #### リクエスト
 
@@ -1308,6 +1358,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-5"></a>
 
 #### レスポンス
 ```
@@ -1381,8 +1433,14 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - senderGroupingKey    | String  | 発信グルーピングキー                            |
 | - recipientGroupingKey | String  | 受信者グルーピングキー                           |
 
+<a id="message"></a>
+
 ## メッセージ
+<a id="cancel-sending-messages"></a>
+
 ### メッセージ送信取消
+
+<a id="request-5"></a>
 
 #### リクエスト
 
@@ -1418,6 +1476,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 一般/認証メッセージは同じAPIでキャンセルできます。
 
+<a id="response-6"></a>
+
 #### レスポンス
 ```
 {
@@ -1441,7 +1501,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
 ```
 
+<a id="query-updates-of-message-result"></a>
+
 ### メッセージ結果アップデートの照会
+
+<a id="request-6"></a>
 
 #### リクエスト
 
@@ -1477,6 +1541,8 @@ Content-Type: application/json;charset=UTF-8
 | alimtalkMessageType | String  | X    | お知らせトークメッセージタイプ(NORMAL、AUTH)           |
 | pageNum             | Integer | X    | ページ番号(基本：1)                      |
 | pageSize            | Integer | X    | 照会件数(基本：15、最大: 1000)          |
+
+<a id="response-7"></a>
 
 #### レスポンス
 ```
@@ -1530,8 +1596,14 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/message-results?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
+<a id="mass-delivery"></a>
+
 ## 大量送信
+<a id="list-mass-delivery-requests"></a>
+
 ### 大量送信リクエストリスト照会
+
+<a id="request-8"></a>
 
 #### リクエスト
 [URL]
@@ -1571,6 +1643,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum | optional, Integer | - | X | ページ番号 |
 | pageSize | optional, Integer | 1000 | X | 検索数 |
 
+<a id="curl"></a>
+
 #### cURL
 ```
 curl -X GET \
@@ -1578,6 +1652,8 @@ https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appK
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-9"></a>
 
 #### レスポンス
 ```
@@ -1667,7 +1743,11 @@ https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appK
 | - totalCount | Integer | 総数
 
 
+<a id="list-mass-delivery-recipients"></a>
+
 ### 大量送信大量送信受信者リスト照会
+
+<a id="request-9"></a>
 
 #### リクエスト
 [URL]
@@ -1706,6 +1786,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum | optional, Integer | - | X | ページ番号 |
 | pageSize | optional, Integer | 1000 | X | 検索数 |
 
+<a id="curl-2"></a>
+
 #### cURL
 ```
 curl -X GET \
@@ -1713,6 +1795,8 @@ https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appK
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-10"></a>
 
 #### レスポンス
 ```
@@ -1758,7 +1842,11 @@ https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appK
 | -- resultCodeName | String | 結果コード内容 |
 | - totalCount | Integer | 総数 |
 
+<a id="get-a-mass-delivery-recipient"></a>
+
 ### 大量送信大量送信受信者照会
+
+<a id="request-10"></a>
 
 #### リクエスト
 [URL]
@@ -1798,6 +1886,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum | optional, Integer | - | X | ページ番号 |
 | pageSize | optional, Integer | 1000 | X | 検索数 |
 
+<a id="curl-3"></a>
+
 #### cURL
 ```
 curl -X GET \
@@ -1805,6 +1895,8 @@ https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appK
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-11"></a>
 
 #### レスポンス
 ```
@@ -1906,9 +1998,15 @@ https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appK
 |-- currencyType | String |	message(ユーザーに伝達されるメッセージ)内に含まれる価格/金額/決済金額の通貨単位KRW、USD、EURなどの国際通貨コードを使用(モーメント広告に該当) |
 
 
+<a id="templates"></a>
+
 ## テンプレート
 
+<a id="list-template-categories"></a>
+
 ### テンプレートカテゴリー照会
+<a id="request-11"></a>
+
 #### リクエスト
 [URL]
 
@@ -1932,6 +2030,8 @@ Content-Type: application/json;charset=UTF-8
 | 値    | タイプ | 必須 | 説明                               |
 |---|---|---|---|
 | X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+<a id="response-12"></a>
 
 #### レスポンス
 ```
@@ -1974,7 +2074,11 @@ Content-Type: application/json;charset=UTF-8
 |-- inclusion | String |	カテゴリー対象テンプレートの説明 |
 |-- exclusion| String| カテゴリの除外対象のテンプレートの説明 |
 
+<a id="register-templates"></a>
+
 ### テンプレートの登録
+<a id="request-12"></a>
+
 #### リクエスト
 [URL]
 
@@ -2053,6 +2157,8 @@ Content-Type: application/json;charset=UTF-8
 | -schemeIos      | String  | X    | iOSアプリリンク(ALタイプの場合は必須フィールド、最大500文字)       |
 | -schemeAndroid  | String  | X    | Androidアプリリンク(ALタイプの場合は必須フィールド、最大500文字)   |
 
+<a id="response-13"></a>
+
 #### レスポンス
 ```
 {
@@ -2071,7 +2177,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | 結果メッセージ |
 | - isSuccessful  | Boolean | 成否 |
 
+<a id="modify-templates"></a>
+
 ### テンプレートの修正
+<a id="request-13"></a>
+
 #### リクエスト
 [URL]
 
@@ -2149,6 +2259,8 @@ Content-Type: application/json;charset=UTF-8
 | -schemeIos      | String  | X    | iOSアプリリンク(ALタイプの場合は必須フィールド、最大500文字)       |
 | -schemeAndroid  | String  | X    | Androidアプリリンク(ALタイプの場合は必須フィールド、最大500文字)   |
 
+<a id="response-14"></a>
+
 #### レスポンス
 ```
 {
@@ -2167,7 +2279,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | 結果メッセージ |
 | - isSuccessful  | Boolean | 成否 |
 
+<a id="delete-templates"></a>
+
 ### テンプレートの削除
+<a id="request-14"></a>
+
 #### リクエスト
 [URL]
 
@@ -2190,6 +2306,8 @@ Content-Type: application/json;charset=UTF-8
   "X-Secret-Key": String
 }
 ```
+
+<a id="response-15"></a>
 
 #### レスポンス
 ```
@@ -2214,7 +2332,11 @@ Content-Type: application/json;charset=UTF-8
 * カカオに残っているテンプレートは1年間使っていないと休眠処理され、休眠状態が1年間続くと削除処理されます。(カカオでテンプレートが休眠に切り替わるときや、削除されるときは担当者に通知が送信されます。)
 
 
+<a id="inquire-of-templates"></a>
+
 ### テンプレートの問い合わせをする
+<a id="request-15"></a>
+
 #### リクエスト
 [URL]
 
@@ -2255,6 +2377,8 @@ Content-Type: application/json;charset=UTF-8
 
 * REJステータスのテンプレートにコメントを付けると、REQステータスに変更されます。
 
+<a id="response-16"></a>
+
 #### レスポンス
 ```
 {
@@ -2273,7 +2397,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | 結果メッセージ |
 | - isSuccessful  | Boolean | 成否 |
 
+<a id="send-inquiry-on-templates-with-file-attachment"></a>
+
 ### ファイルを添付してテンプレートお問い合わせ
+<a id="request-16"></a>
+
 #### リクエスト
 [URL]
 
@@ -2316,6 +2444,8 @@ Content-Type: application/json;charset=UTF-8
 
 * REJステータスのテンプレートにコメントを付けると、REQステータスに変更されます。
 
+<a id="response-17"></a>
+
 #### レスポンス
 ```
 {
@@ -2334,7 +2464,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 結果メッセージ|
 |- isSuccessful|	Boolean| 成否|
 
+<a id="single-query-for-template"></a>
+
 ### テンプレート個別照会
+
+<a id="request-18"></a>
 
 #### リクエスト
 
@@ -2377,6 +2511,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}"
 ```
+
+<a id="response-19"></a>
 
 #### レスポンス
 
@@ -2556,7 +2692,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - updateDate            | String  |    X     | 修正日                                                                                                                                                                           |
 
 
+<a id="list-templates"></a>
+
 ### テンプレートリストの照会
+
+<a id="request-19"></a>
 
 #### リクエスト
 
@@ -2605,6 +2745,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/templates?plusFriendId={発信キー}&templateStatus={テンプレートステータスコード}"
 ```
+
+<a id="response-20"></a>
 
 #### レスポンス
 ```
@@ -2708,7 +2850,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- createDate        | String  | 作成日時                                                                                                   |
 | - totalCount         | Integer | 総個数                                                                                                    |
 
+<a id="change-template-to-channel-add-type"></a>
+
 ### テンプレートチャンネル追加型に変更
+
+<a id="request-17"></a>
 
 #### リクエスト
 [URL]
@@ -2737,6 +2883,8 @@ Content-Type: application/json;charset=UTF-8
 
 * グループプロフィールに登録されたテンプレートは、チャンネルタイプに変換することはできません
 
+<a id="response-18"></a>
+
 #### レスポンス
 ```
 {
@@ -2755,7 +2903,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 結果メッセージ|
 |- isSuccessful|	Boolean| 成否|
 
+<a id="list-template-modifications"></a>
+
 ### テンプレートの修正リスト照会
+
+<a id="request-20"></a>
 
 #### リクエスト
 
@@ -2788,6 +2940,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}/modifications"
 ```
+
+<a id="response-21"></a>
 
 #### レスポンス
 ```
@@ -2893,7 +3047,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- createDate        | String  | 作成日時                            |
 | - totalCount         | Integer | 総個数                              |
 
+<a id="register-template-image"></a>
+
 ### テンプレート画像の登録
+<a id="request-21"></a>
+
 #### リクエスト
 [URL]
 
@@ -2929,6 +3087,8 @@ Content-Type: multipart/form-data
 curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/template-image" -F "file=@alimtalk-template-image.jpeg"
 ```
 
+<a id="response-22"></a>
+
 #### レスポンス
 ```
 {
@@ -2954,7 +3114,101 @@ curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}
 |- templateImageName    | String |	画像名（アップロードされたファイル名） |
 |- templateImageUrl     | String |	画像のURL |
 
+<a id="register-template-item-highlight-images"></a>
+
+### テンプレートアイテムハイライト画像登録
+
+<!-- TODO: translate body -->
+
+<a id="request-22"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="response-23"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="register-template-plugin"></a>
+
+### テンプレートプラグイン登録
+
+<!-- TODO: translate body -->
+
+<a id="request-23"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="response-24"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="modify-template-plugin"></a>
+
+### テンプレートプラグイン修正
+
+<!-- TODO: translate body -->
+
+<a id="request-24"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="response-25"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="modify-template-plugin-2"></a>
+
+### テンプレートプラグイン削除
+
+<!-- TODO: translate body -->
+
+<a id="request-25"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="response-26"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="retrieve-template-plugin"></a>
+
+### テンプレートプラグイン照会
+
+<!-- TODO: translate body -->
+
+<a id="request-26"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="response-27"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="manage-alternative-delivery"></a>
+
 ## 代替送信管理
+<a id="register-an-sms-appkey"></a>
+
 ### SMS AppKey登録
 
 [URL]
@@ -2999,6 +3253,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
 ```
 
+<a id="response-28"></a>
+
 #### レスポンス
 ```
 
@@ -3010,6 +3266,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
   }
 }
 ```
+
+<a id="register-alternative-delivery-settings"></a>
 
 ### 代替送信設定登録
 
@@ -3057,6 +3315,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/failback/appkey -d '{"plusFriendId": "@プラスフレンド","isResend": true,"resendSendNo": "01012341234" }
 ```
+
+<a id="response-29"></a>
 
 #### レスポンス
 ```

--- a/ko/alimtalk-api-guide.md
+++ b/ko/alimtalk-api-guide.md
@@ -1,6 +1,10 @@
 ## Notification > KakaoTalk Bizmessage > 알림톡 > API v2.3 Guide
 
+<a id="alimtalk"></a>
+
 ## 알림톡
+
+<a id="api-domain"></a>
 
 #### [API Domain]
 
@@ -17,6 +21,8 @@
 </tbody>
 </table>
 
+<a id="overview-of-v23-api"></a>
+
 ## Overview of v2.3 API
 
 1. 알림톡 바로 연결, 아이템리스트, 톡 비즈 플러그인, 대표 링크, 비즈니스폼 버튼 기능이 추가되었습니다.
@@ -24,7 +30,11 @@
 3. 알림톡 플러그인 등록/수정/삭제/조회 API가 추가되었습니다.
 4. 메시지 리스트 조회 API에서 buttons 필드가 삭제되었습니다.
 
+<a id="general-messages"></a>
+
 ## 일반 메시지
+
+<a id="request-of-sending-replaced-messages"></a>
 
 ### 메시지 치환 발송 요청
 
@@ -154,6 +164,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages -d '{"senderKey":"{발신 키}","templateCode":"{템플릿 코드}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{수신번호}","templateParameter":{"{치환자 필드}":"{치환 데이터}"}}]}'
 ```
 
+<a id="response"></a>
+
 #### 응답
 
 ```
@@ -194,6 +206,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultCode           | Integer |    O     | 발송 요청 결과 코드  |
 | -- resultMessage        | String  |    O     | 발송 요청 결과 메시지 |
 | -- recipientGroupingKey | String  |    X     | 수신자 그룹핑 키    |
+
+<a id="request-of-sending-full-text"></a>
 
 ### 메시지 전문 발송 요청
 
@@ -393,6 +407,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/raw-messages -d '{"senderKey":"{발신 키}","templateCode":"{템플릿 코드}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{수신번호}","content":"{내용}","buttons":[{"ordering":"{버튼 순서}","type":"{버튼 타입}","name":"{버튼 이름}","linkMo":"{모바일 웹 링크}"}]}]}'
 ```
 
+<a id="response-2"></a>
+
 #### 응답
 
 ```
@@ -434,7 +450,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultMessage        | String  |    O     | 발송 요청 결과 메시지 |
 | -- recipientGroupingKey | String  |    X     | 수신자 그룹핑 키    |
 
+<a id="list-messages"></a>
+
 ### 메시지 리스트 조회
+
+<a id="request"></a>
 
 #### 요청
 
@@ -485,6 +505,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 90일 이전 발송 요청 데이터는 조회되지 않습니다.
 * 발송 요청 일시의 범위는 최대 30일입니다.
+
+<a id="response-3"></a>
 
 #### 응답
 
@@ -557,7 +579,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<a id="get-messages"></a>
+
 ### 메시지 단건 조회
+
+<a id="request-2"></a>
 
 #### 요청
 
@@ -593,6 +619,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-4"></a>
 
 #### 응답
 
@@ -774,6 +802,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - senderGroupingKey     | String  |    X     | 발신 그룹핑 키                                                                                                                                                               |
 | - recipientGroupingKey  | String  |    X     | 수신자 그룹핑 키                                                                                                                                                              |
 
+<a id="authentication-messages"></a>
+
 ## 인증 메시지
 
 <span id="precautions-authword"></span>
@@ -786,6 +816,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 
 - 예시 1-1) 인증 메시지 API 요청시 전문(템플릿 치환자 포함)에 인증 문구가 포함되어 있지 않은 경우 발송 실패됩니다.
 - 예시 1-2) 인증 문구가 영문인 경우 대소문자 구분 없이 유효성 검사가 진행됩니다.
+
+<a id="request-of-sending-replaced-messages-2"></a>
 
 ### 메시지 치환 발송 요청
 
@@ -818,6 +850,8 @@ Content-Type: application/json;charset=UTF-8
 [Request body]
 [위와 동일](./alimtalk-api-guide/#_3)
 
+<a id="request-of-sending-full-text-2"></a>
+
 ### 메시지 전문 발송 요청
 
 [URL]
@@ -849,7 +883,11 @@ Content-Type: application/json;charset=UTF-8
 [Request Body]
 [위와 동일](./alimtalk-api-guide/#_5)
 
+<a id="list-messages-2"></a>
+
 ### 메시지 리스트 조회
+
+<a id="request-3"></a>
 
 #### 요청
 
@@ -881,7 +919,11 @@ Content-Type: application/json;charset=UTF-8
 [Query parameter]
 [위와 동일](./alimtalk-api-guide/#_7)
 
+<a id="get-messages-2"></a>
+
 ### 메시지 단건 조회
+
+<a id="request-4"></a>
 
 #### 요청
 
@@ -918,13 +960,21 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/messages/{requestId}/{recipientSeq}"
 ```
 
+<a id="response-5"></a>
+
 #### 응답
 
 [위와 동일](./alimtalk-api-guide/#_9)
 
+<a id="message"></a>
+
 ## 메시지
 
+<a id="cancel-sending-messages"></a>
+
 ### 메시지 발송 취소
+
+<a id="request-5"></a>
 
 #### 요청
 
@@ -962,6 +1012,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 일반/인증 메시지 모두 동일한 API로 취소할 수 있습니다.
 
+<a id="response-6"></a>
+
 #### 응답
 
 ```
@@ -987,7 +1039,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
 ```
 
+<a id="query-updates-of-message-result"></a>
+
 ### 메시지 결과 업데이트 조회
+
+<a id="request-6"></a>
 
 #### 요청
 
@@ -1025,6 +1081,8 @@ Content-Type: application/json;charset=UTF-8
 | alimtalkMessageType | 	String  | X   | 	알림톡 메시지 타입(NORMAL, AUTH)           |
 | pageNum             | 	Integer | 	X  | 	페이지 번호(기본: 1)                      |
 | pageSize            | 	Integer | 	X  | 	조회 건수(Default: 15, Max: 1000)      |
+
+<a id="response-7"></a>
 
 #### 응답
 
@@ -1080,7 +1138,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/message-results?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
+<a id="query-the-number-of-message-result-updates"></a>
+
 ### 메시지 결과 업데이트 건수 조회
+
+<a id="request-7"></a>
 
 #### 요청
 
@@ -1117,6 +1179,8 @@ Content-Type: application/json;charset=UTF-8
 | endUpdateDate       | 	String  | O   | 	결과 업데이트 조회 종료 시간(yyyy-MM-dd HH:mm) |
 | alimtalkMessageType | 	String  | X   | 	알림톡 메시지 타입(NORMAL, AUTH)           |
 
+<a id="response-8"></a>
+
 #### 응답
 
 ```
@@ -1144,6 +1208,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/message-results/count?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
+<a id="status-code-of-smslms-resending"></a>
+
 ### SMS/LMS 대체 발송 상태 코드
 
 | 이름    | 	설명                                  |
@@ -1154,9 +1220,15 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | RSC04 | 	대체 발송 성공                            |
 | RSC05 | 	대체 발송 실패                            |
 
+<a id="mass-delivery"></a>
+
 ## 대량 발송
 
+<a id="list-mass-delivery-requests"></a>
+
 ### 대량 발송 요청 목록 조회
+
+<a id="request-8"></a>
 
 #### 요청
 
@@ -1199,6 +1271,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum          | optional, Integer | -     | X   | 페이지 번호    |
 | pageSize         | optional, Integer | 1000  | X   | 검색 수      |
 
+<a id="curl"></a>
+
 #### cURL
 
 ```
@@ -1207,6 +1281,8 @@ curl -X GET \
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-9"></a>
 
 #### 응답
 
@@ -1261,7 +1337,11 @@ curl -X GET \
 | -- createUser       | String  |    X     | 생성 사용자(콘솔에서 발송 시 사용자 UUID로 저장)                                                 |
 | - totalCount        | Integer |    X     | 총개수                                                                            |
 
+<a id="list-mass-delivery-recipients"></a>
+
 ### 대량 발송 수신자 목록 조회
+
+<a id="request-9"></a>
 
 #### 요청
 
@@ -1301,6 +1381,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum          | optional, Integer | -     | X   | 페이지 번호    |
 | pageSize         | optional, Integer | 1000  | X   | 검색 수      |
 
+<a id="curl-2"></a>
+
 #### cURL
 
 ```
@@ -1309,6 +1391,8 @@ curl -X GET \
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-10"></a>
 
 #### 응답
 
@@ -1355,7 +1439,11 @@ curl -X GET \
 | -- resultCodeName | String  |    X     | 결과 코드 내용   |
 | - totalCount      | Integer |    X     | 총개수        |
 
+<a id="get-a-mass-delivery-recipient"></a>
+
 ### 대량 발송 수신자 조회
+
+<a id="request-10"></a>
 
 #### 요청
 
@@ -1396,6 +1484,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum          | optional, Integer | -     | X   | 페이지 번호    |
 | pageSize         | optional, Integer | 1000  | X   | 검색 수      |
 
+<a id="curl-3"></a>
+
 #### cURL
 
 ```
@@ -1404,6 +1494,8 @@ curl -X GET \
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-11"></a>
 
 #### 응답
 
@@ -1572,9 +1664,15 @@ curl -X GET \
 | -- pluginId             | String  |    X     | 플러그인 ID(최대 24자)                                                                                                                                                        |
 | -- target               | String  |    X     | 웹 링크 타입일 경우, "target":"out" 속성 추가 시 아웃 링크\<br\>기본 인앱 링크로 발송                                                                                                            |
 
+<a id="templates"></a>
+
 ## 템플릿
 
+<a id="list-template-categories"></a>
+
 ### 템플릿 카테고리 조회
+
+<a id="request-11"></a>
 
 #### 요청
 
@@ -1602,6 +1700,8 @@ Content-Type: application/json;charset=UTF-8
 | 이름           | 	타입     | 	필수 | 	설명              |
 |--------------|---------|-----|------------------|
 | X-Secret-Key | 	String | O   | 콘솔에서 생성할 수 있습니다. |
+
+<a id="response-12"></a>
 
 #### 응답
 
@@ -1645,7 +1745,11 @@ Content-Type: application/json;charset=UTF-8
 | -- inclusion    | String  |    X     | 카테고리 적용 대상 템플릿 설명        |
 | -- exclusion    | String  |    X     | 카테고리 제외 대상 템플릿 설명        |
 
+<a id="register-templates"></a>
+
 ### 템플릿 등록
+
+<a id="request-12"></a>
 
 #### 요청
 
@@ -1798,6 +1902,8 @@ Content-Type: application/json;charset=UTF-8
 * 채널 추가형(AD) 또는 복합형(MI) 메시지 유형 템플릿 등록 시 채널 추가(AC) 버튼이 첫 번째 순서에 위치해야 합니다.
 * 채널 추가(AC) 버튼의 버튼명은 "채널 추가"로 고정하여 등록해야 합니다.
 
+<a id="response-13"></a>
+
 #### 응답
 
 ```
@@ -1817,7 +1923,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
 
+<a id="modify-templates"></a>
+
 ### 템플릿 수정
+
+<a id="request-13"></a>
 
 #### 요청
 
@@ -1969,6 +2079,8 @@ Content-Type: application/json;charset=UTF-8
 * 채널 추가형(AD)과 복합형(MI) 메시지 유형 템플릿 수정 시, 채널 추가(AC) 버튼이 첫 번째 순서에 위치해야 합니다.
 * 채널 추가(AC) 버튼의 버튼명은 "채널 추가"로 고정하여, 수정해야 합니다.
 
+<a id="response-14"></a>
+
 #### 응답
 
 ```
@@ -1988,7 +2100,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
 
+<a id="delete-templates"></a>
+
 ### 템플릿 삭제
+
+<a id="request-14"></a>
 
 #### 요청
 
@@ -2019,6 +2135,8 @@ Content-Type: application/json;charset=UTF-8
 * 승인된 템플릿의 경우, 카카오톡 비즈메시지의 제약 때문에 카카오 내부 데이터는 삭제할 수 없습니다.
 * 카카오에 남아 있는 템플릿은 1년 미사용 시 휴면 처리되고, 휴면 상태가 1년간 지속되면 삭제 처리됩니다.(카카오에서 템플릿이 휴면 전환되거나 삭제되면 담당자에게 알림이 발송됩니다.)
 
+<a id="response-15"></a>
+
 #### 응답
 
 ```
@@ -2038,7 +2156,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
 
+<a id="inquire-of-templates"></a>
+
 ### 템플릿 문의하기
+
+<a id="request-15"></a>
 
 #### 요청
 
@@ -2083,6 +2205,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 반려 상태의 템플릿에 문의를 남길 경우, 검수 중(REQ) 상태로 변경됩니다.
 
+<a id="response-16"></a>
+
 #### 응답
 
 ```
@@ -2102,7 +2226,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
 
+<a id="send-inquiry-on-templates-with-file-attachment"></a>
+
 ### 파일 첨부하여 템플릿 문의하기
+
+<a id="request-16"></a>
 
 #### 요청
 
@@ -2149,6 +2277,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 반려 상태의 템플릿에 문의를 남길 경우, 검수 중(REQ) 상태로 변경됩니다.
 
+<a id="response-17"></a>
+
 #### 응답
 
 ```
@@ -2168,7 +2298,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
 
+<a id="change-template-to-channel-add-type"></a>
+
 ### 템플릿 채널 추가형으로 변경
+
+<a id="request-17"></a>
 
 #### 요청
 
@@ -2201,6 +2335,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 그룹 발신 프로필에 등록된 템플릿은 채널 추가형으로 전환할 수 없습니다.
 
+<a id="response-18"></a>
+
 #### 응답
 
 ```
@@ -2220,7 +2356,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
 
+<a id="single-query-for-template"></a>
+
 ### 템플릿 단건 조회
+
+<a id="request-18"></a>
 
 #### 요청
 
@@ -2263,6 +2403,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}"
 ```
+
+<a id="response-19"></a>
 
 #### 응답
 
@@ -2443,7 +2585,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - updateDate            | String  |    X     | 수정일자                                                                                                                                                                             |
 
 
+<a id="list-templates"></a>
+
 ### 템플릿 리스트 조회
+
+<a id="request-19"></a>
 
 #### 요청
 
@@ -2495,6 +2641,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates?templateStatus={템플릿 상태 코드}"
 ```
+
+<a id="response-20"></a>
 
 #### 응답
 
@@ -2677,7 +2825,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- updateDate            | String  |    X     | 수정일자                                                                                                                                                                   |
 | - totalCount             | Integer |    X     | 총개수                                                                                                                                                                    |
 
+<a id="list-template-modifications"></a>
+
 ### 템플릿 수정 리스트 조회
+
+<a id="request-20"></a>
 
 #### 요청
 
@@ -2713,6 +2865,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}/modifications"
 ```
+
+<a id="response-21"></a>
 
 #### 응답
 
@@ -2891,7 +3045,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- updateDate                 | String  |    X     | 수정일자                                                                                                                                                                   |
 | - totalCount                  | Integer |    X     | 총개수                                                                                                                                                                    |
 
+<a id="register-template-image"></a>
+
 ### 템플릿 이미지 등록
+
+<a id="request-21"></a>
 
 #### 요청
 
@@ -2932,6 +3090,8 @@ Content-Type: multipart/form-data
 curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/template-image" -F "file=@alimtalk-template-image.jpeg"
 ```
 
+<a id="response-22"></a>
+
 #### 응답
 
 ```
@@ -2958,7 +3118,11 @@ curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}
 | - templateImageName | String  |    X     | 이미지명(업로드한 파일명) |
 | - templateImageUrl  | String  |    X     | 이미지 URL        |
 
+<a id="register-template-item-highlight-images"></a>
+
 ### 템플릿 아이템 하이라이트 이미지 등록
+
+<a id="request-22"></a>
 
 #### 요청
 
@@ -2999,6 +3163,8 @@ Content-Type: multipart/form-data
 curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/template-image/item-highlight" -F "file=@alimtalk-template-image.jpeg"
 ```
 
+<a id="response-23"></a>
+
 #### 응답
 
 ```
@@ -3025,7 +3191,11 @@ curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}
 | - templateImageName | String  |    X     | 이미지명(업로드한 파일명) |
 | - templateImageUrl  | String  |    X     | 이미지 URL        |
 
+<a id="register-template-plugin"></a>
+
 ### 템플릿 플러그인 등록
+
+<a id="request-23"></a>
 
 #### 요청
 
@@ -3071,6 +3241,8 @@ Content-Type: application/json;charset=UTF-8
 | pluginId    | 	String | 	O  | 플러그인 아이디                                                   |
 | callbackUrl | 	String | 	O  | 플러그인 버튼 클릭 시, 수신받을 콜백 URL                                  |
 
+<a id="response-24"></a>
+
 #### 응답
 
 ```
@@ -3090,7 +3262,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
 
+<a id="modify-template-plugin"></a>
+
 ### 템플릿 플러그인 수정
+
+<a id="request-24"></a>
 
 #### 요청
 
@@ -3135,6 +3311,8 @@ Content-Type: application/json;charset=UTF-8
 | pluginType  | 	String | 	O  | 플러그인 타입(SECURE_IMAGE: 보안 이미지 전송, ONE_TIME_PROFILE: 개인정보 이용) |
 | callbackUrl | 	String | 	O  | 플러그인 버튼 클릭 시, 수신받을 콜백 URL                                  |
 
+<a id="response-25"></a>
+
 #### 응답
 
 ```
@@ -3154,7 +3332,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
 
+<a id="modify-template-plugin-2"></a>
+
 ### 템플릿 플러그인 삭제
+
+<a id="request-25"></a>
 
 #### 요청
 
@@ -3185,6 +3367,8 @@ Content-Type: application/json;charset=UTF-8
 |--------------|---------|-----|------------------|
 | X-Secret-Key | 	String | O   | 콘솔에서 생성할 수 있습니다. |
 
+<a id="response-26"></a>
+
 #### 응답
 
 ```
@@ -3204,7 +3388,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
 
+<a id="retrieve-template-plugin"></a>
+
 ### 템플릿 플러그인 조회
+
+<a id="request-26"></a>
 
 #### 요청
 
@@ -3233,6 +3421,8 @@ Content-Type: application/json;charset=UTF-8
 | 이름           | 	타입     | 	필수 | 	설명              |
 |--------------|---------|-----|------------------|
 | X-Secret-Key | 	String | O   | 콘솔에서 생성할 수 있습니다. |
+
+<a id="response-27"></a>
 
 #### 응답
 
@@ -3271,7 +3461,11 @@ Content-Type: application/json;charset=UTF-8
 | - modifiable     | Boolean |    X     | 수정 가능 여부                                                   |
 | - deletable      | Boolean |    X     | 삭제 가능 여부                                                   |
 
+<a id="manage-alternative-delivery"></a>
+
 ## 대체 발송 관리
+
+<a id="register-an-sms-appkey"></a>
 
 ### SMS AppKey 등록
 
@@ -3318,6 +3512,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
 ```
 
+<a id="response-28"></a>
+
 #### 응답
 
 ```
@@ -3337,6 +3533,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | - resultCode    | Integer |    O     | 결과 코드  |
 | - resultMessage | String  |    O     | 결과 메시지 |
 | - isSuccessful  | Boolean |    O     | 성공 여부  |
+
+<a id="register-alternative-delivery-settings"></a>
 
 ### 대체 발송 설정 등록
 
@@ -3386,6 +3584,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/failback/appkey -d '{"senderKey": "0be23c29de88d6888798aeda57062516354d74ba","isResend": true,"resendSendNo": "01012341234" }
 ```
+
+<a id="response-29"></a>
 
 #### 응답
 


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Body text is never modified.** The model only sees heading outlines; edits apply to heading lines (and `<!-- TODO: translate body -->` stubs for missing sections) only.

## Analysis

| | |
| --- | --- |
| Engine | `api (Anthropic SDK)` |
| Model | `claude-sonnet-4-20250514` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `pre-align/fix-headings-20260615-080708` |
| Scope | 1 doc(s) scanned · 3 file(s) changed |
| Self-verify | ⚠️ 14 mismatch(es) remain |
| Jenkins build | http://testlab.cloud.toastoven.net:8080/job/user-guide-agent/job/align-heading/job/260521/80/ |
| Generated | 2026-06-15T10:51:47 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`pre-align/fix-headings-20260615-080708`): [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FAlimtalk%2Fblob%2Fpre-align%2Ffix-headings-20260615-080708%2Fko%2Falimtalk-api-guide.md&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FAlimtalk%2Fpull%2F228&source=ko&langs=en%2Cja)

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra demoted | extra removed | verify |
| --- | --: | --: | --: | --: | --: | --: | --: | :--: |
| `ko/alimtalk-api-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/alimtalk-api-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/alimtalk-api-guide.md` | 0 | 0 | 0 | 15 | 0 | 0 | 0 | ⚠️ 14 |

<details><summary>남은 불일치 (검토 필요)</summary>

- `ja/alimtalk-api-guide.md`:
  - extra_in_target (ko#None/ja#13)
  - extra_in_target (ko#None/ja#22)
  - extra_in_target (ko#None/ja#23)
  - extra_in_target (ko#None/ja#24)
  - missing_in_target (ko#31/ja#None)
  - missing_in_target (ko#32/ja#None)
  - missing_in_target (ko#33/ja#None)
  - missing_in_target (ko#34/ja#None)
  - missing_in_target (ko#67/ja#None)
  - missing_in_target (ko#68/ja#None)
  - missing_in_target (ko#69/ja#None)
  - extra_in_target (ko#None/ja#73)
  - extra_in_target (ko#None/ja#74)
  - extra_in_target (ko#None/ja#75)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/Alimtalk`