### PR TITLE
chore(pre-align): align-v2 heading structure (3 docs) with ko

### DIFF
--- a/en/alimtalk-api-guide-v2.0.md
+++ b/en/alimtalk-api-guide-v2.0.md
@@ -1,6 +1,10 @@
 ## Notification > KakaoTalk Bizmessage > AlimTalk > API v2.0 Guide
 
+<a id="alimtalk"></a>
+
 ## AlimTalk
+
+<a id="api-domain"></a>
 
 #### [API Domain]
 
@@ -17,6 +21,8 @@
 </tbody>
 </table>
 
+<a id="overview-of-v20-api"></a>
+
 ## Overview of v2.0 API
 1. It has been changed to allow emphasized template for Register Template API(for a full-text delivery, the title value can be configured.)
 2. Expanded the template type. Ad or additional information can be added.
@@ -25,7 +31,11 @@
 5. Added Attach Files to Send Inquiry on Templates API.
 
 
+<a id="general-messages"></a>
+
 ## General Messages
+
+<a id="request-of-sending-replaced-messages"></a>
 
 ### Request of Sending Replaced Messages
 
@@ -119,6 +129,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages -d '{"senderkey":"{Sender key}","templateCode":"{template code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{recipient number}","templateParameter":{"{replaced field}":"{replacement data}"}}]}'
 ```
 
+<a id="response"></a>
+
 #### Response
 
 ```
@@ -159,6 +171,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultCode           | Integer | Result code of delivery request    |
 | -- resultMessage        | String  | Result message of delivery request |
 | -- recipientGroupingKey | String  | Recipient's grouping key           |
+
+<a id="request-of-sending-full-text"></a>
 
 ### Request of Sending Full Text
 
@@ -270,6 +284,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/raw-messages -d '{"senderKey":"{Sender key}","templateCode":"{template code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{recipient number}","content":"{body}","buttons":[{"ordering":"{button sequence}","type":"{button type}","name":"{button name}","linkMo":"{mobile web link}"}]}]}'
 ```
 
+<a id="response-2"></a>
+
 #### Response
 
 ```
@@ -311,7 +327,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultMessage        | String  | Result message of delivery request |
 | -- recipientGroupingKey | String  | Recipient's grouping key           |
 
+<a id="list-messages"></a>
+
 ### List Messages
+
+<a id="request"></a>
 
 #### Request
 
@@ -361,6 +381,8 @@ Content-Type: application/json;charset=UTF-8
 
 * Cannot query data requested for delivery which are dated before 90 days.
 * The maximum available days for delivery request is 30 days.
+
+<a id="response-3"></a>
 
 #### Response
 ```
@@ -459,7 +481,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | RSC04 | Resending successful                             |
 | RSC05 | Resending failed                                 |
 
+<a id="get-messages"></a>
+
 ### Get Messages
+
+<a id="request-2"></a>
 
 #### Request
 
@@ -492,6 +518,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-4"></a>
 
 #### Response
 ```
@@ -585,6 +613,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - senderGroupingKey    | String  | Sender's grouping key                                        |
 | - recipientGroupingKey | String  | Recipient grouping key                                       |
 
+<a id="authentication-messages"></a>
+
 ## Authentication Messages
 
 <span id="precautions-authword"></span>
@@ -597,6 +627,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 - Example 1) Delivery shall fail if the full text(including template replacement) does not include authentication words, in the request of Authentication Messages API(for emergency)
 - Example 2) Validity for English words shall be checked regardless of small or capital letters
 
+
+<a id="request-of-sending-replaced-messages-2"></a>
 
 ### Request of Sending Replaced Messages
 
@@ -682,6 +714,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/auth/messages -d '{"senderKey":"{Sender Key}","templateCode":"{template code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{recipient number}","templateParameter":{"{replaced field}":"{replacement data}"}}]}'
 ```
 
+<a id="response-5"></a>
+
 #### Response
 
 ```
@@ -722,6 +756,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultCode           | Integer | Result code of delivery request    |
 | -- resultMessage        | String  | Result message of delivery request |
 | -- recipientGroupingKey | String  | Recipient's grouping key           |
+
+<a id="request-of-sending-full-text-2"></a>
 
 ### Request of Sending Full Text
 
@@ -827,6 +863,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/auth/raw-messages -d '{"senderKey":"{Sender Key}","templateCode":"{template code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{recipient number}","content":"{body message}","buttons":[{"ordering":"{button sequence}","type":"{button type}","name":"{button name}","linkMo":"{mobile web link}"}]}]}'
 ```
 
+<a id="response-6"></a>
+
 #### Response
 
 ```
@@ -867,6 +905,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultCode           | Integer | Result code of delivery request    |
 | -- resultMessage        | String  | Result message of delivery request |
 | -- recipientGroupingKey | String  | Recipient's grouping key           |
+
+<a id="list-messages-2"></a>
 
 ### List Messages
 
@@ -917,6 +957,8 @@ Content-Type: application/json;charset=UTF-8
 
 * Delivery request data before 90 days cannot be queried.
 * Delivery can be requested within 30 days to the maximum.   
+
+<a id="request-3"></a>
 
 #### Response
 ```
@@ -1006,6 +1048,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/auth/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<a id="response-7"></a>
+
 #### Status of Resending SMS/LMS
 | Value | Description                                     |
 | ----- | ----------------------------------------------- |
@@ -1015,7 +1059,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | RSC04 | Resending successful                            |
 | RSC05 | Resending failed                                |
 
+<a id="get-messages-2"></a>
+
 ### Get Messages
+
+<a id="request-4"></a>
 
 #### Request
 
@@ -1048,6 +1096,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/auth/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-8"></a>
 
 #### Response
 ```
@@ -1144,8 +1194,14 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - senderGroupingKey    | String  | Sender's grouping key                                        |
 | - recipientGroupingKey | String  | Recipient's grouping key                                     |
 
+<a id="messages"></a>
+
 ## Messages
+<a id="cancel-sending-messages"></a>
+
 ### Cancel Sending Messages
+
+<a id="request-5"></a>
 
 #### Request
 
@@ -1181,6 +1237,8 @@ Content-Type: application/json;charset=UTF-8
 
 * Both general and authentication messages can be canceled by same API.
 
+<a id="response-9"></a>
+
 #### Response
 ```
 {
@@ -1204,7 +1262,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
 ```
 
+<a id="query-updates-of-message-result"></a>
+
 ### Query Updates of Message Result
+
+<a id="request-6"></a>
 
 #### Request
 
@@ -1240,6 +1302,8 @@ Content-Type: application/json;charset=UTF-8
 | alimtalkMessageType | String  | X        | AlimTalk message type(NORMAL, AUTH)                     |
 | pageNum             | Integer | X        | Page number(default: 1)                                 |
 | pageSize            | Integer | X        | Number of queries(default: 15, Max: 1000)              |
+
+<a id="response-10"></a>
 
 #### Response
 ```
@@ -1294,9 +1358,21 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/message-results?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
+<a id="messages-1"></a>
+
+### SMS/LMS 대체 발송 상태 코드
+
+<!-- TODO: translate body -->
+
+<a id="templates"></a>
+
 ## Templates
 
+<a id="list-template-categories"></a>
+
 ### List Template Categories
+<a id="request-7"></a>
+
 #### Request
 [URL]
 
@@ -1320,6 +1396,8 @@ Content-Type: application/json;charset=UTF-8
 | Value        | Type   | Required | Description                                                  |
 | ------------ | ------ | -------- | ------------------------------------------------------------ |
 | X-Secret-Key | String | O        | Can be created on console.  |
+
+<a id="response-11"></a>
 
 #### Response
 ```
@@ -1362,7 +1440,11 @@ Content-Type: application/json;charset=UTF-8
 | -- inclusion    | String  |	Description of templates to which the category applies |
 | -- exclusion    | String  | Description of templates to which the category does not apply |
 
+<a id="register-templates"></a>
+
 ### Register Templates
+
+<a id="request-8"></a>
 
 #### Request
 
@@ -1439,6 +1521,8 @@ Content-Type: application/json;charset=UTF-8
 | -schemeIos      | String  | X        | iOS app link(required for the AL type, up to 500 characters) |
 | -schemeAndroid  | String  | X        | Android app link(required for the AL type, up to 500 characters) |
 
+<a id="response-12"></a>
+
 #### Response
 
 ```
@@ -1458,7 +1542,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | Result message    |
 | - isSuccessful  | Boolean | Successful or not |
 
+<a id="modify-templates"></a>
+
 ### Modify Templates
+
+<a id="request-9"></a>
 
 #### Request
 
@@ -1534,6 +1622,8 @@ Content-Type: application/json;charset=UTF-8
 | -schemeIos      | String  | X        | iOS app link(required for the AL type, up to 500 characters) |
 | -schemeAndroid  | String  | X        | Android app link(required for the AL type, up to 500 characters) |
 
+<a id="response-13"></a>
+
 #### Response
 
 ```
@@ -1553,7 +1643,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | Result message    |
 | - isSuccessful  | Boolean | Successful or not |
 
+<a id="delete-templates"></a>
+
 ### Delete Templates
+
+<a id="request-10"></a>
 
 #### Request
 
