### PR TITLE
chore(pre-align): align heading structure (32 docs) with ko

### DIFF
--- a/en/alimtalk-api-guide-v2.0.md
+++ b/en/alimtalk-api-guide-v2.0.md
@@ -472,7 +472,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
-#### Status of Sending SMS/LMS
+**Status of Sending SMS/LMS**
 | Value | Description                                      |
 | ----- | ------------------------------------------------ |
 | RSC01 | No target of resending                           |

--- a/en/alimtalk-api-guide-v2.1.md
+++ b/en/alimtalk-api-guide-v2.1.md
@@ -470,7 +470,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
-#### Status of Sending SMS/LMS
+**Status of Sending SMS/LMS**
 | Value | Description                                      |
 | ----- | ------------------------------------------------ |
 | RSC01 | No target of resending                           |

--- a/ja/alimtalk-api-guide-v2.0.md
+++ b/ja/alimtalk-api-guide-v2.0.md
@@ -466,7 +466,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
-#### SMS/LMS再送信ステータス
+**SMS/LMS再送信ステータス**
 | 値 | 説明                      |
 | ----- | ------------------------------- |
 | RSC01 | 再送信の対象ではない                 |

--- a/ja/alimtalk-api-guide-v2.1.md
+++ b/ja/alimtalk-api-guide-v2.1.md
@@ -467,7 +467,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
-#### SMS/LMS再送信ステータス
+**SMS/LMS再送信ステータス**
 | 値 | 説明                      |
 | ----- | ------------------------------- |
 | RSC01 | 再送信の対象ではない                 |

--- a/ja/alimtalk-api-guide-v2.2.md
+++ b/ja/alimtalk-api-guide-v2.2.md
@@ -497,7 +497,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
-#### SMS/LMS再送信ステータス
+**SMS/LMS再送信ステータス**
 | 値 | 説明                      |
 | ----- | ------------------------------- |
 | RSC01 | 再送信の対象ではない                 |