@@ -1579,6 +1673,8 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
+<a id="response-14"></a>
+
 #### Response
 ```
 {
@@ -1597,7 +1693,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | Result message    |
 | - isSuccessful  | Boolean | Successful or not |
 
+<a id="inquire-of-templates"></a>
+
 ### Inquire of Templates
+
+<a id="request-11"></a>
 
 #### Request
 
@@ -1638,6 +1738,8 @@ Content-Type: application/json;charset=UTF-8
 | ------- | ------ | -------- | ----------- |
 | comment | String | O        | Inquiries   |
 
+<a id="response-15"></a>
+
 #### Response
 ```
 {
@@ -1656,7 +1758,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | Result message    |
 | - isSuccessful  | Boolean | Successful or not |
 
+<a id="attach-files-to-send-inquiry-on-templates"></a>
+
 ### Attach files to send inquiry on templates
+<a id="request-12"></a>
+
 #### Request
 [URL]
 
@@ -1697,6 +1803,8 @@ Content-Type: application/json;charset=UTF-8
 |comment|	String |	O | Content of Inquiry          |
 |attachments| List<File> | X | List of Attachment(Up to 10) |
 
+<a id="response-16"></a>
+
 #### Response
 ```
 {
@@ -1715,7 +1823,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result Message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="list-templates"></a>
+
 ### List Templates
+
+<a id="request-13"></a>
 
 #### Request
 
@@ -1765,6 +1877,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/templates?templateStatus={template status code}"
 ```
+
+<a id="response-17"></a>
 
 #### Response
 ```
@@ -1866,7 +1980,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- createDate        | String  | Date and time of creation                                    |
 | - totalCount         | Integer | Total count                                                  |
 
+<a id="list-template-modifications"></a>
+
 ### List Template modifications
+
+<a id="request-14"></a>
 
 #### Request
 
@@ -1899,6 +2017,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}/modifications"
 ```
+
+<a id="response-18"></a>
 
 #### Response
 ```
@@ -2001,3 +2121,33 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- activated         | Boolean | activated or not                                             |
 | -- createDate        | String  | Date and time of creation                                    |
 | - totalCount         | Integer | Total count                                                  |
+<a id="section-1"></a>
+
+## 대체 발송 관리
+
+<!-- TODO: translate body -->
+
+<a id="section-1-1"></a>
+
+### SMS AppKey 등록
+
+<!-- TODO: translate body -->
+
+<a id="section-1-1-1"></a>
+
+#### 응답
+
+<!-- TODO: translate body -->
+
+<a id="section-1-2"></a>
+
+### 대체 발송 설정 등록
+
+<!-- TODO: translate body -->
+
+<a id="section-1-2-1"></a>
+
+#### 응답
+
+<!-- TODO: translate body -->
+

--- a/en/alimtalk-api-guide-v2.1.md
+++ b/en/alimtalk-api-guide-v2.1.md
@@ -1,6 +1,10 @@
 ## Notification > KakaoTalk Bizmessage > AlimTalk > API v2.1 Guide
 
+<a id="alimtalk"></a>
+
 ## AlimTalk
+
+<a id="api-domain"></a>
 
 #### [API Domain]
 
@@ -17,13 +21,19 @@
 </tbody>
 </table>
 
+<a id="overview-of-v21-api"></a>
+
 ## Overview of v2.1 API
 1. Added AlimTalk Template-Image Uploding API.
 2. Expanded the templateEmphasizeType type. 'IMAGE' can be added.
 3. Added templateImageName, templateImageUrl on Inquire of Templates
 
 
+<a id="general-messages"></a>
+
 ## General Messages
+
+<a id="request-of-sending-replaced-messages"></a>
 
 ### Request of Sending Replaced Messages
 
@@ -117,6 +127,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/messages -d '{"senderkey":"{Sender key}","templateCode":"{template code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{recipient number}","templateParameter":{"{replaced field}":"{replacement data}"}}]}'
 ```
 
+<a id="response"></a>
+
 #### Response
 
 ```
@@ -157,6 +169,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultCode           | Integer | Result code of delivery request    |
 | -- resultMessage        | String  | Result message of delivery request |
 | -- recipientGroupingKey | String  | Recipient's grouping key           |
+
+<a id="request-of-sending-full-text"></a>
 
 ### Request of Sending Full Text
 
@@ -268,6 +282,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/raw-messages -d '{"senderKey":"{Sender key}","templateCode":"{template code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{recipient number}","content":"{body}","buttons":[{"ordering":"{button sequence}","type":"{button type}","name":"{button name}","linkMo":"{mobile web link}"}]}]}'
 ```
 
+<a id="response-2"></a>
+
 #### Response
 
 ```
@@ -309,7 +325,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultMessage        | String  | Result message of delivery request |
 | -- recipientGroupingKey | String  | Recipient's grouping key           |
 
+<a id="list-messages"></a>
+
 ### List Messages
+
+<a id="request"></a>
 
 #### Request
 
@@ -359,6 +379,8 @@ Content-Type: application/json;charset=UTF-8
 
 * Cannot query data requested for delivery which are dated before 90 days.
 * The maximum available days for delivery request is 30 days.
+
+<a id="response-3"></a>
 
 #### Response
 ```
@@ -457,7 +479,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | RSC04 | Resending successful                             |
 | RSC05 | Resending failed                                 |
 
+<a id="get-messages"></a>
+
 ### Get Messages
+
+<a id="request-2"></a>
 
 #### Request
 
@@ -490,6 +516,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-4"></a>
 
 #### Response
 ```
@@ -583,6 +611,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - senderGroupingKey    | String  | Sender's grouping key                                        |
 | - recipientGroupingKey | String  | Recipient grouping key                                       |
 
+<a id="authentication-messages"></a>
+
 ## Authentication Messages
 
 <span id="precautions-authword"></span>
@@ -595,6 +625,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 - Example 1) Delivery shall fail if the full text(including template replacement) does not include authentication words, in the request of Authentication Messages API(for emergency)
 - Example 2) Validity for English words shall be checked regardless of small or capital letters
 
+
+<a id="request-of-sending-replaced-messages-2"></a>
 
 ### Request of Sending Replaced Messages
 
@@ -680,6 +712,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/auth/messages -d '{"senderKey":"{Sender Key}","templateCode":"{template code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{recipient number}","templateParameter":{"{replaced field}":"{replacement data}"}}]}'
 ```
 
+<a id="response-5"></a>
+
 #### Response
 
 ```
@@ -720,6 +754,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultCode           | Integer | Result code of delivery request    |
 | -- resultMessage        | String  | Result message of delivery request |
 | -- recipientGroupingKey | String  | Recipient's grouping key           |
+
+<a id="request-of-sending-full-text-2"></a>
 
 ### Request of Sending Full Text
 
@@ -825,6 +861,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/auth/raw-messages -d '{"senderKey":"{Sender Key}","templateCode":"{template code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{recipient number}","content":"{body message}","buttons":[{"ordering":"{button sequence}","type":"{button type}","name":"{button name}","linkMo":"{mobile web link}"}]}]}'
 ```
 
+<a id="response-6"></a>
+
 #### Response
 
 ```
@@ -865,6 +903,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultCode           | Integer | Result code of delivery request    |
 | -- resultMessage        | String  | Result message of delivery request |
 | -- recipientGroupingKey | String  | Recipient's grouping key           |
+
+<a id="list-messages-2"></a>
 
 ### List Messages
 
@@ -915,6 +955,8 @@ Content-Type: application/json;charset=UTF-8
 
 * Delivery request data before 90 days cannot be queried.
 * Delivery can be requested within 30 days to the maximum.   
+
+<a id="request-3"></a>
 
 #### Response
 ```
@@ -1004,6 +1046,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/auth/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<a id="response-7"></a>
+
 #### Status of Resending SMS/LMS
 | Value | Description                                     |
 | ----- | ----------------------------------------------- |
@@ -1013,7 +1057,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | RSC04 | Resending successful                            |
 | RSC05 | Resending failed                                |
 
+<a id="get-messages-2"></a>
+
 ### Get Messages
+
+<a id="request-4"></a>
 
 #### Request
 
@@ -1046,6 +1094,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/auth/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-8"></a>
 
 #### Response
 ```
@@ -1142,8 +1192,14 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - senderGroupingKey    | String  | Sender's grouping key                                        |
 | - recipientGroupingKey | String  | Recipient's grouping key                                     |
 
+<a id="messages"></a>
+
 ## Messages
+<a id="cancel-sending-messages"></a>
+
 ### Cancel Sending Messages
+
+<a id="request-5"></a>
 
 #### Request
 
@@ -1179,6 +1235,8 @@ Content-Type: application/json;charset=UTF-8
 
 * Both general and authentication messages can be canceled by same API.
 
+<a id="response-9"></a>
+
 #### Response
 ```
 {
@@ -1202,7 +1260,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
 ```
 
+<a id="query-updates-of-message-result"></a>
+
 ### Query Updates of Message Result
+
+<a id="request-6"></a>
 
 #### Request
 
@@ -1238,6 +1300,8 @@ Content-Type: application/json;charset=UTF-8
 | alimtalkMessageType | String  | X        | AlimTalk message type(NORMAL, AUTH)                     |
 | pageNum             | Integer | X        | Page number(default: 1)                                 |
 | pageSize            | Integer | X        | Number of queries(default: 15, Max: 1000)              |
+
+<a id="response-10"></a>
 
 #### Response
 ```
@@ -1292,9 +1356,21 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/message-results?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
+<a id="messages-1"></a>
+
+### SMS/LMS 대체 발송 상태 코드
+
+<!-- TODO: translate body -->
+
+<a id="templates"></a>
+
 ## Templates
 
+<a id="list-template-categories"></a>
+
 ### List Template Categories
+<a id="request-7"></a>
+
 #### Request
 [URL]
 
@@ -1318,6 +1394,8 @@ Content-Type: application/json;charset=UTF-8
 | Value        | Type   | Required | Description                                                  |
 | ------------ | ------ | -------- | ------------------------------------------------------------ |
 | X-Secret-Key | String | O        | Can be created on console.  |
+
+<a id="response-11"></a>
 
 #### Response
 ```
@@ -1360,7 +1438,11 @@ Content-Type: application/json;charset=UTF-8
 | -- inclusion    | String  |	Description of templates to which the category applies |
 | -- exclusion    | String  | Description of templates to which the category does not apply |
 
+<a id="register-templates"></a>
+
 ### Register Templates
+
+<a id="request-8"></a>
 
 #### Request
 
@@ -1441,6 +1523,8 @@ Content-Type: application/json;charset=UTF-8
 | -schemeIos      | String  | X        | iOS app link(required for the AL type, up to 500 characters) |
 | -schemeAndroid  | String  | X        | Android app link(required for the AL type, up to 500 characters) |
 
+<a id="response-12"></a>
+
 #### Response
 
 ```
@@ -1460,7 +1544,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | Result message    |
 | - isSuccessful  | Boolean | Successful or not |
 
+<a id="modify-templates"></a>
+
 ### Modify Templates
+
+<a id="request-9"></a>
 
 #### Request
 
@@ -1540,6 +1628,8 @@ Content-Type: application/json;charset=UTF-8
 | -schemeIos      | String  | X        | iOS app link(required for the AL type, up to 500 characters) |
 | -schemeAndroid  | String  | X        | Android app link(required for the AL type, up to 500 characters) |
 
+<a id="response-13"></a>
+
 #### Response
 
 ```
@@ -1559,7 +1649,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | Result message    |
 | - isSuccessful  | Boolean | Successful or not |
 
+<a id="delete-templates"></a>
+
 ### Delete Templates
+
+<a id="request-10"></a>
 
 #### Request
 
@@ -1585,6 +1679,8 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
+<a id="response-14"></a>
+
 #### Response
 ```
 {
@@ -1603,7 +1699,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | Result message    |
 | - isSuccessful  | Boolean | Successful or not |
 
+<a id="inquire-of-templates"></a>
+
 ### Inquire of Templates
+
+<a id="request-11"></a>
 
 #### Request
 
@@ -1644,6 +1744,8 @@ Content-Type: application/json;charset=UTF-8
 | ------- | ------ | -------- | ----------- |
 | comment | String | O        | Inquiries   |
 
+<a id="response-15"></a>
+
 #### Response
 ```
 {
@@ -1662,7 +1764,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | Result message    |
 | - isSuccessful  | Boolean | Successful or not |
 
+<a id="attach-files-to-send-inquiry-on-templates"></a>
+
 ### Attach files to send inquiry on templates
+<a id="request-12"></a>
+
 #### Request
 [URL]
 
@@ -1703,6 +1809,8 @@ Content-Type: application/json;charset=UTF-8
 |comment|	String |	O | Content of Inquiry           |
 |attachments| List<File> | X | List of Attachment(Up to 10) |
 
+<a id="response-16"></a>
+
 #### Response
 ```
 {
@@ -1721,7 +1829,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| Result Message|
 |- isSuccessful|	Boolean| Successful or not|
 
+<a id="list-templates"></a>
+
 ### List Templates
+
+<a id="request-13"></a>
 
 #### Request
 
@@ -1771,6 +1883,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/templates?templateStatus={template status code}"
 ```
+
+<a id="response-17"></a>
 
 #### Response
 ```
@@ -1876,7 +1990,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- createDate        | String  | Date and time of creation                                    |
 | - totalCount         | Integer | Total count                                                  |
 
+<a id="list-template-modifications"></a>
+
 ### List Template modifications
+
+<a id="request-14"></a>
 
 #### Request
 
@@ -1909,6 +2027,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}/modifications"
 ```
+
+<a id="response-18"></a>
 
 #### Response
 ```
@@ -2016,7 +2136,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- createDate        | String  | Date and time of creation                                    |
 | - totalCount         | Integer | Total count                                                  |
 
+<a id="register-template-image"></a>
+
 ### Register Template Image
+<a id="request-15"></a>
+
 #### Request
 [URL]
 
@@ -2052,6 +2176,8 @@ Content-Type: multipart/form-data
 curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/template-image" -F "file=@alimtalk-template-image.jpeg"
 ```
 
+<a id="response-19"></a>
+
 #### Response
 ```
 {
@@ -2076,3 +2202,33 @@ curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}
 | templateImage        | Object  | Body area                                                    |
 | - templateImageName  | String  | Image name                                                   |
 | - templateImageUrl   | String  | Image URL                                                    |
+<a id="section-1"></a>
+
+## 대체 발송 관리
+
+<!-- TODO: translate body -->
+
+<a id="section-1-1"></a>
+
+### SMS AppKey 등록
+
+<!-- TODO: translate body -->
+
+<a id="section-1-1-1"></a>
+
+#### 응답
+
+<!-- TODO: translate body -->
+
+<a id="section-1-2"></a>
+
+### 대체 발송 설정 등록
+
+<!-- TODO: translate body -->
+
+<a id="section-1-2-1"></a>
+
+#### 응답
+
+<!-- TODO: translate body -->
+

--- a/en/alimtalk-api-guide-v2.2.md
+++ b/en/alimtalk-api-guide-v2.2.md
@@ -1,6 +1,10 @@
 ## Notification > KakaoTalk Bizmessage > AlimTalk > API v2.2 Guide
 
+<a id="alimtalk"></a>
+
 ## AlimTalk
+
+<a id="api-domain"></a>
 
 #### [API Domain]
 
@@ -17,13 +21,19 @@
 </tbody>
 </table>
 
+<a id="overview-of-v22-api"></a>
+
 ## Overview of v2.2 API
 1. Added AlimTalk mass delivery query and statistics query API.
 2. Added a `buttons` field to the response body of replaced message sending API.
 3. Added `chatExtra`, `chatEvent`, and `target` fields to the `buttons` field in the response body of the full text message sending API.
 4. Added `chatExtra`, `chatEvent`, and `target` fields to the `buttons` field in the response body of the message query API.
 
+<a id="general-messages"></a>
+
 ## General Messages
+
+<a id="request-of-sending-replaced-messages"></a>
 
 ### Request of Sending Replaced Messages
 
@@ -132,6 +142,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/messages -d '{"senderkey":"{Sender key}","templateCode":"{template code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{recipient number}","templateParameter":{"{replaced field}":"{replacement data}"}}]}'
 ```
 
+<a id="response"></a>
+
 #### Response
 
 ```
@@ -172,6 +184,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 |-- resultCode | Integer | Result code of delivery request |
 |-- resultMessage | String | Result message of delivery request |
 |-- recipientGroupingKey | String | Recipient's grouping key |
+
+<a id="request-of-sending-full-text"></a>
 
 ### Request of Sending Full Text
 
@@ -291,6 +305,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/raw-messages -d '{"senderKey":"{Sender key}","templateCode":"{template code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{recipient number}","content":"{body}","buttons":[{"ordering":"{button sequence}","type":"{button type}","name":"{button name}","linkMo":"{mobile web link}"}]}]}'
 ```
 
+<a id="response-2"></a>
+
 #### Response
 
 ```
@@ -332,7 +348,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 |-- resultMessage | String | Result message of delivery request |
 |-- recipientGroupingKey | String | Recipient's grouping key |
 
+<a id="list-messages"></a>
+
 ### List Messages
+
+<a id="request"></a>
 
 #### Request
 
@@ -381,6 +401,8 @@ Content-Type: application/json;charset=UTF-8
 
 * Cannot query data requested for delivery which are dated before 90 days.
 * The maximum available days for delivery request is 30 days.
+
+<a id="response-3"></a>
 
 #### Response
 ```
@@ -476,7 +498,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<a id="get-messages"></a>
+
 ### Get Messages
+
+<a id="request-2"></a>
 
 #### Request
 
@@ -509,6 +535,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-4"></a>
 
 #### Response
 ```
@@ -611,6 +639,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |- senderGroupingKey | String | Sender's grouping key |
 |- recipientGroupingKey | String |  Recipient grouping key |
 
+<a id="authentication-messages"></a>
+
 ## Authentication Messages
 
 <span id="precautions-authword"></span>
@@ -623,6 +653,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 - Example 1-1) Delivery shall fail if the full text(including template replacement) does not include authentication words, in the request of Authentication Messages API(for emergency)
 - Example 1-2) Validity for English words shall be checked regardless of small or capital letters
 
+
+<a id="request-of-sending-replaced-messages-2"></a>
 
 ### Request of Sending Replaced Messages
 
@@ -726,6 +758,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/auth/messages -d '{"senderKey":"{Sender Key}","templateCode":"{template code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{recipient number}","templateParameter":{"{replaced field}":"{replacement data}"}}]}'
 ```
 
+<a id="response-5"></a>
+
 #### Response
 
 ```
@@ -766,6 +800,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 |-- resultCode | Integer | Result code of delivery request |
 |-- resultMessage | String | Result message of delivery request |
 |-- recipientGroupingKey | String | Recipient's grouping key |
+
+<a id="request-of-sending-full-text-2"></a>
 
 ### Request of Sending Full Text
 
@@ -880,6 +916,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/auth/raw-messages -d '{"senderKey":"{Sender Key}","templateCode":"{template code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{recipient number}","content":"{body message}","buttons":[{"ordering":"{button sequence}","type":"{button type}","name":"{button name}","linkMo":"{mobile web link}"}]}]}'
 ```
 
+<a id="response-6"></a>
+
 #### Response
 
 ```
@@ -921,7 +959,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 |-- resultMessage | String | Result message of delivery request |
 |-- recipientGroupingKey | String | Recipient's grouping key |
 
+<a id="list-messages-2"></a>
+
 ### List Messages
+
+<a id="request-3"></a>
 
 #### Request
 
@@ -970,6 +1012,8 @@ Content-Type: application/json;charset=UTF-8
 
 * Delivery request data before 90 days cannot be queried.
 * Delivery can be requested within 30 days to the maximum.   
+
+<a id="response-7"></a>
 
 #### Response
 ```
@@ -1065,7 +1109,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/auth/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<a id="get-messages-2"></a>
+
 ### Get Messages
+
+<a id="request-4"></a>
 
 #### Request
 
@@ -1098,6 +1146,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/auth/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-8"></a>
 
 #### Response
 ```
@@ -1200,8 +1250,14 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |- senderGroupingKey | String | Sender's grouping key |
 |- recipientGroupingKey | String |  Recipient's grouping key |
 
+<a id="messages"></a>
+
 ## Messages
+<a id="cancel-sending-messages"></a>
+
 ### Cancel Sending Messages
+
+<a id="request-5"></a>
 
 #### Request
 
@@ -1237,6 +1293,8 @@ Content-Type: application/json;charset=UTF-8
 
 * Both general and authentication messages can be canceled by the same API.
 
+<a id="response-9"></a>
+
 #### Response
 ```
 {
@@ -1260,7 +1318,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
 ```
 
+<a id="query-updates-of-message-result"></a>
+
 ### Query Updates of Message Result
+
+<a id="request-6"></a>
 
 #### Request
 
@@ -1296,6 +1358,8 @@ Content-Type: application/json;charset=UTF-8
 |alimtalkMessageType|   String| X | AlimTalk message type(NORMAL, AUTH) |
 |pageNum|   Integer|    X|  Page number(default: 1)|
 |pageSize|  Integer|    X|  Number of queries(default: 15, Max: 1000)|
+
+<a id="response-10"></a>
 
 #### Response
 ```
@@ -1349,6 +1413,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/message-results?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
+<a id="status-code-of-smslms-resending"></a>
+
 ### Status Code of SMS/LMS Resending
 | Name |  Description|
 |---|---|
@@ -1358,8 +1424,14 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |RSC04| Resending successful|
 |RSC05| Resending failed|
 
+<a id="mass-delivery"></a>
+
 ## Mass Delivery
+<a id="list-mass-delivery-requests"></a>
+
 ### List Mass Delivery Requests
+
+<a id="request-7"></a>
 
 #### Request
 [URL]
@@ -1399,6 +1471,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum | optional, Integer | - | X | Page number |
 | pageSize | optional, Integer | 1000 | X | Search count |
 
+<a id="curl"></a>
+
 #### cURL
 ```
 curl -X GET \
@@ -1406,6 +1480,8 @@ curl -X GET \
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-11"></a>
 
 #### Response
 ```
@@ -1495,7 +1571,11 @@ curl -X GET \
 | - totalCount | Integer | Total count |
 
 
+<a id="list-mass-delivery-recipients"></a>
+
 ### List Mass Delivery Recipients
+
+<a id="request-8"></a>
 
 #### Request
 [URL]
@@ -1534,6 +1614,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum | optional, Integer | - | X | Page Number |
 | pageSize | optional, Integer | 1000 | X | Search count |
 
+<a id="curl-2"></a>
+
 #### cURL
 ```
 curl -X GET \
@@ -1541,6 +1623,8 @@ curl -X GET \
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-12"></a>
 
 #### Response
 ```
@@ -1586,7 +1670,11 @@ curl -X GET \
 | -- resultCodeName | String | Result code content |
 | - totalCount | Integer | Total count |
 
+<a id="get-a-mass-delivery-recipient"></a>
+
 ### Get a Mass Delivery Recipient
+
+<a id="request-9"></a>
 
 #### Request
 [URL]
@@ -1626,6 +1714,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum | optional, Integer | - | X | Page number |
 | pageSize | optional, Integer | 1000 | X | Search count |
 
+<a id="curl-3"></a>
+
 #### cURL
 ```
 curl -X GET \
@@ -1633,6 +1723,8 @@ curl -X GET \
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-13"></a>
 
 #### Response
 ```
@@ -1724,9 +1816,15 @@ curl -X GET \
 | -- chatEvent | String | BT: Bot event name to connect when switching to bot |
 | -- target|    String| In the case of a web link button, out link used when adding "target":"out" attribute<br>Send with the default in-app link |
 
+<a id="templates"></a>
+
 ## Templates
 
+<a id="list-template-categories"></a>
+
 ### List Template Categories
+<a id="request-10"></a>
+
 #### Request
 [URL]
 
@@ -1750,6 +1848,8 @@ Content-Type: application/json;charset=UTF-8
 | Name |  Type| Required| Description|
 |---|---|---|---|
 |X-Secret-Key|  String| O | Can be created on console.  |
+
+<a id="response-14"></a>
 
 #### Response
 ```
@@ -1792,7 +1892,11 @@ Content-Type: application/json;charset=UTF-8
 |-- inclusion | String |    Description of templates to which the category applies |
 |-- exclusion| String| Description of templates to which the category does not apply |
 
+<a id="register-templates"></a>
+
 ### Register Templates
+<a id="request-11"></a>
+
 #### Request
 [URL]
 
@@ -1871,6 +1975,8 @@ Content-Type: application/json;charset=UTF-8
 |-schemeIos | String | X |  iOS app link(required for the AL type, up to 500 characters) |
 |-schemeAndroid | String | X |  Android app link(required for the AL type, up to 500 characters) |
 
+<a id="response-15"></a>
+
 #### Response
 ```
 {
@@ -1889,7 +1995,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|   String| Result message|
 |- isSuccessful|    Boolean| Successful or not|
 
+<a id="modify-templates"></a>
+
 ### Modify Templates
+<a id="request-12"></a>
+
 #### Request
 [URL]
 
@@ -1967,6 +2077,8 @@ Content-Type: application/json;charset=UTF-8
 |-schemeIos | String | X |  iOS app link(required for the AL type, up to 500 characters) |
 |-schemeAndroid | String | X |  Android app link(required for the AL type, up to 500 characters) |
 
+<a id="response-16"></a>
+
 #### Response
 ```
 {
@@ -1985,7 +2097,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|   String| Result message|
 |- isSuccessful|    Boolean| Successful or not|
 
+<a id="delete-templates"></a>
+
 ### Delete Templates
+<a id="request-13"></a>
+
 #### Request
 [URL]
 
@@ -2013,6 +2129,8 @@ Content-Type: application/json;charset=UTF-8
 * In the case of an approved template, Kakao's internal data cannot be deleted due to the restrictions of KakaoTalk BizMessage.
 * A template remaining in Kakao becomes dormant if it is not used for 1 year, and gets deleted if it remains dormant for 1 year.(If a template becomes dormant or gets deleted on Kakao, the person in charge will be notified.)
 
+<a id="response-17"></a>
+
 #### Response
 ```
 {
@@ -2031,7 +2149,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|   String| Result message|
 |- isSuccessful|    Boolean| Successful or not|
 
+<a id="inquire-of-templates"></a>
+
 ### Inquire of Templates
+<a id="request-14"></a>
+
 #### Request
 [URL]
 
@@ -2072,6 +2194,8 @@ Content-Type: application/json;charset=UTF-8
 
 * When commenting a template in the REJ status, it will be changed to the REQ status.
 
+<a id="response-18"></a>
+
 #### Response
 ```
 {
@@ -2090,7 +2214,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|   String| Result message|
 |- isSuccessful|    Boolean| Successful or not|
 
+<a id="attach-files-to-send-inquiry-on-templates"></a>
+
 ### Attach files to send inquiry on templates
+<a id="request-15"></a>
+
 #### Request
 [URL]
 
@@ -2133,6 +2261,8 @@ Content-Type: application/json;charset=UTF-8
 
 * When commenting a template in the REJ status, it will be changed to the REQ status.
 
+<a id="response-19"></a>
+
 #### Response
 ```
 {
@@ -2151,7 +2281,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|   String| Result Message|
 |- isSuccessful|    Boolean| Successful or not|
 
+<a id="list-templates"></a>
+
 ### List Templates
+
+<a id="request-16"></a>
 
 #### Request
 
@@ -2200,6 +2334,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/templates?templateStatus={template status code}"
 ```
+
+<a id="response-20"></a>
 
 #### Response
 ```
@@ -2311,7 +2447,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |-- updateDate | String | Date of modification                                                                                                                                               |
 |- totalCount | Integer | Total count                                                                                                                                                        |
 
+<a id="list-template-modifications"></a>
+
 ### List Template modifications
+
+<a id="request-17"></a>
 
 #### Request
 
@@ -2344,6 +2484,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}/modifications"
 ```
+
+<a id="response-21"></a>
 
 #### Response
 ```
@@ -2457,7 +2599,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |-- updateDate | String | Date of modification                                                                                                                                               |
 |- totalCount | Integer | Total count                                                                                                                                                        |
 
+<a id="register-template-image"></a>
+
 ### Register Template Image
+<a id="request-18"></a>
+
 #### Request
 [URL]
 
@@ -2493,6 +2639,8 @@ Content-Type: multipart/form-data
 curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/template-image" -F "file=@alimtalk-template-image.jpeg"
 ```
 
+<a id="response-22"></a>
+
 #### Response
 ```
 {
@@ -2518,7 +2666,11 @@ curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}
 |- templateImageName | String | Image name(name of uploaded file) |
 |- templateImageUrl | String |  Image URL |
 
+<a id="manage-alternative-delivery"></a>
+
 ## Manage Alternative Delivery
+<a id="register-an-sms-appkey"></a>
+
 ### Register an SMS AppKey
 
 [URL]
@@ -2562,6 +2714,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
 ```
 
+<a id="response-23"></a>
+
 #### Response
 ```
 
@@ -2573,6 +2727,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
   }
 }
 ```
+
+<a id="register-alternative-delivery-settings"></a>
 
 ### Register Alternative Delivery Settings
 
@@ -2620,6 +2776,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/failback/appkey -d '{"senderKey": "0be23c29de88d6888798aeda57062516354d74ba","isResend": true,"resendSendNo": "01012341234" }
 ```
+
+<a id="response-24"></a>
 
 #### Response
 ```

--- a/ja/alimtalk-api-guide-v2.0.md
+++ b/ja/alimtalk-api-guide-v2.0.md
@@ -1,6 +1,10 @@
 ## Notification > KakaoTalk Bizmessage > お知らせトーク > API v2.0 Guide
 
+<a id="alimtalk"></a>
+
 ## お知らせトーク
+
+<a id="api-domain"></a>
 
 #### [APIドメイン]
 
@@ -17,11 +21,17 @@
 </tbody>
 </table>
 
+<a id="overview-of-v20-api"></a>
+
 ## v2.0 API紹介
 1. カカオチャンネル追加時、発行されたsenderKeyフィールドでAPI呼び出しが行われるように変更しました。
 2. カカオチャンネルグループ機能が追加されました。
 
+<a id="general-messages"></a>
+
 ## 一般メッセージ
+
+<a id="request-of-sending-replaced-messages"></a>
 
 ### メッセージ置換送信リクエスト
 
@@ -115,6 +125,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","templateParameter":{"{日本語識別子フィールド}":"{置換データ}"}}]}'
 ```
 
+<a id="response"></a>
+
 #### レスポンス
 
 ```
@@ -155,6 +167,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultCode           | Integer | 送信リクエスト結果コード |
 | -- resultMessage        | String  | 送信リクエスト結果メッセージ |
 | -- recipientGroupingKey | String  | 受信者グルーピングキー |
+
+<a id="request-of-sending-full-text"></a>
 
 ### メッセージ全文送信リクエスト
 
@@ -265,6 +279,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/raw-messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","content":"{内容}","buttons":[{"ordering":"{ボタン順序}","type":"{ボタンタイプ}","name":"{ボタン名}","linkMo":"{モバイルWebリンク}"}]}]}'
 ```
 
+<a id="response-2"></a>
+
 #### レスポンス
 
 ```
@@ -306,7 +322,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultMessage        | String  | 送信リクエスト結果メッセージ |
 | -- recipientGroupingKey | String  | 受信者グルーピングキー |
 
+<a id="list-messages"></a>
+
 ### メッセージリストの照会
+
+<a id="request"></a>
 
 #### リクエスト
 
@@ -355,6 +375,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 90日以上前の送信リクエストデータは照会されません。
 * 送信リクエスト日時の範囲は最大30日です。
+
+<a id="response-3"></a>
 
 #### レスポンス
 ```
@@ -453,7 +475,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | RSC04 | 再送信成功                  |
 | RSC05 | 再送信失敗                  |
 
+<a id="get-messages"></a>
+
 ### メッセージ単件照会
+
+<a id="request-2"></a>
 
 #### リクエスト
 
@@ -486,6 +512,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-4"></a>
 
 #### レスポンス
 ```
@@ -579,6 +607,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - senderGroupingKey    | String  | 発信グルーピングキー                            |
 | - recipientGroupingKey | String  | 受信者グルーピングキー                           |
 
+<a id="authentication-messages"></a>
+
 ## 認証メッセージ
 
 <span id="precautions-authword"></span>
@@ -591,6 +621,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 - 例1)認証メッセージAPI送信リクエストした時、全文(テンプレート日本語識別子含む)に認証文言が含まれていない場合は、送信に失敗します。
 - 例2)認証文言が英文の場合、大文字/小文字の区別なしで有効性チェックが行われます。
 
+
+<a id="request-of-sending-replaced-messages-2"></a>
 
 ### メッセージ置換送信リクエスト
 
@@ -680,6 +712,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/auth/messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","templateParameter":{"{日本語識別子フィールド}":"{置換データ}"}}]}'
 ```
 
+<a id="response-5"></a>
+
 #### レスポンス
 
 ```
@@ -720,6 +754,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultCode           | Integer | 送信リクエスト結果コード |
 | -- resultMessage        | String  | 送信リクエスト結果メッセージ |
 | -- recipientGroupingKey | String  | 受信者グルーピングキー |
+
+<a id="request-of-sending-full-text-2"></a>
 
 ### メッセージ全文送信リクエスト
 
@@ -827,6 +863,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/auth/raw-messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","content":"{内容}","buttons":[{"ordering":"{ボタン順序}","type":"{ボタンタイプ}","name":"{ボタン名}","linkMo":"{モバイルWebリンク}"}]}]}'
 ```
 
+<a id="response-6"></a>
+
 #### レスポンス
 
 ```
@@ -867,6 +905,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultCode           | Integer | 送信リクエスト結果コード |
 | -- resultMessage        | String  | 送信リクエスト結果メッセージ |
 | -- recipientGroupingKey | String  | 受信者グルーピングキー |
+
+<a id="list-messages-2"></a>
 
 ### メッセージリストの照会
 
@@ -917,6 +957,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 90日以上前の送信リクエストデータは照会されません。
 * 送信リクエスト日時の範囲は最大30日です。
+
+<a id="request-3"></a>
 
 #### レスポンス
 ```
@@ -1006,6 +1048,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/auth/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<a id="response-7"></a>
+
 #### SMS/LMS再送信ステータス
 | 値 | 説明                      |
 | ----- | ------------------------------- |
@@ -1015,7 +1059,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | RSC04 | 再送信成功                  |
 | RSC05 | 再送信失敗                  |
 
+<a id="get-messages-2"></a>
+
 ### メッセージ単件照会
+
+<a id="request-4"></a>
 
 #### リクエスト
 
@@ -1048,6 +1096,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/auth/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-8"></a>
 
 #### レスポンス
 ```
@@ -1144,8 +1194,14 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - senderGroupingKey    | String  | 発信グルーピングキー                            |
 | - recipientGroupingKey | String  | 受信者グルーピングキー                           |
 
+<a id="messages"></a>
+
 ## メッセージ
+<a id="cancel-sending-messages"></a>
+
 ### メッセージ送信取消
+
+<a id="request-5"></a>
 
 #### リクエスト
 
@@ -1181,6 +1237,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 一般/認証メッセージは同じAPIでキャンセルできます。
 
+<a id="response-9"></a>
+
 #### レスポンス
 ```
 {
@@ -1204,7 +1262,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
 ```
 
+<a id="query-updates-of-message-result"></a>
+
 ### メッセージ結果アップデートの照会
+
+<a id="request-6"></a>
 
 #### リクエスト
 
@@ -1240,6 +1302,8 @@ Content-Type: application/json;charset=UTF-8
 | alimtalkMessageType | String  | X    | お知らせトークメッセージタイプ(NORMAL、AUTH)           |
 | pageNum             | Integer | X    | ページ番号(基本：1)                      |
 | pageSize            | Integer | X    | 照会件数(基本：15、最大: 1000)          |
+
+<a id="response-10"></a>
 
 #### レスポンス
 ```
@@ -1294,9 +1358,21 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/message-results?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
+<a id="messages-1"></a>
+
+### SMS/LMS 대체 발송 상태 코드
+
+<!-- TODO: translate body -->
+
+<a id="templates"></a>
+
 ## テンプレート
 
+<a id="list-template-categories"></a>
+
 ### テンプレートカテゴリー照会
+<a id="request-7"></a>
+
 #### リクエスト
 [URL]
 
@@ -1320,6 +1396,8 @@ Content-Type: application/json;charset=UTF-8
 | 値    | タイプ | 必須 | 説明                               |
 |---|---|---|---|
 | X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+<a id="response-11"></a>
 
 #### レスポンス
 ```
@@ -1362,7 +1440,11 @@ Content-Type: application/json;charset=UTF-8
 |-- inclusion | String |	カテゴリー対象テンプレートの説明 |
 |-- exclusion| String| カテゴリの除外対象のテンプレートの説明 |
 
+<a id="register-templates"></a>
+
 ### テンプレートの登録
+<a id="request-8"></a>
+
 #### リクエスト
 [URL]
 
@@ -1438,6 +1520,8 @@ Content-Type: application/json;charset=UTF-8
 | -schemeIos      | String  | X    | iOSアプリリンク(ALタイプの場合は必須フィールド、最大500文字)       |
 | -schemeAndroid  | String  | X    | Androidアプリリンク(ALタイプの場合は必須フィールド、最大500文字)   |
 
+<a id="response-12"></a>
+
 #### レスポンス
 ```
 {
@@ -1456,7 +1540,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | 結果メッセージ |
 | - isSuccessful  | Boolean | 成否 |
 
+<a id="modify-templates"></a>
+
 ### テンプレートの修正
+<a id="request-9"></a>
+
 #### リクエスト
 [URL]
 
@@ -1530,6 +1618,8 @@ Content-Type: application/json;charset=UTF-8
 | -schemeIos      | String  | X    | iOSアプリリンク(ALタイプの場合は必須フィールド、最大500文字)       |
 | -schemeAndroid  | String  | X    | Androidアプリリンク(ALタイプの場合は必須フィールド、最大500文字)   |
 
+<a id="response-13"></a>
+
 #### レスポンス
 ```
 {
@@ -1548,7 +1638,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | 結果メッセージ |
 | - isSuccessful  | Boolean | 成否 |
 
+<a id="delete-templates"></a>
+
 ### テンプレートの削除
+<a id="request-10"></a>
+
 #### リクエスト
 [URL]
 
@@ -1572,6 +1666,8 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
+<a id="response-14"></a>
+
 #### レスポンス
 ```
 {
@@ -1590,7 +1686,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | 結果メッセージ |
 | - isSuccessful  | Boolean | 成否 |
 
+<a id="inquire-of-templates"></a>
+
 ### テンプレートの問い合わせをする
+<a id="request-11"></a>
+
 #### リクエスト
 [URL]
 
@@ -1629,6 +1729,8 @@ Content-Type: application/json;charset=UTF-8
 | ------- | ------ | ---- | ----- |
 | comment | String | O    | お問い合わせ内容 |
 
+<a id="response-15"></a>
+
 #### レスポンス
 ```
 {
@@ -1647,7 +1749,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | 結果メッセージ |
 | - isSuccessful  | Boolean | 成否 |
 
+<a id="attach-files-to-send-inquiry-on-templates"></a>
+
 ### ファイルを添付してテンプレートお問い合わせ
+<a id="request-12"></a>
+
 #### リクエスト
 [URL]
 
@@ -1688,6 +1794,8 @@ Content-Type: application/json;charset=UTF-8
 |comment|	String |	O | お問い合わせ内容         |
 |attachments| List<File> | X | 添付ファイルリスト(最大10個) |
 
+<a id="response-16"></a>
+
 #### レスポンス
 ```
 {
@@ -1706,7 +1814,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 結果メッセージ|
 |- isSuccessful|	Boolean| 成否|
 
+<a id="list-templates"></a>
+
 ### テンプレートリストの照会
+
+<a id="request-13"></a>
 
 #### リクエスト
 
@@ -1755,6 +1867,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/templates?plusFriendId={発信キー}&templateStatus={テンプレートステータスコード}"
 ```
+
+<a id="response-17"></a>
 
 #### レスポンス
 ```
@@ -1854,7 +1968,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- createDate        | String  | 作成日時                            |
 | - totalCount         | Integer | 総個数                              |
 
+<a id="list-template-modifications"></a>
+
 ### テンプレートの修正リスト照会
+
+<a id="request-14"></a>
 
 #### リクエスト
 
@@ -1887,6 +2005,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/plus-friends/{plusFriendId}/templates/{templateCode}/modifications"
 ```
+
+<a id="response-18"></a>
 
 #### レスポンス
 ```
@@ -1992,7 +2112,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |-- updateDate | String | 修正日                                                                                            |
 |- totalCount | Integer | 総数                                                                                            |
 
+<a id="section-1"></a>
+
 ## 代替送信管理
+<a id="section-1-1"></a>
+
 ### SMS AppKey登録
 
 [URL]
@@ -2037,6 +2161,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
 ```
 
+<a id="section-1-1-1"></a>
+
 #### レスポンス
 ```
 
@@ -2048,6 +2174,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
   }
 }
 ```
+
+<a id="section-1-2"></a>
 
 ### 代替送信設定登録
 
@@ -2096,6 +2224,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/failback/appkey -d '{"plusFriendId": "@プラスフレンド","isResend": true,"resendSendNo": "01012341234" }
 ```
+
+<a id="section-1-2-1"></a>
 
 #### レスポンス
 ```

--- a/ja/alimtalk-api-guide-v2.1.md
+++ b/ja/alimtalk-api-guide-v2.1.md
@@ -1,6 +1,10 @@
 ## Notification > KakaoTalk Bizmessage > お知らせトーク > API v2.1 Guide
 
+<a id="alimtalk"></a>
+
 ## お知らせトーク
+
+<a id="api-domain"></a>
 
 #### [APIドメイン]
 
@@ -17,12 +21,18 @@
 </tbody>
 </table>
 
+<a id="overview-of-v21-api"></a>
+
 ## v2.1 API紹介
 1. 通知フリックテンプレート画像のアップロードAPIが追加されました。
 2. templateEmphasizeType中、'IMAGE'が追加されました。
 3. テンプレート照会時、templateImageName、templateImageUrlフィールドが追加されました。
 
+<a id="general-messages"></a>
+
 ## 一般メッセージ
+
+<a id="request-of-sending-replaced-messages"></a>
 
 ### メッセージ置換送信リクエスト
 
@@ -116,6 +126,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","templateParameter":{"{日本語識別子フィールド}":"{置換データ}"}}]}'
 ```
 
+<a id="response"></a>
+
 #### レスポンス
 
 ```
@@ -156,6 +168,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultCode           | Integer | 送信リクエスト結果コード |
 | -- resultMessage        | String  | 送信リクエスト結果メッセージ |
 | -- recipientGroupingKey | String  | 受信者グルーピングキー |
+
+<a id="request-of-sending-full-text"></a>
 
 ### メッセージ全文送信リクエスト
 
@@ -266,6 +280,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/raw-messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","content":"{内容}","buttons":[{"ordering":"{ボタン順序}","type":"{ボタンタイプ}","name":"{ボタン名}","linkMo":"{モバイルWebリンク}"}]}]}'
 ```
 
+<a id="response-2"></a>
+
 #### レスポンス
 
 ```
@@ -307,7 +323,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultMessage        | String  | 送信リクエスト結果メッセージ |
 | -- recipientGroupingKey | String  | 受信者グルーピングキー |
 
+<a id="list-messages"></a>
+
 ### メッセージリストの照会
+
+<a id="request"></a>
 
 #### リクエスト
 
@@ -356,6 +376,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 90日以上前の送信リクエストデータは照会されません。
 * 送信リクエスト日時の範囲は最大30日です。
+
+<a id="response-3"></a>
 
 #### レスポンス
 ```
@@ -454,7 +476,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | RSC04 | 再送信成功                  |
 | RSC05 | 再送信失敗                  |
 
+<a id="get-messages"></a>
+
 ### メッセージ単件照会
+
+<a id="request-2"></a>
 
 #### リクエスト
 
@@ -487,6 +513,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-4"></a>
 
 #### レスポンス
 ```
@@ -580,6 +608,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - senderGroupingKey    | String  | 発信グルーピングキー                            |
 | - recipientGroupingKey | String  | 受信者グルーピングキー                           |
 
+<a id="authentication-messages"></a>
+
 ## 認証メッセージ
 
 <span id="precautions-authword"></span>
@@ -592,6 +622,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 - 例1)認証メッセージAPI送信リクエストした時、全文(テンプレート日本語識別子含む)に認証文言が含まれていない場合は、送信に失敗します。
 - 例2)認証文言が英文の場合、大文字/小文字の区別なしで有効性チェックが行われます。
 
+
+<a id="request-of-sending-replaced-messages-2"></a>
 
 ### メッセージ置換送信リクエスト
 
@@ -681,6 +713,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/auth/messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","templateParameter":{"{日本語識別子フィールド}":"{置換データ}"}}]}'
 ```
 
+<a id="response-5"></a>
+
 #### レスポンス
 
 ```
@@ -721,6 +755,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultCode           | Integer | 送信リクエスト結果コード |
 | -- resultMessage        | String  | 送信リクエスト結果メッセージ |
 | -- recipientGroupingKey | String  | 受信者グルーピングキー |
+
+<a id="request-of-sending-full-text-2"></a>
 
 ### メッセージ全文送信リクエスト
 
@@ -828,6 +864,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/auth/raw-messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","content":"{内容}","buttons":[{"ordering":"{ボタン順序}","type":"{ボタンタイプ}","name":"{ボタン名}","linkMo":"{モバイルWebリンク}"}]}]}'
 ```
 
+<a id="response-6"></a>
+
 #### レスポンス
 
 ```
@@ -868,6 +906,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultCode           | Integer | 送信リクエスト結果コード |
 | -- resultMessage        | String  | 送信リクエスト結果メッセージ |
 | -- recipientGroupingKey | String  | 受信者グルーピングキー |
+
+<a id="list-messages-2"></a>
 
 ### メッセージリストの照会
 
@@ -918,6 +958,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 90日以上前の送信リクエストデータは照会されません。
 * 送信リクエスト日時の範囲は最大30日です。
+
+<a id="request-3"></a>
 
 #### レスポンス
 ```
@@ -1007,6 +1049,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/auth/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<a id="response-7"></a>
+
 #### SMS/LMS再送信ステータス
 | 値 | 説明                      |
 | ----- | ------------------------------- |
@@ -1016,7 +1060,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | RSC04 | 再送信成功                  |
 | RSC05 | 再送信失敗                  |
 
+<a id="get-messages-2"></a>
+
 ### メッセージ単件照会
+
+<a id="request-4"></a>
 
 #### リクエスト
 
@@ -1049,6 +1097,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/auth/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-8"></a>
 
 #### レスポンス
 ```
@@ -1145,8 +1195,14 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - senderGroupingKey    | String  | 発信グルーピングキー                            |
 | - recipientGroupingKey | String  | 受信者グルーピングキー                           |
 
+<a id="messages"></a>
+
 ## メッセージ
+<a id="cancel-sending-messages"></a>
+
 ### メッセージ送信取消
+
+<a id="request-5"></a>
 
 #### リクエスト
 
@@ -1182,6 +1238,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 一般/認証メッセージは同じAPIでキャンセルできます。
 
+<a id="response-9"></a>
+
 #### レスポンス
 ```
 {
@@ -1205,7 +1263,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
 ```
 
+<a id="query-updates-of-message-result"></a>
+
 ### メッセージ結果アップデートの照会
+
+<a id="request-6"></a>
 
 #### リクエスト
 
@@ -1241,6 +1303,8 @@ Content-Type: application/json;charset=UTF-8
 | alimtalkMessageType | String  | X    | お知らせトークメッセージタイプ(NORMAL、AUTH)           |
 | pageNum             | Integer | X    | ページ番号(基本：1)                      |
 | pageSize            | Integer | X    | 照会件数(基本：15、最大: 1000)          |
+
+<a id="response-10"></a>
 
 #### レスポンス
 ```
@@ -1294,9 +1358,21 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/message-results?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
+<a id="messages-1"></a>
+
+### SMS/LMS 대체 발송 상태 코드
+
+<!-- TODO: translate body -->
+
+<a id="templates"></a>
+
 ## テンプレート
 
+<a id="list-template-categories"></a>
+
 ### テンプレートカテゴリー照会
+<a id="request-7"></a>
+
 #### リクエスト
 [URL]
 
@@ -1320,6 +1396,8 @@ Content-Type: application/json;charset=UTF-8
 | 値    | タイプ | 必須 | 説明                               |
 |---|---|---|---|
 | X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+<a id="response-11"></a>
 
 #### レスポンス
 ```
@@ -1362,7 +1440,11 @@ Content-Type: application/json;charset=UTF-8
 |-- inclusion | String |	カテゴリー対象テンプレートの説明 |
 |-- exclusion| String| カテゴリの除外対象のテンプレートの説明 |
 
+<a id="register-templates"></a>
+
 ### テンプレートの登録
+<a id="request-8"></a>
+
 #### リクエスト
 [URL]
 
@@ -1441,6 +1523,8 @@ Content-Type: application/json;charset=UTF-8
 | -schemeIos      | String  | X    | iOSアプリリンク(ALタイプの場合は必須フィールド、最大500文字)       |
 | -schemeAndroid  | String  | X    | Androidアプリリンク(ALタイプの場合は必須フィールド、最大500文字)   |
 
+<a id="response-12"></a>
+
 #### レスポンス
 ```
 {
@@ -1459,7 +1543,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | 結果メッセージ |
 | - isSuccessful  | Boolean | 成否 |
 
+<a id="modify-templates"></a>
+
 ### テンプレートの修正
+<a id="request-9"></a>
+
 #### リクエスト
 [URL]
 
@@ -1537,6 +1625,8 @@ Content-Type: application/json;charset=UTF-8
 | -schemeIos      | String  | X    | iOSアプリリンク(ALタイプの場合は必須フィールド、最大500文字)       |
 | -schemeAndroid  | String  | X    | Androidアプリリンク(ALタイプの場合は必須フィールド、最大500文字)   |
 
+<a id="response-13"></a>
+
 #### レスポンス
 ```
 {
@@ -1555,7 +1645,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | 結果メッセージ |
 | - isSuccessful  | Boolean | 成否 |
 
+<a id="delete-templates"></a>
+
 ### テンプレートの削除
+<a id="request-10"></a>
+
 #### リクエスト
 [URL]
 
@@ -1579,6 +1673,8 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
+<a id="response-14"></a>
+
 #### レスポンス
 ```
 {
@@ -1597,7 +1693,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | 結果メッセージ |
 | - isSuccessful  | Boolean | 成否 |
 
+<a id="inquire-of-templates"></a>
+
 ### テンプレートの問い合わせをする
+<a id="request-11"></a>
+
 #### リクエスト
 [URL]
 
@@ -1636,6 +1736,8 @@ Content-Type: application/json;charset=UTF-8
 | ------- | ------ | ---- | ----- |
 | comment | String | O    | お問い合わせ内容 |
 
+<a id="response-15"></a>
+
 #### レスポンス
 ```
 {
@@ -1654,7 +1756,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | 結果メッセージ |
 | - isSuccessful  | Boolean | 成否 |
 
+<a id="attach-files-to-send-inquiry-on-templates"></a>
+
 ### ファイルを添付してテンプレートお問い合わせ
+<a id="request-12"></a>
+
 #### リクエスト
 [URL]
 
@@ -1695,6 +1801,8 @@ Content-Type: application/json;charset=UTF-8
 |comment|	String |	O | お問い合わせ内容         |
 |attachments| List<File> | X | 添付ファイルリスト(最大10個) |
 
+<a id="response-16"></a>
+
 #### レスポンス
 ```
 {
@@ -1713,7 +1821,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 結果メッセージ|
 |- isSuccessful|	Boolean| 成否|
 
+<a id="list-templates"></a>
+
 ### テンプレートリストの照会
+
+<a id="request-13"></a>
 
 #### リクエスト
 
@@ -1762,6 +1874,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/templates?plusFriendId={発信キー}&templateStatus={テンプレートステータスコード}"
 ```
+
+<a id="response-17"></a>
 
 #### レスポンス
 ```
@@ -1865,7 +1979,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- createDate        | String  | 作成日時                            |
 | - totalCount         | Integer | 総個数                              |
 
+<a id="list-template-modifications"></a>
+
 ### テンプレートの修正リスト照会
+
+<a id="request-14"></a>
 
 #### リクエスト
 
@@ -1898,6 +2016,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/plus-friends/{plusFriendId}/templates/{templateCode}/modifications"
 ```
+
+<a id="response-18"></a>
 
 #### レスポンス
 ```
@@ -2003,7 +2123,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- createDate        | String  | 作成日時                            |
 | - totalCount         | Integer | 総個数                              |
 
+<a id="register-template-image"></a>
+
 ### テンプレート画像の登録
+<a id="request-15"></a>
+
 #### リクエスト
 [URL]
 
@@ -2039,6 +2163,8 @@ Content-Type: multipart/form-data
 curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/template-image" -F "file=@alimtalk-template-image.jpeg"
 ```
 
+<a id="response-19"></a>
+
 #### レスポンス
 ```
 {
@@ -2064,7 +2190,11 @@ curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}
 |- templateImageName    | String |	画像名（アップロードされたファイル名） |
 |- templateImageUrl     | String |	画像のURL |
 
+<a id="section-1"></a>
+
 ## 代替送信管理
+<a id="section-1-1"></a>
+
 ### SMS AppKey登録
 
 [URL]
@@ -2109,6 +2239,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
 ```
 
+<a id="section-1-1-1"></a>
+
 #### レスポンス
 ```
 
@@ -2120,6 +2252,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
   }
 }
 ```
+
+<a id="section-1-2"></a>
 
 ### 代替送信設定登録
 
@@ -2168,6 +2302,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/failback/appkey -d '{"plusFriendId": "@プラスフレンド","isResend": true,"resendSendNo": "01012341234" }
 ```
+
+<a id="section-1-2-1"></a>
 
 #### レスポンス
 ```

--- a/ja/alimtalk-api-guide-v2.2.md
+++ b/ja/alimtalk-api-guide-v2.2.md
@@ -1,6 +1,10 @@
 ## Notification > KakaoTalk Bizmessage > お知らせトーク > API v2.2 Guide
 
+<a id="alimtalk"></a>
+
 ## お知らせトーク
+
+<a id="api-domain"></a>
 
 #### [APIドメイン]
 
@@ -17,13 +21,19 @@
 </tbody>
 </table>
 
+<a id="overview-of-v22-api"></a>
+
 ## v2.2 API紹介
 1. お知らせトーク大量送信照会、統計照会APIが追加されました。
 2. 置換メッセージ送信時、buttonsフィールドが追加されました。
 3. 専門メッセージ送信時、buttonsフィールドにchatExtra、chatEvent、targetフィールドが追加されました。
 4. メッセージ照会時、buttonsフィールドにchatExtra、chatEvent、targetフィールドが追加されました。
 
+<a id="general-messages"></a>
+
 ## 一般メッセージ
+
+<a id="request-of-sending-replaced-messages"></a>
 
 ### メッセージ置換送信リクエスト
 
@@ -132,6 +142,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","templateParameter":{"{日本語識別子フィールド}":"{置換データ}"}}]}'
 ```
 
+<a id="response"></a>
+
 #### レスポンス
 
 ```
@@ -172,6 +184,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultCode           | Integer | 送信リクエスト結果コード |
 | -- resultMessage        | String  | 送信リクエスト結果メッセージ |
 | -- recipientGroupingKey | String  | 受信者グルーピングキー |
+
+<a id="request-of-sending-full-text"></a>
 
 ### メッセージ全文送信リクエスト
 
@@ -290,6 +304,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/raw-messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","content":"{内容}","buttons":[{"ordering":"{ボタン順序}","type":"{ボタンタイプ}","name":"{ボタン名}","linkMo":"{モバイルWebリンク}"}]}]}'
 ```
 
+<a id="response-2"></a>
+
 #### レスポンス
 
 ```
@@ -331,7 +347,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultMessage        | String  | 送信リクエスト結果メッセージ |
 | -- recipientGroupingKey | String  | 受信者グルーピングキー |
 
+<a id="list-messages"></a>
+
 ### メッセージリストの照会
+
+<a id="request"></a>
 
 #### リクエスト
 
@@ -380,6 +400,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 90日以上前の送信リクエストデータは照会されません。
 * 送信リクエスト日時の範囲は最大30日です。
+
+<a id="response-3"></a>
 
 #### レスポンス
 ```
@@ -484,7 +506,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | RSC04 | 再送信成功                  |
 | RSC05 | 再送信失敗                  |
 
+<a id="get-messages"></a>
+
 ### メッセージ単件照会
+
+<a id="request-2"></a>
 
 #### リクエスト
 
@@ -517,6 +543,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-4"></a>
 
 #### レスポンス
 ```
@@ -616,6 +644,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - senderGroupingKey    | String  | 発信グルーピングキー                            |
 | - recipientGroupingKey | String  | 受信者グルーピングキー                           |
 
+<a id="authentication-messages"></a>
+
 ## 認証メッセージ
 
 <span id="precautions-authword"></span>
@@ -628,6 +658,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 - 例1)認証メッセージAPI送信リクエストした時、全文(テンプレート日本語識別子含む)に認証文言が含まれていない場合は、送信に失敗します。
 - 例2)認証文言が英文の場合、大文字/小文字の区別なしで有効性チェックが行われます。
 
+
+<a id="request-of-sending-replaced-messages-2"></a>
 
 ### メッセージ置換送信リクエスト
 
@@ -732,6 +764,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/auth/messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","templateParameter":{"{日本語識別子フィールド}":"{置換データ}"}}]}'
 ```
 
+<a id="response-5"></a>
+
 #### レスポンス
 
 ```
@@ -772,6 +806,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultCode           | Integer | 送信リクエスト結果コード |
 | -- resultMessage        | String  | 送信リクエスト結果メッセージ |
 | -- recipientGroupingKey | String  | 受信者グルーピングキー |
+
+<a id="request-of-sending-full-text-2"></a>
 
 ### メッセージ全文送信リクエスト
 
@@ -887,6 +923,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/auth/raw-messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","content":"{内容}","buttons":[{"ordering":"{ボタン順序}","type":"{ボタンタイプ}","name":"{ボタン名}","linkMo":"{モバイルWebリンク}"}]}]}'
 ```
 
+<a id="response-6"></a>
+
 #### レスポンス
 
 ```
@@ -927,6 +965,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 | -- resultCode           | Integer | 送信リクエスト結果コード |
 | -- resultMessage        | String  | 送信リクエスト結果メッセージ |
 | -- recipientGroupingKey | String  | 受信者グルーピングキー |
+
+<a id="list-messages-2"></a>
 
 ### メッセージリストの照会
 
@@ -977,6 +1017,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 90日以上前の送信リクエストデータは照会されません。
 * 送信リクエスト日時の範囲は最大30日です。
+
+<a id="request-3"></a>
 
 #### レスポンス
 ```
@@ -1072,6 +1114,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/auth/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<a id="response-7"></a>
+
 #### SMS/LMS再送信ステータス
 | 値 | 説明                      |
 | ----- | ------------------------------- |
@@ -1081,7 +1125,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | RSC04 | 再送信成功                  |
 | RSC05 | 再送信失敗                  |
 
+<a id="get-messages-2"></a>
+
 ### メッセージ単件照会
+
+<a id="request-4"></a>
 
 #### リクエスト
 
@@ -1114,6 +1162,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/auth/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-8"></a>
 
 #### レスポンス
 ```
@@ -1216,8 +1266,14 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | - senderGroupingKey    | String  | 発信グルーピングキー                            |
 | - recipientGroupingKey | String  | 受信者グルーピングキー                           |
 
+<a id="messages"></a>
+
 ## メッセージ
+<a id="cancel-sending-messages"></a>
+
 ### メッセージ送信取消
+
+<a id="request-5"></a>
 
 #### リクエスト
 
@@ -1253,6 +1309,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 一般/認証メッセージは同じAPIでキャンセルできます。
 
+<a id="response-9"></a>
+
 #### レスポンス
 ```
 {
@@ -1276,7 +1334,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
 ```
 
+<a id="query-updates-of-message-result"></a>
+
 ### メッセージ結果アップデートの照会
+
+<a id="request-6"></a>
 
 #### リクエスト
 
@@ -1312,6 +1374,8 @@ Content-Type: application/json;charset=UTF-8
 | alimtalkMessageType | String  | X    | お知らせトークメッセージタイプ(NORMAL、AUTH)           |
 | pageNum             | Integer | X    | ページ番号(基本：1)                      |
 | pageSize            | Integer | X    | 照会件数(基本：15、最大: 1000)          |
+
+<a id="response-10"></a>
 
 #### レスポンス
 ```
@@ -1365,8 +1429,20 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/message-results?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
+<a id="status-code-of-smslms-resending"></a>
+
+### SMS/LMS 대체 발송 상태 코드
+
+<!-- TODO: translate body -->
+
+<a id="mass-delivery"></a>
+
 ## 大量送信
+<a id="list-mass-delivery-requests"></a>
+
 ### 大量送信リクエストリスト照会
+
+<a id="request-7"></a>
 
 #### リクエスト
 [URL]
@@ -1406,6 +1482,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum | optional, Integer | - | X | ページ番号 |
 | pageSize | optional, Integer | 1000 | X | 検索数 |
 
+<a id="curl"></a>
+
 #### cURL
 ```
 curl -X GET \
@@ -1413,6 +1491,8 @@ https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appK
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-11"></a>
 
 #### レスポンス
 ```
@@ -1502,7 +1582,11 @@ https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appK
 | - totalCount | Integer | 総数
 
 
+<a id="list-mass-delivery-recipients"></a>
+
 ### 大量送信大量送信受信者リスト照会
+
+<a id="request-8"></a>
 
 #### リクエスト
 [URL]
@@ -1541,6 +1625,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum | optional, Integer | - | X | ページ番号 |
 | pageSize | optional, Integer | 1000 | X | 検索数 |
 
+<a id="curl-2"></a>
+
 #### cURL
 ```
 curl -X GET \
@@ -1548,6 +1634,8 @@ https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appK
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-12"></a>
 
 #### レスポンス
 ```
@@ -1593,7 +1681,11 @@ https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appK
 | -- resultCodeName | String | 結果コード内容 |
 | - totalCount | Integer | 総数 |
 
+<a id="get-a-mass-delivery-recipient"></a>
+
 ### 大量送信大量送信受信者照会
+
+<a id="request-9"></a>
 
 #### リクエスト
 [URL]
@@ -1633,6 +1725,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum | optional, Integer | - | X | ページ番号 |
 | pageSize | optional, Integer | 1000 | X | 検索数 |
 
+<a id="curl-3"></a>
+
 #### cURL
 ```
 curl -X GET \
@@ -1640,6 +1734,8 @@ https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appK
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-13"></a>
 
 #### レスポンス
 ```
@@ -1739,9 +1835,15 @@ https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appK
 |-- currencyType | String |	message(ユーザーに伝達されるメッセージ)内に含まれる価格/金額/決済金額の通貨単位KRW、USD、EURなどの国際通貨コードを使用(モーメント広告に該当) |
 
 
+<a id="templates"></a>
+
 ## テンプレート
 
+<a id="list-template-categories"></a>
+
 ### テンプレートカテゴリー照会
+<a id="request-10"></a>
+
 #### リクエスト
 [URL]
 
@@ -1765,6 +1867,8 @@ Content-Type: application/json;charset=UTF-8
 | 値    | タイプ | 必須 | 説明                               |
 |---|---|---|---|
 | X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+<a id="response-14"></a>
 
 #### レスポンス
 ```
@@ -1807,7 +1911,11 @@ Content-Type: application/json;charset=UTF-8
 |-- inclusion | String |	カテゴリー対象テンプレートの説明 |
 |-- exclusion| String| カテゴリの除外対象のテンプレートの説明 |
 
+<a id="register-templates"></a>
+
 ### テンプレートの登録
+<a id="request-11"></a>
+
 #### リクエスト
 [URL]
 
@@ -1886,6 +1994,8 @@ Content-Type: application/json;charset=UTF-8
 | -schemeIos      | String  | X    | iOSアプリリンク(ALタイプの場合は必須フィールド、最大500文字)       |
 | -schemeAndroid  | String  | X    | Androidアプリリンク(ALタイプの場合は必須フィールド、最大500文字)   |
 
+<a id="response-15"></a>
+
 #### レスポンス
 ```
 {
@@ -1904,7 +2014,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | 結果メッセージ |
 | - isSuccessful  | Boolean | 成否 |
 
+<a id="modify-templates"></a>
+
 ### テンプレートの修正
+<a id="request-12"></a>
+
 #### リクエスト
 [URL]
 
@@ -1982,6 +2096,8 @@ Content-Type: application/json;charset=UTF-8
 | -schemeIos      | String  | X    | iOSアプリリンク(ALタイプの場合は必須フィールド、最大500文字)       |
 | -schemeAndroid  | String  | X    | Androidアプリリンク(ALタイプの場合は必須フィールド、最大500文字)   |
 
+<a id="response-16"></a>
+
 #### レスポンス
 ```
 {
@@ -2000,7 +2116,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | 結果メッセージ |
 | - isSuccessful  | Boolean | 成否 |
 
+<a id="delete-templates"></a>
+
 ### テンプレートの削除
+<a id="request-13"></a>
+
 #### リクエスト
 [URL]
 
@@ -2023,6 +2143,8 @@ Content-Type: application/json;charset=UTF-8
   "X-Secret-Key": String
 }
 ```
+
+<a id="response-17"></a>
 
 #### レスポンス
 ```
@@ -2047,7 +2169,11 @@ Content-Type: application/json;charset=UTF-8
 * カカオに残っているテンプレートは1年間使っていないと休眠処理され、休眠状態が1年間続くと削除処理されます。(カカオでテンプレートが休眠に切り替わるときや、削除されるときは担当者に通知が送信されます。)
 
 
+<a id="inquire-of-templates"></a>
+
 ### テンプレートの問い合わせをする
+<a id="request-14"></a>
+
 #### リクエスト
 [URL]
 
@@ -2088,6 +2214,8 @@ Content-Type: application/json;charset=UTF-8
 
 * REJステータスのテンプレートにコメントを付けると、REQステータスに変更されます。
 
+<a id="response-18"></a>
+
 #### レスポンス
 ```
 {
@@ -2106,7 +2234,11 @@ Content-Type: application/json;charset=UTF-8
 | - resultMessage | String  | 結果メッセージ |
 | - isSuccessful  | Boolean | 成否 |
 
+<a id="attach-files-to-send-inquiry-on-templates"></a>
+
 ### ファイルを添付してテンプレートお問い合わせ
+<a id="request-15"></a>
+
 #### リクエスト
 [URL]
 
@@ -2149,6 +2281,8 @@ Content-Type: application/json;charset=UTF-8
 
 * REJステータスのテンプレートにコメントを付けると、REQステータスに変更されます。
 
+<a id="response-19"></a>
+
 #### レスポンス
 ```
 {
@@ -2167,7 +2301,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 結果メッセージ|
 |- isSuccessful|	Boolean| 成否|
 
+<a id="list-templates"></a>
+
 ### テンプレートリストの照会
+
+<a id="request-16"></a>
 
 #### リクエスト
 
@@ -2216,6 +2354,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/templates?plusFriendId={発信キー}&templateStatus={テンプレートステータスコード}"
 ```
+
+<a id="response-20"></a>
 
 #### レスポンス
 ```
@@ -2324,7 +2464,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |- totalCount | Integer | 総数                                                                                           |
 
 
+<a id="list-template-modifications"></a>
+
 ### テンプレートの修正リスト照会
+
+<a id="request-17"></a>
 
 #### リクエスト
 
@@ -2357,6 +2501,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}/modifications"
 ```
+
+<a id="response-21"></a>
 
 #### レスポンス
 ```
@@ -2462,7 +2608,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- createDate        | String  | 作成日時                            |
 | - totalCount         | Integer | 総個数                              |
 
+<a id="register-template-image"></a>
+
 ### テンプレート画像の登録
+<a id="request-18"></a>
+
 #### リクエスト
 [URL]
 
@@ -2498,6 +2648,8 @@ Content-Type: multipart/form-data
 curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/template-image" -F "file=@alimtalk-template-image.jpeg"
 ```
 
+<a id="response-22"></a>
+
 #### レスポンス
 ```
 {
@@ -2523,7 +2675,11 @@ curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}
 |- templateImageName    | String |	画像名（アップロードされたファイル名） |
 |- templateImageUrl     | String |	画像のURL |
 
+<a id="manage-alternative-delivery"></a>
+
 ## 代替送信管理
+<a id="register-an-sms-appkey"></a>
+
 ### SMS AppKey登録
 
 [URL]
@@ -2568,6 +2724,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
 ```
 
+<a id="response-23"></a>
+
 #### レスポンス
 ```
 
@@ -2579,6 +2737,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
   }
 }
 ```
+
+<a id="register-alternative-delivery-settings"></a>
 
 ### 代替送信設定登録
 
@@ -2627,6 +2787,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/failback/appkey -d '{"plusFriendId": "@プラスフレンド","isResend": true,"resendSendNo": "01012341234" }
 ```
+
+<a id="response-24"></a>
 
 #### レスポンス
 ```

--- a/ko/alimtalk-api-guide-v2.0.md
+++ b/ko/alimtalk-api-guide-v2.0.md
@@ -1,6 +1,10 @@
 ## Notification > KakaoTalk Bizmessage > 알림톡 > API v2.0 Guide
 
+<a id="alimtalk"></a>
+
 ## 알림톡
+
+<a id="api-domain"></a>
 
 #### [API 도메인]
 
@@ -17,12 +21,18 @@
 </tbody>
 </table>
 
+<a id="overview-of-v20-api"></a>
+
 ## v2.0 API 소개
 1. 카카오 채널 추가 시, 발급 받은 senderKey 필드로 API 호출이 되도록 변경 되었습니다.(plusFriendId 필드 대체)
 2. API uri가 변경 되었습니다.(/plus-friends -> /senders)
 3. 카카오 채널 그룹 기능이 추가 되었습니다.
 
+<a id="general-messages"></a>
+
 ## 일반 메시지
+
+<a id="request-of-sending-replaced-messages"></a>
 
 ### 메시지 치환 발송 요청
 
@@ -115,6 +125,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages -d '{"senderKey":"{발신 키}","templateCode":"{템플릿 코드}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{수신번호}","templateParameter":{"{치환자 필드}":"{치환 데이터}"}}]}'
 ```
 