--- a/ja/alimtalk-api-guide.md
+++ b/ja/alimtalk-api-guide.md
@@ -885,7 +885,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","templateParameter":{"{日本語識別子フィールド}":"{置換データ}"}}]}'
 ```
 
-#### レスポンス
+**レスポンス**
 
 ```
 {
@@ -1045,7 +1045,7 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/raw-messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","content":"{内容}","buttons":[{"ordering":"{ボタン順序}","type":"{ボタンタイプ}","name":"{ボタン名}","linkMo":"{モバイルWebリンク}"}]}]}'
 ```
 
-#### レスポンス
+**レスポンス**
 
 ```
 {
@@ -1144,7 +1144,7 @@ Content-Type: application/json;charset=UTF-8
 * 90日以上前の送信リクエストデータは照会されません。
 * 送信リクエスト日時の範囲は最大30日です。
 
-#### レスポンス
+**レスポンス**
 ```
 {
   "header" : {
@@ -1238,9 +1238,9 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
-### メッセージ結果アップデート件数の照会
+**メッセージ結果アップデート件数の照会**
 
-#### リクエスト
+**リクエスト**
 
 [URL]
 
@@ -1275,7 +1275,7 @@ Content-Type: application/json;charset=UTF-8
 | endUpdateDate       | 	String  | O   | 	結果アップデート照会終了時間(yyyy-MM-dd HH:mm) |
 | alimtalkMessageType | 	String  | X   | 	お知らせトークのメッセージタイプ(NORMAL, AUTH)           |
 
-#### レスポンス
+**レスポンス**
 
 ```
 {
@@ -1587,6 +1587,30 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/message-results?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
+
+<a id="query-the-number-of-message-result-updates"></a>
+
+### メッセージ結果更新件数照会
+
+<!-- TODO: translate body -->
+
+<a id="request-7"></a>
+
+#### 要求
+
+<!-- TODO: translate body -->
+
+<a id="response-8"></a>
+
+#### ## 応答
+
+<!-- TODO: translate body -->
+
+<a id="status-code-of-smslms-resending"></a>
+
+### SMS/LMS 代替送信ステータスコード
+
+<!-- TODO: translate body -->
 
 <a id="mass-delivery"></a>
 

--- a/ja/friendtalkupgrade-api-guide.md
+++ b/ja/friendtalkupgrade-api-guide.md
@@ -945,6 +945,8 @@ Content-Type: application/json;charset=UTF-8
 | createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
 | statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
 
+<a id="request-to-send-carousel-commerce-type"></a>
+
 #### カルーセルコマース形式の送信リクエスト
 
 ##### カルーセル固定置換パラメータ(pathベースのテンプレートパラメータ)


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Body text is never modified.** The model only sees heading outlines; edits apply to heading lines (and `<!-- TODO: translate body -->` stubs for missing sections) only.

## Analysis

| | |
| --- | --- |
| Engine | `api (Anthropic SDK)` |
| Model | `claude-sonnet-4-6` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `alpha` |
| Scope | 32 doc(s) scanned · 7 file(s) changed · 27 unchanged |
| Self-verify | ⚠️ 9 mismatch(es) remain |
| Jenkins build | http://cd.cloud.toastoven.net:8080/job/content_deploy/job/align-heading/job/main/9/ |
| Generated | 2026-07-01T22:53:56 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`alpha`): [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FAlimtalk%2Ftree%2Falpha&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FAlimtalk%2Fpull%2F244&source=ko&langs=en%2Cja)

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra demoted | extra removed | verify |
| --- | --: | --: | --: | --: | --: | --: | --: | :--: |
| `en/alimtalk-api-guide-v2.0.md` | 0 | 0 | 0 | 0 | 0 | 1 | 0 | ⚠️ 1 |
| `ja/alimtalk-api-guide-v2.0.md` | 0 | 0 | 0 | 0 | 0 | 1 | 0 | ⚠️ 1 |
| `en/alimtalk-api-guide-v2.1.md` | 0 | 0 | 0 | 0 | 0 | 1 | 0 | ⚠️ 1 |
| `ja/alimtalk-api-guide-v2.1.md` | 0 | 0 | 0 | 0 | 0 | 1 | 0 | ⚠️ 1 |
| `ja/alimtalk-api-guide-v2.2.md` | 0 | 0 | 0 | 0 | 0 | 1 | 0 | ⚠️ 1 |
| `ja/alimtalk-api-guide.md` | 0 | 4 | 0 | 0 | 0 | 6 | 0 | ⚠️ 2 |
| `ja/friendtalkupgrade-api-guide.md` | 0 | 0 | 0 | 1 | 0 | 0 | 0 | ⚠️ 2 |

<details><summary>남은 불일치 (검토 필요)</summary>

- `en/alimtalk-api-guide-v2.0.md`:
  - extra_in_target (ko#None/en#22)
- `ja/alimtalk-api-guide-v2.0.md`:
  - extra_in_target (ko#None/ja#22)
- `en/alimtalk-api-guide-v2.1.md`:
  - extra_in_target (ko#None/en#22)
- `ja/alimtalk-api-guide-v2.1.md`:
  - extra_in_target (ko#None/ja#22)
- `ja/alimtalk-api-guide-v2.2.md`:
  - extra_in_target (ko#None/ja#22)
- `ja/alimtalk-api-guide.md`:
  - extra_in_target (ko#None/ja#14)
  - extra_in_target (ko#None/ja#21)
- `ja/friendtalkupgrade-api-guide.md`:
  - missing_in_target (ko#21/ja#None)
  - extra_in_target (ko#None/ja#22)

</details>

<details><summary>변경 없이 건너뛴 문서 (27) — 이미 `ko`와 정렬됨 / 대상 파일 없음 (PR에서 제외)</summary>

- `Overview.md`
- `alimtalk-api-guide-v1.4.md`
- `alimtalk-api-guide-v1.5.md`
- `alimtalk-console-guide.md`
- `alimtalk-overview.md`
- `common-api-guide.md`
- `common-console-guide.md`
- `error-code.md`
- `friendtalk-api-guide-v1.4.md`
- `friendtalk-api-guide-v1.5.md`
- `friendtalk-api-guide-v2.0.md`
- `friendtalk-api-guide-v2.2.md`
- `friendtalk-api-guide-v2.3.md`
- `friendtalk-api-guide.md`
- `friendtalk-compatible-api-guide.md`
- `friendtalk-console-guide.md`
- `friendtalk-overview.md`
- `friendtalkupgrade-console-guide.md`
- `friendtalkupgrade-overview.md`
- `release-notes.md`
- `sender-api-guide-v2.0.md`
- `sender-api-guide-v2.1.md`
- `sender-api-guide-v2.3.md`
- `sender-console-guide.md`
- `sender-overview.md`
- `troubleshooting-guide.md`
- `webhook-api-guide.md`

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/Alimtalk`