+<a id="response"></a>
+
 #### 응답
 
 ```
@@ -155,6 +167,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 |-- resultCode | Integer | 발송 요청 결과 코드 |
 |-- resultMessage | String | 발송 요청 결과 메시지 |
 |-- recipientGroupingKey | String | 수신자 그룹핑 키 |
+
+<a id="request-of-sending-full-text"></a>
 
 ### 메시지 전문 발송 요청
 
@@ -267,6 +281,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/raw-messages -d '{"senderKey":"{발신 키}","templateCode":"{템플릿 코드}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{수신번호}","content":"{내용}","buttons":[{"ordering":"{버튼 순서}","type":"{버튼 타입}","name":"{버튼 이름}","linkMo":"{모바일 웹 링크}"}]}]}'
 ```
 
+<a id="response-2"></a>
+
 #### 응답
 
 ```
@@ -308,7 +324,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 |-- resultMessage | String | 발송 요청 결과 메시지 |
 |-- recipientGroupingKey | String | 수신자 그룹핑 키 |
 
+<a id="list-messages"></a>
+
 ### 메시지 리스트 조회
+
+<a id="request"></a>
 
 #### 요청
 
@@ -357,6 +377,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 90일 이전 발송 요청 데이터는 조회되지 않습니다.
 * 발송 요청 일시의 범위는 최대 30일입니다.
+
+<a id="response-3"></a>
 
 #### 응답
 ```
@@ -446,7 +468,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<a id="get-messages"></a>
+
 ### 메시지 단건 조회
+
+<a id="request-2"></a>
 
 #### 요청
 
@@ -479,6 +505,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-4"></a>
 
 #### 응답
 ```
@@ -575,6 +603,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |- senderGroupingKey | String | 발신 그룹핑 키 |
 |- recipientGroupingKey | String |	수신자 그룹핑 키 |
 
+<a id="authentication-messages"></a>
+
 ## 인증 메시지
 
 <span id="precautions-authword"></span>
@@ -587,6 +617,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 - 예시 1-1) 인증 메시지 API 요청시 전문(템플릿 치환자 포함)에 인증 문구가 포함되어 있지 않은 경우 발송 실패됩니다.
 - 예시 1-2) 인증 문구가 영문인 경우 대소문자 구분 없이 유효성 검사가 진행됩니다.
 
+
+<a id="request-of-sending-replaced-messages-2"></a>
 
 ### 메시지 치환 발송 요청
 
@@ -676,6 +708,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/auth/messages -d '{"senderKey":"{발신 키}","templateCode":"{템플릿 코드}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{수신번호}","templateParameter":{"{치환자 필드}":"{치환 데이터}"}}]}'
 ```
 
+<a id="response-5"></a>
+
 #### 응답
 
 ```
@@ -716,6 +750,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 |-- resultCode | Integer | 발송 요청 결과 코드 |
 |-- resultMessage | String | 발송 요청 결과 메시지 |
 |-- recipientGroupingKey | String | 수신자 그룹핑 키 |
+
+<a id="request-of-sending-full-text-2"></a>
 
 ### 메시지 전문 발송 요청
 
@@ -823,6 +859,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/auth/raw-messages -d '{"senderKey":"{발신 키}","templateCode":"{템플릿 코드}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{수신번호}","content":"{내용}","buttons":[{"ordering":"{버튼 순서}","type":"{버튼 타입}","name":"{버튼 이름}","linkMo":"{모바일 웹 링크}"}]}]}'
 ```
 
+<a id="response-6"></a>
+
 #### 응답
 
 ```
@@ -864,7 +902,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 |-- resultMessage | String | 발송 요청 결과 메시지 |
 |-- recipientGroupingKey | String | 수신자 그룹핑 키 |
 
+<a id="list-messages-2"></a>
+
 ### 메시지 리스트 조회
+
+<a id="request-3"></a>
 
 #### 요청
 
@@ -913,6 +955,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 90일 이전 발송 요청 데이터는 조회되지 않습니다.
 * 발송 요청 일시의 범위는 최대 30일입니다.
+
+<a id="response-7"></a>
 
 #### 응답
 ```
@@ -1002,7 +1046,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/auth/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<a id="get-messages-2"></a>
+
 ### 메시지 단건 조회
+
+<a id="request-4"></a>
 
 #### 요청
 
@@ -1035,6 +1083,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/auth/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-8"></a>
 
 #### 응답
 ```
@@ -1131,8 +1181,14 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |- senderGroupingKey | String | 발신 그룹핑 키 |
 |- recipientGroupingKey | String |	수신자 그룹핑 키 |
 
+<a id="messages"></a>
+
 ## 메시지
+<a id="cancel-sending-messages"></a>
+
 ### 메시지 발송 취소
+
+<a id="request-5"></a>
 
 #### 요청
 
@@ -1168,6 +1224,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 일반/인증 메시지 모두 동일한 API로 취소할 수 있습니다.
 
+<a id="response-9"></a>
+
 #### 응답
 ```
 {
@@ -1191,7 +1249,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
 ```
 
+<a id="query-updates-of-message-result"></a>
+
 ### 메시지 결과 업데이트 조회
+
+<a id="request-6"></a>
 
 #### 요청
 
@@ -1227,6 +1289,8 @@ Content-Type: application/json;charset=UTF-8
 |alimtalkMessageType|	String| X |	알림톡 메시지 타입(NORMAL, AUTH) |
 |pageNum|	Integer|	X|	페이지 번호(기본: 1)|
 |pageSize|	Integer|	X|	조회 건수(Default: 15, Max: 1000)|
+
+<a id="response-10"></a>
 
 #### 응답
 ```
@@ -1280,6 +1344,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/message-results?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
+<a id="messages-1"></a>
+
 ### SMS/LMS 대체 발송 상태 코드
 | 이름 |	설명|
 |---|---|
@@ -1289,9 +1355,15 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |RSC04|	대체 발송 성공|
 |RSC05|	대체 발송 실패|
 
+<a id="templates"></a>
+
 ## 템플릿
 
+<a id="list-template-categories"></a>
+
 ### 템플릿 카테고리 조회
+<a id="request-7"></a>
+
 #### 요청
 [URL]
 
@@ -1315,6 +1387,8 @@ Content-Type: application/json;charset=UTF-8
 | 이름 |	타입|	필수|	설명|
 |---|---|---|---|
 |X-Secret-Key|	String| O | 콘솔에서 생성할 수 있습니다.  |
+
+<a id="response-11"></a>
 
 #### 응답
 ```
@@ -1357,7 +1431,11 @@ Content-Type: application/json;charset=UTF-8
 |-- inclusion | String |	카테고리 적용 대상 템플릿 설명 |
 |-- exclusion| String| 카테고리 제외 대상 템플릿 설명 |
 
+<a id="register-templates"></a>
+
 ### 템플릿 등록
+<a id="request-8"></a>
+
 #### 요청
 [URL]
 
@@ -1432,6 +1510,8 @@ Content-Type: application/json;charset=UTF-8
 |-schemeIos | String | X |	iOS 앱 링크(AL 타입일 경우 필수 필드, 최대 500자) |
 |-schemeAndroid | String | X |	안드로이드 앱 링크(AL 타입일 경우 필수 필드, 최대 500자) |
 
+<a id="response-12"></a>
+
 #### 응답
 ```
 {
@@ -1450,7 +1530,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 결과 메시지|
 |- isSuccessful|	Boolean| 성공 여부|
 
+<a id="modify-templates"></a>
+
 ### 템플릿 수정
+<a id="request-9"></a>
+
 #### 요청
 [URL]
 
@@ -1524,6 +1608,8 @@ Content-Type: application/json;charset=UTF-8
 |-schemeIos | String | X |	iOS 앱 링크(AL 타입일 경우 필수 필드, 최대 500자) |
 |-schemeAndroid | String | X |	안드로이드 앱 링크(AL 타입일 경우 필수 필드, 최대 500자) |
 
+<a id="response-13"></a>
+
 #### 응답
 ```
 {
@@ -1542,7 +1628,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 결과 메시지|
 |- isSuccessful|	Boolean| 성공 여부|
 
+<a id="delete-templates"></a>
+
 ### 템플릿 삭제
+<a id="request-10"></a>
+
 #### 요청
 [URL]
 
@@ -1566,6 +1656,8 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
+<a id="response-14"></a>
+
 #### 응답
 ```
 {
@@ -1584,7 +1676,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 결과 메시지|
 |- isSuccessful|	Boolean| 성공 여부|
 
+<a id="inquire-of-templates"></a>
+
 ### 템플릿 문의하기
+<a id="request-11"></a>
+
 #### 요청
 [URL]
 
@@ -1623,6 +1719,8 @@ Content-Type: application/json;charset=UTF-8
 |---|---|---|---|
 |comment|	String |	O | 문의 내용 |
 
+<a id="response-15"></a>
+
 #### 응답
 ```
 {
@@ -1641,7 +1739,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 결과 메시지|
 |- isSuccessful|	Boolean| 성공 여부|
 
+<a id="attach-files-to-send-inquiry-on-templates"></a>
+
 ### 파일 첨부하여 템플릿 문의하기
+<a id="request-12"></a>
+
 #### 요청
 [URL]
 
@@ -1682,6 +1784,8 @@ Content-Type: application/json;charset=UTF-8
 |comment|	String |	O | 문의 내용           |
 |attachments| List<File> | X | 첨부 파일 목록(최대 10개) |
 
+<a id="response-16"></a>
+
 #### 응답
 ```
 {
@@ -1700,7 +1804,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 결과 메시지|
 |- isSuccessful|	Boolean| 성공 여부|
 
+<a id="list-templates"></a>
+
 ### 템플릿 리스트 조회
+
+<a id="request-13"></a>
 
 #### 요청
 
@@ -1749,6 +1857,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/senders/{senderKey}/templates?templateStatus={템플릿 상태 코드}"
 ```
+
+<a id="response-17"></a>
 
 #### 응답
 ```
@@ -1856,7 +1966,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |-- updateDate | String | 수정일자 |
 |- totalCount | Integer | 총개수 |
 
+<a id="list-template-modifications"></a>
+
 ### 템플릿 수정 리스트 조회
+
+<a id="request-14"></a>
 
 #### 요청
 
@@ -1889,6 +2003,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}/modifications"
 ```
+
+<a id="response-18"></a>
 
 #### 응답
 ```
@@ -1998,7 +2114,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |-- updateDate | String | 수정일자                                                                                             |
 |- totalCount | Integer | 총개수                                                                                              |
 
+<a id="section-1"></a>
+
 ## 대체 발송 관리
+<a id="section-1-1"></a>
+
 ### SMS AppKey 등록
 
 [URL]
@@ -2042,6 +2162,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
 ```
 
+<a id="section-1-1-1"></a>
+
 #### 응답
 ```
 
@@ -2053,6 +2175,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
   }
 }
 ```
+
+<a id="section-1-2"></a>
 
 ### 대체 발송 설정 등록
 
@@ -2100,6 +2224,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/failback/appkey -d '{"senderKey": "0be23c29de88d6888798aeda57062516354d74ba","isResend": true,"resendSendNo": "01012341234" }
 ```
+
+<a id="section-1-2-1"></a>
 
 #### 응답
 ```

--- a/ko/alimtalk-api-guide-v2.1.md
+++ b/ko/alimtalk-api-guide-v2.1.md
@@ -1,6 +1,10 @@
 ## Notification > KakaoTalk Bizmessage > 알림톡 > API v2.1 Guide
 
+<a id="alimtalk"></a>
+
 ## 알림톡
+
+<a id="api-domain"></a>
 
 #### [API 도메인]
 
@@ -17,12 +21,18 @@
 </tbody>
 </table>
 
+<a id="overview-of-v21-api"></a>
+
 ## v2.1 API 소개
 1. 알림톡 템플릿 이미지 업로드 API가 추가되었습니다.
 2. 템플릿 조회 시, templateImageName, templateImageUrl 필드가 추가되었습니다.
 3. 예약 발송이 90일 -> 60일 이후까지 가능하도록 변경되었습니다.
 
+<a id="general-messages"></a>
+
 ## 일반 메시지
+
+<a id="request-of-sending-replaced-messages"></a>
 
 ### 메시지 치환 발송 요청
 
@@ -115,6 +125,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/messages -d '{"senderKey":"{발신 키}","templateCode":"{템플릿 코드}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{수신번호}","templateParameter":{"{치환자 필드}":"{치환 데이터}"}}]}'
 ```
 
+<a id="response"></a>
+
 #### 응답
 
 ```
@@ -155,6 +167,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 |-- resultCode | Integer | 발송 요청 결과 코드 |
 |-- resultMessage | String | 발송 요청 결과 메시지 |
 |-- recipientGroupingKey | String | 수신자 그룹핑 키 |
+
+<a id="request-of-sending-full-text"></a>
 
 ### 메시지 전문 발송 요청
 
@@ -267,6 +281,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/raw-messages -d '{"senderKey":"{발신 키}","templateCode":"{템플릿 코드}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{수신번호}","content":"{내용}","buttons":[{"ordering":"{버튼 순서}","type":"{버튼 타입}","name":"{버튼 이름}","linkMo":"{모바일 웹 링크}"}]}]}'
 ```
 
+<a id="response-2"></a>
+
 #### 응답
 
 ```
@@ -308,7 +324,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 |-- resultMessage | String | 발송 요청 결과 메시지 |
 |-- recipientGroupingKey | String | 수신자 그룹핑 키 |
 
+<a id="list-messages"></a>
+
 ### 메시지 리스트 조회
+
+<a id="request"></a>
 
 #### 요청
 
@@ -357,6 +377,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 90일 이전 발송 요청 데이터는 조회되지 않습니다.
 * 발송 요청 일시의 범위는 최대 30일입니다.
+
+<a id="response-3"></a>
 
 #### 응답
 ```
@@ -446,7 +468,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<a id="get-messages"></a>
+
 ### 메시지 단건 조회
+
+<a id="request-2"></a>
 
 #### 요청
 
@@ -479,6 +505,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-4"></a>
 
 #### 응답
 ```
@@ -575,6 +603,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |- senderGroupingKey | String | 발신 그룹핑 키 |
 |- recipientGroupingKey | String |	수신자 그룹핑 키 |
 
+<a id="authentication-messages"></a>
+
 ## 인증 메시지
 
 <span id="precautions-authword"></span>
@@ -587,6 +617,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 - 예시 1-1) 인증 메시지 API 요청시 전문(템플릿 치환자 포함)에 인증 문구가 포함되어 있지 않은 경우 발송 실패됩니다.
 - 예시 1-2) 인증 문구가 영문인 경우 대소문자 구분 없이 유효성 검사가 진행됩니다.
 
+
+<a id="request-of-sending-replaced-messages-2"></a>
 
 ### 메시지 치환 발송 요청
 
@@ -676,6 +708,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/auth/messages -d '{"senderKey":"{발신 키}","templateCode":"{템플릿 코드}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{수신번호}","templateParameter":{"{치환자 필드}":"{치환 데이터}"}}]}'
 ```
 
+<a id="response-5"></a>
+
 #### 응답
 
 ```
@@ -716,6 +750,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 |-- resultCode | Integer | 발송 요청 결과 코드 |
 |-- resultMessage | String | 발송 요청 결과 메시지 |
 |-- recipientGroupingKey | String | 수신자 그룹핑 키 |
+
+<a id="request-of-sending-full-text-2"></a>
 
 ### 메시지 전문 발송 요청
 
@@ -823,6 +859,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/auth/raw-messages -d '{"senderKey":"{발신 키}","templateCode":"{템플릿 코드}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{수신번호}","content":"{내용}","buttons":[{"ordering":"{버튼 순서}","type":"{버튼 타입}","name":"{버튼 이름}","linkMo":"{모바일 웹 링크}"}]}]}'
 ```
 
+<a id="response-6"></a>
+
 #### 응답
 
 ```
@@ -864,7 +902,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 |-- resultMessage | String | 발송 요청 결과 메시지 |
 |-- recipientGroupingKey | String | 수신자 그룹핑 키 |
 
+<a id="list-messages-2"></a>
+
 ### 메시지 리스트 조회
+
+<a id="request-3"></a>
 
 #### 요청
 
@@ -913,6 +955,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 90일 이전 발송 요청 데이터는 조회되지 않습니다.
 * 발송 요청 일시의 범위는 최대 30일입니다.
+
+<a id="response-7"></a>
 
 #### 응답
 ```
@@ -1002,7 +1046,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/auth/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<a id="get-messages-2"></a>
+
 ### 메시지 단건 조회
+
+<a id="request-4"></a>
 
 #### 요청
 
@@ -1035,6 +1083,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/auth/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-8"></a>
 
 #### 응답
 ```
@@ -1131,8 +1181,14 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |- senderGroupingKey | String | 발신 그룹핑 키 |
 |- recipientGroupingKey | String |	수신자 그룹핑 키 |
 
+<a id="messages"></a>
+
 ## 메시지
+<a id="cancel-sending-messages"></a>
+
 ### 메시지 발송 취소
+
+<a id="request-5"></a>
 
 #### 요청
 
@@ -1168,6 +1224,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 일반/인증 메시지 모두 동일한 API로 취소할 수 있습니다.
 
+<a id="response-9"></a>
+
 #### 응답
 ```
 {
@@ -1191,7 +1249,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
 ```
 
+<a id="query-updates-of-message-result"></a>
+
 ### 메시지 결과 업데이트 조회
+
+<a id="request-6"></a>
 
 #### 요청
 
@@ -1227,6 +1289,8 @@ Content-Type: application/json;charset=UTF-8
 |alimtalkMessageType|	String| X |	알림톡 메시지 타입(NORMAL, AUTH) |
 |pageNum|	Integer|	X|	페이지 번호(기본: 1)|
 |pageSize|	Integer|	X|	조회 건수(Default: 15, Max: 1000)|
+
+<a id="response-10"></a>
 
 #### 응답
 ```
@@ -1280,6 +1344,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/message-results?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
+<a id="messages-1"></a>
+
 ### SMS/LMS 대체 발송 상태 코드
 | 이름 |	설명|
 |---|---|
@@ -1289,9 +1355,15 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |RSC04|	대체 발송 성공|
 |RSC05|	대체 발송 실패|
 
+<a id="templates"></a>
+
 ## 템플릿
 
+<a id="list-template-categories"></a>
+
 ### 템플릿 카테고리 조회
+<a id="request-7"></a>
+
 #### 요청
 [URL]
 
@@ -1315,6 +1387,8 @@ Content-Type: application/json;charset=UTF-8
 | 이름 |	타입|	필수|	설명|
 |---|---|---|---|
 |X-Secret-Key|	String| O | 콘솔에서 생성할 수 있습니다.  |
+
+<a id="response-11"></a>
 
 #### 응답
 ```
@@ -1357,7 +1431,11 @@ Content-Type: application/json;charset=UTF-8
 |-- inclusion | String |	카테고리 적용 대상 템플릿 설명 |
 |-- exclusion| String| 카테고리 제외 대상 템플릿 설명 |
 
+<a id="register-templates"></a>
+
 ### 템플릿 등록
+<a id="request-8"></a>
+
 #### 요청
 [URL]
 
@@ -1436,6 +1514,8 @@ Content-Type: application/json;charset=UTF-8
 |-schemeIos | String | X |	iOS 앱 링크(AL 타입일 경우 필수 필드, 최대 500자) |
 |-schemeAndroid | String | X |	안드로이드 앱 링크(AL 타입일 경우 필수 필드, 최대 500자) |
 
+<a id="response-12"></a>
+
 #### 응답
 ```
 {
@@ -1454,7 +1534,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 결과 메시지|
 |- isSuccessful|	Boolean| 성공 여부|
 
+<a id="modify-templates"></a>
+
 ### 템플릿 수정
+<a id="request-9"></a>
+
 #### 요청
 [URL]
 
@@ -1532,6 +1616,8 @@ Content-Type: application/json;charset=UTF-8
 |-schemeIos | String | X |	iOS 앱 링크(AL 타입일 경우 필수 필드, 최대 500자) |
 |-schemeAndroid | String | X |	안드로이드 앱 링크(AL 타입일 경우 필수 필드, 최대 500자) |
 
+<a id="response-13"></a>
+
 #### 응답
 ```
 {
@@ -1550,7 +1636,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 결과 메시지|
 |- isSuccessful|	Boolean| 성공 여부|
 
+<a id="delete-templates"></a>
+
 ### 템플릿 삭제
+<a id="request-10"></a>
+
 #### 요청
 [URL]
 
@@ -1574,6 +1664,8 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
+<a id="response-14"></a>
+
 #### 응답
 ```
 {
@@ -1592,7 +1684,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 결과 메시지|
 |- isSuccessful|	Boolean| 성공 여부|
 
+<a id="inquire-of-templates"></a>
+
 ### 템플릿 문의하기
+<a id="request-11"></a>
+
 #### 요청
 [URL]
 
@@ -1631,6 +1727,8 @@ Content-Type: application/json;charset=UTF-8
 |---|---|---|---|
 |comment|	String |	O | 문의 내용 |
 
+<a id="response-15"></a>
+
 #### 응답
 ```
 {
@@ -1649,7 +1747,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 결과 메시지|
 |- isSuccessful|	Boolean| 성공 여부|
 
+<a id="attach-files-to-send-inquiry-on-templates"></a>
+
 ### 파일 첨부하여 템플릿 문의하기
+<a id="request-12"></a>
+
 #### 요청
 [URL]
 
@@ -1690,6 +1792,8 @@ Content-Type: application/json;charset=UTF-8
 |comment|	String |	O | 문의 내용            |
 |attachments| List<File> | X | 첨부 파일 목록(최대 10개) |
 
+<a id="response-16"></a>
+
 #### 응답
 ```
 {
@@ -1708,7 +1812,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 결과 메시지|
 |- isSuccessful|	Boolean| 성공 여부|
 
+<a id="list-templates"></a>
+
 ### 템플릿 리스트 조회
+
+<a id="request-13"></a>
 
 #### 요청
 
@@ -1757,6 +1865,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/senders/{senderKey}/templates?templateStatus={템플릿 상태 코드}"
 ```
+
+<a id="response-17"></a>
 
 #### 응답
 ```
@@ -1868,7 +1978,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |-- updateDate | String | 수정일자 |
 |- totalCount | Integer | 총개수 |
 
+<a id="list-template-modifications"></a>
+
 ### 템플릿 수정 리스트 조회
+
+<a id="request-14"></a>
 
 #### 요청
 
@@ -1901,6 +2015,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}/modifications"
 ```
+
+<a id="response-18"></a>
 
 #### 응답
 ```
@@ -2014,7 +2130,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |-- updateDate | String | 수정일자 |
 |- totalCount | Integer | 총개수 |
 
+<a id="register-template-image"></a>
+
 ### 템플릿 이미지 등록
+<a id="request-15"></a>
+
 #### 요청
 [URL]
 
@@ -2050,6 +2170,8 @@ Content-Type: multipart/form-data
 curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/template-image" -F "file=@alimtalk-template-image.jpeg"
 ```
 
+<a id="response-19"></a>
+
 #### 응답
 ```
 {
@@ -2075,7 +2197,11 @@ curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}
 |- templateImageName | String |	이미지명(업로드한 파일명) |
 |- templateImageUrl | String |	이미지 URL |
 
+<a id="section-1"></a>
+
 ## 대체 발송 관리
+<a id="section-1-1"></a>
+
 ### SMS AppKey 등록
 
 [URL]
@@ -2119,6 +2245,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
 ```
 
+<a id="section-1-1-1"></a>
+
 #### 응답
 ```
 
@@ -2130,6 +2258,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
   }
 }
 ```
+
+<a id="section-1-2"></a>
 
 ### 대체 발송 설정 등록
 
@@ -2177,6 +2307,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/failback/appkey -d '{"senderKey": "0be23c29de88d6888798aeda57062516354d74ba","isResend": true,"resendSendNo": "01012341234" }
 ```
+
+<a id="section-1-2-1"></a>
 
 #### 응답
 ```

--- a/ko/alimtalk-api-guide-v2.2.md
+++ b/ko/alimtalk-api-guide-v2.2.md
@@ -1,6 +1,10 @@
 ## Notification > KakaoTalk Bizmessage > 알림톡 > API v2.2 Guide
 
+<a id="alimtalk"></a>
+
 ## 알림톡
+
+<a id="api-domain"></a>
 
 #### [API Domain]
 
@@ -17,13 +21,19 @@
 </tbody>
 </table>
 
+<a id="overview-of-v22-api"></a>
+
 ## Overview of v2.2 API
 1. 알림톡 대량 발송 조회, 통계 조회 API가 추가되었습니다.
 2. 메시지 치환 발송 API 응답 본문에 `buttons` 필드가 추가되었습니다.
 3. 메시지 전문 발송 API 응답 본문의 `buttons` 필드에 `chatExtra`, `chatEvent`, `target` 필드가 추가되었습니다.
 4. 메시지 조회 API 응답 본문의 `buttons` 필드에 `chatExtra`, `chatEvent`, `target` 필드가 추가되었습니다.
 
+<a id="general-messages"></a>
+
 ## 일반 메시지
+
+<a id="request-of-sending-replaced-messages"></a>
 
 ### 메시지 치환 발송 요청
 
@@ -131,6 +141,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/messages -d '{"senderKey":"{발신 키}","templateCode":"{템플릿 코드}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{수신번호}","templateParameter":{"{치환자 필드}":"{치환 데이터}"}}]}'
 ```
 
+<a id="response"></a>
+
 #### 응답
 
 ```
@@ -171,6 +183,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 |-- resultCode | Integer | 발송 요청 결과 코드 |
 |-- resultMessage | String | 발송 요청 결과 메시지 |
 |-- recipientGroupingKey | String | 수신자 그룹핑 키 |
+
+<a id="request-of-sending-full-text"></a>
 
 ### 메시지 전문 발송 요청
 
@@ -291,6 +305,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/raw-messages -d '{"senderKey":"{발신 키}","templateCode":"{템플릿 코드}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{수신번호}","content":"{내용}","buttons":[{"ordering":"{버튼 순서}","type":"{버튼 타입}","name":"{버튼 이름}","linkMo":"{모바일 웹 링크}"}]}]}'
 ```
 
+<a id="response-2"></a>
+
 #### 응답
 
 ```
@@ -332,7 +348,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 |-- resultMessage | String | 발송 요청 결과 메시지 |
 |-- recipientGroupingKey | String | 수신자 그룹핑 키 |
 
+<a id="list-messages"></a>
+
 ### 메시지 리스트 조회
+
+<a id="request"></a>
 
 #### 요청
 
@@ -381,6 +401,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 90일 이전 발송 요청 데이터는 조회되지 않습니다.
 * 발송 요청 일시의 범위는 최대 30일입니다.
+
+<a id="response-3"></a>
 
 #### 응답
 ```
@@ -476,7 +498,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<a id="get-messages"></a>
+
 ### 메시지 단건 조회
+
+<a id="request-2"></a>
 
 #### 요청
 
@@ -509,6 +535,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-4"></a>
 
 #### 응답
 ```
@@ -611,6 +639,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |- senderGroupingKey | String | 발신 그룹핑 키 |
 |- recipientGroupingKey | String |	수신자 그룹핑 키 |
 
+<a id="authentication-messages"></a>
+
 ## 인증 메시지
 
 <span id="precautions-authword"></span>
@@ -623,6 +653,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 - 예시 1-1) 인증 메시지 API 요청시 전문(템플릿 치환자 포함)에 인증 문구가 포함되어 있지 않은 경우 발송 실패됩니다.
 - 예시 1-2) 인증 문구가 영문인 경우 대소문자 구분 없이 유효성 검사가 진행됩니다.
 
+
+<a id="request-of-sending-replaced-messages-2"></a>
 
 ### 메시지 치환 발송 요청
 
@@ -727,6 +759,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/auth/messages -d '{"senderKey":"{발신 키}","templateCode":"{템플릿 코드}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{수신번호}","templateParameter":{"{치환자 필드}":"{치환 데이터}"}}]}'
 ```
 
+<a id="response-5"></a>
+
 #### 응답
 
 ```
@@ -767,6 +801,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 |-- resultCode | Integer | 발송 요청 결과 코드 |
 |-- resultMessage | String | 발송 요청 결과 메시지 |
 |-- recipientGroupingKey | String | 수신자 그룹핑 키 |
+
+<a id="request-of-sending-full-text-2"></a>
 
 ### 메시지 전문 발송 요청
 
@@ -882,6 +918,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/auth/raw-messages -d '{"senderKey":"{발신 키}","templateCode":"{템플릿 코드}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{수신번호}","content":"{내용}","buttons":[{"ordering":"{버튼 순서}","type":"{버튼 타입}","name":"{버튼 이름}","linkMo":"{모바일 웹 링크}"}]}]}'
 ```
 
+<a id="response-6"></a>
+
 #### 응답
 
 ```
@@ -923,7 +961,11 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 |-- resultMessage | String | 발송 요청 결과 메시지 |
 |-- recipientGroupingKey | String | 수신자 그룹핑 키 |
 
+<a id="list-messages-2"></a>
+
 ### 메시지 리스트 조회
+
+<a id="request-3"></a>
 
 #### 요청
 
@@ -972,6 +1014,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 90일 이전 발송 요청 데이터는 조회되지 않습니다.
 * 발송 요청 일시의 범위는 최대 30일입니다.
+
+<a id="response-7"></a>
 
 #### 응답
 ```
@@ -1067,7 +1111,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/auth/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
+<a id="get-messages-2"></a>
+
 ### 메시지 단건 조회
+
+<a id="request-4"></a>
 
 #### 요청
 
@@ -1100,6 +1148,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/auth/messages/{requestId}/{recipientSeq}"
 ```
+
+<a id="response-8"></a>
 
 #### 응답
 ```
@@ -1202,8 +1252,14 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |- senderGroupingKey | String | 발신 그룹핑 키 |
 |- recipientGroupingKey | String |	수신자 그룹핑 키 |
 
+<a id="messages"></a>
+
 ## 메시지
+<a id="cancel-sending-messages"></a>
+
 ### 메시지 발송 취소
+
+<a id="request-5"></a>
 
 #### 요청
 
@@ -1239,6 +1295,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 일반/인증 메시지 모두 동일한 API로 취소할 수 있습니다.
 
+<a id="response-9"></a>
+
 #### 응답
 ```
 {
@@ -1262,7 +1320,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
 ```
 
+<a id="query-updates-of-message-result"></a>
+
 ### 메시지 결과 업데이트 조회
+
+<a id="request-6"></a>
 
 #### 요청
 
@@ -1298,6 +1360,8 @@ Content-Type: application/json;charset=UTF-8
 |alimtalkMessageType|	String| X |	알림톡 메시지 타입(NORMAL, AUTH) |
 |pageNum|	Integer|	X|	페이지 번호(기본: 1)|
 |pageSize|	Integer|	X|	조회 건수(Default: 15, Max: 1000)|
+
+<a id="response-10"></a>
 
 #### 응답
 ```
@@ -1351,6 +1415,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/message-results?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
 
+<a id="status-code-of-smslms-resending"></a>
+
 ### SMS/LMS 대체 발송 상태 코드
 | 이름 |	설명|
 |---|---|
@@ -1360,8 +1426,14 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |RSC04|	대체 발송 성공|
 |RSC05|	대체 발송 실패|
 
+<a id="mass-delivery"></a>
+
 ## 대량 발송
+<a id="list-mass-delivery-requests"></a>
+
 ### 대량 발송 요청 목록 조회
+
+<a id="request-7"></a>
 
 #### 요청
 [URL]
@@ -1401,6 +1473,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum | optional, Integer | - | X | 페이지 번호 |
 | pageSize | optional, Integer | 1000 | X | 검색 수 |
 
+<a id="curl"></a>
+
 #### cURL
 ```
 curl -X GET \
@@ -1408,6 +1482,8 @@ curl -X GET \
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-11"></a>
 
 #### 응답
 ```
@@ -1497,7 +1573,11 @@ curl -X GET \
 | - totalCount | Integer | 총개수 |
 
 
+<a id="list-mass-delivery-recipients"></a>
+
 ### 대량 발송 수신자 목록 조회
+
+<a id="request-8"></a>
 
 #### 요청
 [URL]
@@ -1536,6 +1616,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum | optional, Integer | - | X | 페이지 번호 |
 | pageSize | optional, Integer | 1000 | X | 검색 수 |
 
+<a id="curl-2"></a>
+
 #### cURL
 ```
 curl -X GET \
@@ -1543,6 +1625,8 @@ curl -X GET \
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-12"></a>
 
 #### 응답
 ```
@@ -1588,7 +1672,11 @@ curl -X GET \
 | -- resultCodeName | String | 결과 코드 내용 |
 | - totalCount | Integer | 총개수 |
 
+<a id="get-a-mass-delivery-recipient"></a>
+
 ### 대량 발송 수신자 조회
+
+<a id="request-9"></a>
 
 #### 요청
 [URL]
@@ -1628,6 +1716,8 @@ Content-Type: application/json;charset=UTF-8
 | pageNum | optional, Integer | - | X | 페이지 번호 |
 | pageSize | optional, Integer | 1000 | X | 검색 수 |
 
+<a id="curl-3"></a>
+
 #### cURL
 ```
 curl -X GET \
@@ -1635,6 +1725,8 @@ curl -X GET \
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
+
+<a id="response-13"></a>
 
 #### 응답
 ```
@@ -1726,9 +1818,15 @@ curl -X GET \
 | -- chatEvent | String | BT: 봇 전환 시 연결할 봇 이벤트명 |
 | -- target|	String|	웹 링크 버튼일 경우, "target":"out" 속성 추가 시 아웃 링크<br>기본 인앱 링크로 발송 |
 
+<a id="templates"></a>
+
 ## 템플릿
 
+<a id="list-template-categories"></a>
+
 ### 템플릿 카테고리 조회
+<a id="request-10"></a>
+
 #### 요청
 [URL]
 
@@ -1752,6 +1850,8 @@ Content-Type: application/json;charset=UTF-8
 | 이름 |	타입|	필수|	설명|
 |---|---|---|---|
 |X-Secret-Key|	String| O | 콘솔에서 생성할 수 있습니다.  |
+
+<a id="response-14"></a>
 
 #### 응답
 ```
@@ -1794,7 +1894,11 @@ Content-Type: application/json;charset=UTF-8
 |-- inclusion | String |	카테고리 적용 대상 템플릿 설명 |
 |-- exclusion| String| 카테고리 제외 대상 템플릿 설명 |
 
+<a id="register-templates"></a>
+
 ### 템플릿 등록
+<a id="request-11"></a>
+
 #### 요청
 [URL]
 
@@ -1878,6 +1982,8 @@ Content-Type: application/json;charset=UTF-8
 * 채널 추가(AC) 버튼의 버튼명은 "채널 추가"로 고정하여 등록해야 합니다.
 
 
+<a id="response-15"></a>
+
 #### 응답
 ```
 {
@@ -1896,7 +2002,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 결과 메시지|
 |- isSuccessful|	Boolean| 성공 여부|
 
+<a id="modify-templates"></a>
+
 ### 템플릿 수정
+<a id="request-12"></a>
+
 #### 요청
 [URL]
 
@@ -1978,6 +2088,8 @@ Content-Type: application/json;charset=UTF-8
 * 채널 추가형(AD)과 복합형(MI) 메시지 유형 템플릿 수정 시, 채널 추가(AC) 버튼이 첫 번째 순서에 위치해야 합니다.
 * 채널 추가(AC) 버튼의 버튼명은 "채널 추가"로 고정하여, 수정해야 합니다.
 
+<a id="response-16"></a>
+
 #### 응답
 ```
 {
@@ -1996,7 +2108,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 결과 메시지|
 |- isSuccessful|	Boolean| 성공 여부|
 
+<a id="delete-templates"></a>
+
 ### 템플릿 삭제
+<a id="request-13"></a>
+
 #### 요청
 [URL]
 
@@ -2024,6 +2140,8 @@ Content-Type: application/json;charset=UTF-8
 * 카카오에 남아 있는 템플릿은 1년 미사용 시 휴면 처리되고, 휴면 상태가 1년간 지속되면 삭제 처리됩니다.(카카오에서 템플릿이 휴면 전환되거나 삭제되면 담당자에게 알림이 발송됩니다.)
 
 
+<a id="response-17"></a>
+
 #### 응답
 ```
 {
@@ -2042,7 +2160,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 결과 메시지|
 |- isSuccessful|	Boolean| 성공 여부|
 
+<a id="inquire-of-templates"></a>
+
 ### 템플릿 문의하기
+<a id="request-14"></a>
+
 #### 요청
 [URL]
 
@@ -2083,6 +2205,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 반려 상태의 템플릿에 문의를 남길 경우, 검수 중(REQ) 상태로 변경됩니다.
 
+<a id="response-18"></a>
+
 #### 응답
 ```
 {
@@ -2101,7 +2225,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 결과 메시지|
 |- isSuccessful|	Boolean| 성공 여부|
 
+<a id="attach-files-to-send-inquiry-on-templates"></a>
+
 ### 파일 첨부하여 템플릿 문의하기
+<a id="request-15"></a>
+
 #### 요청
 [URL]
 
@@ -2144,6 +2272,8 @@ Content-Type: application/json;charset=UTF-8
 
 * 반려 상태의 템플릿에 문의를 남길 경우, 검수 중(REQ) 상태로 변경됩니다.
 
+<a id="response-19"></a>
+
 #### 응답
 ```
 {
@@ -2162,7 +2292,11 @@ Content-Type: application/json;charset=UTF-8
 |- resultMessage|	String| 결과 메시지|
 |- isSuccessful|	Boolean| 성공 여부|
 
+<a id="list-templates"></a>
+
 ### 템플릿 리스트 조회
+
+<a id="request-16"></a>
 
 #### 요청
 
@@ -2211,6 +2345,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/senders/{senderKey}/templates?templateStatus={템플릿 상태 코드}"
 ```
+
+<a id="response-20"></a>
 
 #### 응답
 ```
@@ -2322,7 +2458,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |-- updateDate | String | 수정일자                                                                                            |
 |- totalCount | Integer | 총개수                                                                                             |
 
+<a id="list-template-modifications"></a>
+
 ### 템플릿 수정 리스트 조회
+
+<a id="request-17"></a>
 
 #### 요청
 
@@ -2355,6 +2495,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}/modifications"
 ```
+
+<a id="response-21"></a>
 
 #### 응답
 ```
@@ -2468,7 +2610,11 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 |-- updateDate | String | 수정일자 |
 |- totalCount | Integer | 총개수 |
 
+<a id="register-template-image"></a>
+
 ### 템플릿 이미지 등록
+<a id="request-18"></a>
+
 #### 요청
 [URL]
 
@@ -2504,6 +2650,8 @@ Content-Type: multipart/form-data
 curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/template-image" -F "file=@alimtalk-template-image.jpeg"
 ```
 
+<a id="response-22"></a>
+
 #### 응답
 ```
 {
@@ -2529,7 +2677,11 @@ curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}
 |- templateImageName | String |	이미지명(업로드한 파일명) |
 |- templateImageUrl | String |	이미지 URL |
 
+<a id="manage-alternative-delivery"></a>
+
 ## 대체 발송 관리
+<a id="register-an-sms-appkey"></a>
+
 ### SMS AppKey 등록
 
 [URL]
@@ -2573,6 +2725,8 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
 ```
 
+<a id="response-23"></a>
+
 #### 응답
 ```
 
@@ -2584,6 +2738,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
   }
 }
 ```
+
+<a id="register-alternative-delivery-settings"></a>
 
 ### 대체 발송 설정 등록
 
@@ -2631,6 +2787,8 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/failback/appkey -d '{"senderKey": "0be23c29de88d6888798aeda57062516354d74ba","isResend": true,"resendSendNo": "01012341234" }
 ```
+
+<a id="response-24"></a>
 
 #### 응답
 ```


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Body text is never modified.** The model only sees heading outlines; edits apply to heading lines (and `<!-- TODO: translate body -->` stubs for missing sections) only.

## Analysis

| | |
| --- | --- |
| Engine | `api (Anthropic SDK)` |
| Model | `claude-sonnet-4-6` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `alpha` |
| Scope | 3 doc(s) scanned · 9 file(s) changed |
| Self-verify | ⚠️ 10 mismatch(es) remain |
| Jenkins build | _(local run)_ |
| Generated | 2026-06-17T12:21:22 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`alpha`): [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FAlimtalk%2Ftree%2Falpha&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FAlimtalk%2Fpull%2F237&source=ko&langs=en%2Cja)

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra demoted | extra removed | verify |
| --- | --: | --: | --: | --: | --: | --: | --: | :--: |
| `ko/alimtalk-api-guide-v2.0.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/alimtalk-api-guide-v2.0.md` | 0 | 6 | 0 | 0 | 0 | 0 | 0 | ⚠️ 2 |
| `ja/alimtalk-api-guide-v2.0.md` | 0 | 1 | 0 | 0 | 0 | 0 | 0 | ⚠️ 2 |
| `ko/alimtalk-api-guide-v2.1.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/alimtalk-api-guide-v2.1.md` | 0 | 6 | 0 | 0 | 0 | 0 | 0 | ⚠️ 2 |
| `ja/alimtalk-api-guide-v2.1.md` | 0 | 1 | 0 | 0 | 0 | 0 | 0 | ⚠️ 2 |
| `ko/alimtalk-api-guide-v2.2.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/alimtalk-api-guide-v2.2.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/alimtalk-api-guide-v2.2.md` | 0 | 1 | 0 | 0 | 0 | 0 | 0 | ⚠️ 2 |

<details><summary>남은 불일치 (검토 필요)</summary>

- `en/alimtalk-api-guide-v2.0.md`:
  - extra_in_target (ko#None/en#13)
  - extra_in_target (ko#None/en#23)
- `ja/alimtalk-api-guide-v2.0.md`:
  - extra_in_target (ko#None/ja#13)
  - extra_in_target (ko#None/ja#23)
- `en/alimtalk-api-guide-v2.1.md`:
  - extra_in_target (ko#None/en#13)
  - extra_in_target (ko#None/en#23)
- `ja/alimtalk-api-guide-v2.1.md`:
  - extra_in_target (ko#None/ja#13)
  - extra_in_target (ko#None/ja#23)
- `ja/alimtalk-api-guide-v2.2.md`:
  - extra_in_target (ko#None/ja#13)
  - extra_in_target (ko#None/ja#23)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/Alimtalk`