### PR TITLE
chore(pre-align): align heading structure (5 docs) with ko

### DIFF
--- a/en/alimtalk-api-guide-v2.0.md
+++ b/en/alimtalk-api-guide-v2.0.md
@@ -472,15 +472,6 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
-#### Status of Sending SMS/LMS
-| Value | Description                                      |
-| ----- | ------------------------------------------------ |
-| RSC01 | No target of resending                           |
-| RSC02 | Target of resending(resent, if delivery fails.) |
-| RSC03 | Resending                                        |
-| RSC04 | Resending successful                             |
-| RSC05 | Resending failed                                 |
-
 <a id="get-messages"></a>
 
 ### Get Messages

--- a/en/alimtalk-api-guide-v2.1.md
+++ b/en/alimtalk-api-guide-v2.1.md
@@ -470,15 +470,6 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
-#### Status of Sending SMS/LMS
-| Value | Description                                      |
-| ----- | ------------------------------------------------ |
-| RSC01 | No target of resending                           |
-| RSC02 | Target of resending(resent, if delivery fails.) |
-| RSC03 | Resending                                        |
-| RSC04 | Resending successful                             |
-| RSC05 | Resending failed                                 |
-
 <a id="get-messages"></a>
 
 ### Get Messages

--- a/en/friendtalkupgrade-api-guide.md
+++ b/en/friendtalkupgrade-api-guide.md
@@ -1870,6 +1870,24 @@ Content-Type: application/json;charset=UTF-8
 | \- senderGroupingKey| String| X| Outgoing grouping key|
 | \- recipientGroupingKey| String| X| Recipient grouping key|
 
+<a id="message-results"></a>
+
+## View Message Result Updates
+
+<!-- TODO: translate body -->
+
+<a id="requested-25"></a>
+
+#### Requested
+
+<!-- TODO: translate body -->
+
+<a id="response-25"></a>
+
+#### Response
+
+<!-- TODO: translate body -->
+
 <a id="cancel-message-sending"></a>
 
 ## Cancel message sending

--- a/ja/alimtalk-api-guide-v2.0.md
+++ b/ja/alimtalk-api-guide-v2.0.md
@@ -466,15 +466,6 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
-#### SMS/LMS再送信ステータス
-| 値 | 説明                      |
-| ----- | ------------------------------- |
-| RSC01 | 再送信の対象ではない                 |
-| RSC02 | 再送信の対象(送信結果が失敗の時、再送信が行われます。) |
-| RSC03 | 再送信中                    |
-| RSC04 | 再送信成功                  |
-| RSC05 | 再送信失敗                  |
-
 <a id="get-messages"></a>
 
 ### メッセージ単件照会

--- a/ja/alimtalk-api-guide-v2.1.md
+++ b/ja/alimtalk-api-guide-v2.1.md
@@ -467,15 +467,6 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
-#### SMS/LMS再送信ステータス
-| 値 | 説明                      |
-| ----- | ------------------------------- |
-| RSC01 | 再送信の対象ではない                 |
-| RSC02 | 再送信の対象(送信結果が失敗の時、再送信が行われます。) |
-| RSC03 | 再送信中                    |
-| RSC04 | 再送信成功                  |
-| RSC05 | 再送信失敗                  |
-
 <a id="get-messages"></a>
 
 ### メッセージ単件照会

--- a/ja/alimtalk-api-guide-v2.2.md
+++ b/ja/alimtalk-api-guide-v2.2.md
@@ -497,15 +497,6 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
-#### SMS/LMS再送信ステータス
-| 値 | 説明                      |
-| ----- | ------------------------------- |
-| RSC01 | 再送信の対象ではない                 |
-| RSC02 | 再送信の対象(送信結果が失敗の時、再送信が行われます。) |
-| RSC03 | 再送信中                    |
-| RSC04 | 再送信成功                  |
-| RSC05 | 再送信失敗                  |
-
 <a id="get-messages"></a>
 
 ### メッセージ単件照会

--- a/ja/alimtalk-api-guide.md
+++ b/ja/alimtalk-api-guide.md
@@ -885,50 +885,6 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","templateParameter":{"{日本語識別子フィールド}":"{置換データ}"}}]}'
 ```
 
-#### レスポンス
-
-```
-{
-  "header": {
-      "resultCode": Integer,
-      "resultMessage": String,
-      "isSuccessful": boolean
-  },
-  "messages": [
-    {
-      "requestId": String,
-      "recipientSeq": Integer,
-      "requestDate": String,
-      "createDate": String,
-      "receiveDate": String,
-      "resendStatus": String,
-      "resendStatusName": String,
-      "resendResultCode": String,
-      "resendRequestId": String,
-      "messageStatus": String,
-      "resultCode": String,
-      "resultCodeName": String
-    }
-  ]
-}
-```
-
-| 値                | タイプ | 説明    |
-| ----------------------- | ------- | ------------ |
-| header                  | Object  | ヘッダ領域 |
-| - resultCode            | Integer | 結果コード |
-| - resultMessage         | String  | 結果メッセージ |
-| - isSuccessful          | Boolean | 成否  |
-| message                 | Object  | 本文領域 |
-| - requestId             | String  | リクエストID        |
-| - senderGroupingKey     | String  | 発信グルーピングキー |
-| - sendResults           | Object  | 送信リクエスト結果 |
-| -- recipientSeq         | Integer | 受信者シーケンス番号 |
-| -- recipientNo          | String  | 受信番号 |
-| -- resultCode           | Integer | 送信リクエスト結果コード |
-| -- resultMessage        | String  | 送信リクエスト結果メッセージ |
-| -- recipientGroupingKey | String  | 受信者グルーピングキー |
-
 <a id="request-of-sending-full-text-2"></a>
 
 ### メッセージ全文送信リクエスト
@@ -1045,53 +1001,6 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/raw-messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","content":"{内容}","buttons":[{"ordering":"{ボタン順序}","type":"{ボタンタイプ}","name":"{ボタン名}","linkMo":"{モバイルWebリンク}"}]}]}'
 ```
 
-#### レスポンス
-
-```
-{
-  "header": {
-    "resultCode": Integer,
-    "resultMessage": String,
-    "isSuccessful": boolean
-  },
-  "body": {
-    "messages": [
-      {
-        "requestId": String,
-        "requestDate": String,
-        "plusFriendId": String,
-        "senderKey": String,
-        "templateCode": String,
-        "masterStatusCode": String,
-        "content": String,
-        "fileId": String,
-        "autoSendYn": String,
-        "statsId": String,
-        "createDate": String,
-        "createUser": String
-      }
-    ],
-    "totalCount": Integer
-  }
-}
-```
-
-| 値                | タイプ | 説明    |
-| ----------------------- | ------- | ------------ |
-| header                  | Object  | ヘッダ領域 |
-| - resultCode            | Integer | 結果コード |
-| - resultMessage         | String  | 結果メッセージ |
-| - isSuccessful          | Boolean | 成否  |
-| message                 | Object  | 本文領域 |
-| - requestId             | String  | リクエストID        |
-| - senderGroupingKey     | String  | 発信グルーピングキー |
-| - sendResults           | Object  | 送信リクエスト結果 |
-| -- recipientSeq         | Integer | 受信者シーケンス番号 |
-| -- recipientNo          | String  | 受信番号 |
-| -- resultCode           | Integer | 送信リクエスト結果コード |
-| -- resultMessage        | String  | 送信リクエスト結果メッセージ |
-| -- recipientGroupingKey | String  | 受信者グルーピングキー |
-
 <a id="list-messages-2"></a>
 
 ### メッセージリストの照会
@@ -1144,101 +1053,11 @@ Content-Type: application/json;charset=UTF-8
 * 90日以上前の送信リクエストデータは照会されません。
 * 送信リクエスト日時の範囲は最大30日です。
 
-#### レスポンス
-```
-{
-  "header" : {
-      "resultCode" :  Integer,
-      "resultMessage" :  String,
-      "isSuccessful" :  boolean
-  },
-  "messageSearchResultResponse" : {
-    "messages" : [
-    {
-      "requestId" :  String,
-      "recipientSeq" : Integer,
-      "plusFriendId" :  String,
-      "senderKey"    :  String,
-      "templateCode" :  String,
-      "recipientNo" :  String,
-      "content" :  String,
-      "requestDate" :  String,
-      "createDate" : String,
-      "receiveDate" : String,
-      "resendStatus" :  String,
-      "resendStatusName" :  String,
-      "messageStatus" :  String,
-      "resultCode" :  String,
-      "resultCodeName" : String,
-      "createUser" : String,
-      "buttons" : [
-        {
-          "ordering" :  Integer,
-          "type" :  String,
-          "name" :  String,
-          "linkMo" :  String,
-          "linkPc": String,
-          "schemeIos": String,
-          "schemeAndroid": String,
-          "chatExtra": String,
-          "chatEvent": String,
-          "target": String
-        }
-      ],
-      "senderGroupingKey": String,
-      "recipientGroupingKey": String
-    }
-    ],
-    "totalCount" :  Integer
-  }
-}
-```
-
-| 値                   | タイプ | 説明                               |
-| --------------------------- | ------- | ---------------------------------------- |
-| header                      | Object  | ヘッダ領域                            |
-| - resultCode                | Integer | 結果コード                            |
-| - resultMessage             | String  | 結果メッセージ                           |
-| - isSuccessful              | Boolean | 成否                             |
-| messageSearchResultResponse | Object  | 本文領域                            |
-| - messages                  | List    | メッセージリスト                           |
-| -- requestId                | String  | リクエストID                                    |
-| -- recipientSeq             | Integer | 受信者シーケンス番号                       |
-| -- plusFriendId             | String  | プラスフレンドID                                 |
-| -- senderKey                | String  | 発信キー                                  |
-| -- templateCode             | String  | テンプレートコード                           |
-| -- recipientNo              | String  | 受信番号                            |
-| -- content                  | String  | 本文                               |
-| -- requestDate              | String  | リクエスト日時                            |
-| -- createDate               | String  | 登録日時                            |
-| -- receiveDate              | String  | 受信日時                            |
-| -- resendStatus             | String  | 再送信ステータスコード                        |
-| -- resendStatusName         | String  | 再送信ステータスコード名                        |
-| -- messageStatus            | String  | リクエストステータス(COMPLETED -> 成功、FAILED -> 失敗、CANCEL -> キャンセル) |
-| -- resultCode               | String  | 受信結果コード                         |
-| -- resultCodeName           | String  | 受信結果コード名                         |
-| -- createUser               | String  | 登録者(コンソールから送信する場合、ユーザーUUIDとして保存)|
-| -- buttons                  | List    | ボタンリスト                            |
-| --- ordering                | Integer | ボタン順序                            |
-| --- type                    | String  | ボタンタイプ(WL：Webリンク、AL：アプリリンク、DS：配送照会、BK：Botキーワード、MD：メッセージ伝達、BC：相談トーク転換、BT：Bot転換、AC：チャンネル追加) |
-| --- name                    | String  | ボタン名                            |
-| --- linkMo                  | String  | モバイルWebリンク(WLタイプの場合は必須フィールド)                |
-| --- linkPc                  | String  | PC Webリンク(WLタイプの場合は任意フィールド)                 |
-| --- schemeIos               | String  | iOSアプリリンク(ALタイプの場合は必須フィールド)                |
-| --- schemeAndroid           | String  | Androidアプリリンク(ALタイプの場合は必須フィールド)            |
-| --- chatExtra               | String  | BC(相談トークに切替) / BT(Botに切替)タイプボタンの時、伝達するメタ情報 |
-| --- chatEvent               | String  | BT(Botに切替)タイプボタンの時、接続するBotイベント名 |
-| --- target                  | String  | Webリンクボタンの場合、 "target":"out"プロパティ追加時のアウトリンク<br>基本インアプリリンクで送信 |
-| -- senderGroupingKey        | String  | 発信グルーピングキー                            |
-| -- recipientGroupingKey     | String  | 受信者グルーピングキー                           |
-| - totalCount                | Integer | 総個数                              |
-
-[例]
-```
-curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
-```
+<a id="query-the-number-of-message-result-updates"></a>
 
 ### メッセージ結果アップデート件数の照会
+
+<a id="request-7"></a>
 
 #### リクエスト
 
@@ -1274,6 +1093,8 @@ Content-Type: application/json;charset=UTF-8
 | startUpdateDate     | 	String  | 	O  | 結果アップデート照会開始時間(yyyy-MM-dd HH:mm)  |
 | endUpdateDate       | 	String  | O   | 	結果アップデート照会終了時間(yyyy-MM-dd HH:mm) |
 | alimtalkMessageType | 	String  | X   | 	お知らせトークのメッセージタイプ(NORMAL, AUTH)           |
+
+<a id="response-8"></a>
 
 #### レスポンス
 

--- a/ja/friendtalkupgrade-api-guide.md
+++ b/ja/friendtalkupgrade-api-guide.md
@@ -1720,6 +1720,24 @@ Content-Type: application/json;charset=UTF-8
 | - resendRequestId     | String  | X        | 代替送信リクエストID                                                                                      | 
 | - createUser          | String  | X        | 登録者(コンソールから送信した場合、ユーザーUUIDで保存)                                                                      |
 
+<a id="message-results"></a>
+
+## メッセージ結果更新照会
+
+<!-- TODO: translate body -->
+
+<a id="requested-25"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="response-25"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
 <a id="cancel-message-sending"></a>
 
 ## メッセージ送信取消


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Body text is never modified.** The model only sees heading outlines; edits apply to heading lines (and `<!-- TODO: translate body -->` stubs for missing sections) only.

## Analysis

| | |
| --- | --- |
| Engine | `api (Anthropic SDK)` |
| Model | `claude-sonnet-4-6` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `alpha` |
| Scope | 5 doc(s) scanned · 8 file(s) changed |
| Self-verify | ⚠️ 16 mismatch(es) remain |
| Jenkins build | http://cd.cloud.toastoven.net:8080/job/content_deploy/job/align-heading/job/main/11/ |
| Generated | 2026-07-02T07:03:26 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`alpha`): [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FAlimtalk%2Ftree%2Falpha&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FAlimtalk%2Fpull%2F245&source=ko&langs=en%2Cja)

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra demoted | extra removed | verify |
| --- | --: | --: | --: | --: | --: | --: | --: | :--: |
| `en/alimtalk-api-guide-v2.0.md` | 0 | 0 | 0 | 0 | 0 | 0 | 1 | ⚠️ 1 |
| `ja/alimtalk-api-guide-v2.0.md` | 0 | 0 | 0 | 0 | 0 | 0 | 1 | ⚠️ 1 |
| `en/alimtalk-api-guide-v2.1.md` | 0 | 0 | 0 | 0 | 0 | 0 | 1 | ⚠️ 1 |
| `ja/alimtalk-api-guide-v2.1.md` | 0 | 0 | 0 | 0 | 0 | 0 | 1 | ⚠️ 1 |
| `ja/alimtalk-api-guide-v2.2.md` | 0 | 0 | 0 | 0 | 0 | 0 | 1 | ⚠️ 1 |
| `ja/alimtalk-api-guide.md` | 0 | 0 | 0 | 3 | 0 | 0 | 3 | ⚠️ 9 |
| `en/friendtalkupgrade-api-guide.md` | 0 | 3 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/friendtalkupgrade-api-guide.md` | 0 | 3 | 0 | 0 | 0 | 0 | 0 | ⚠️ 2 |

<details><summary>남은 불일치 (검토 필요)</summary>

- `en/alimtalk-api-guide-v2.0.md`:
  - extra_in_target (ko#None/en#22)
- `ja/alimtalk-api-guide-v2.0.md`:
  - extra_in_target (ko#None/ja#22)
- `en/alimtalk-api-guide-v2.1.md`:
  - extra_in_target (ko#None/en#22)
- `ja/alimtalk-api-guide-v2.1.md`:
  - extra_in_target (ko#None/ja#22)
- `ja/alimtalk-api-guide-v2.2.md`:
  - extra_in_target (ko#None/ja#22)
- `ja/alimtalk-api-guide.md`:
  - extra_in_target (ko#None/ja#14)
  - extra_in_target (ko#None/ja#21)
  - extra_in_target (ko#None/ja#22)
  - extra_in_target (ko#None/ja#23)
  - extra_in_target (ko#None/ja#24)
  - missing_in_target (ko#31/ja#None)
  - missing_in_target (ko#32/ja#None)
  - missing_in_target (ko#33/ja#None)
  - missing_in_target (ko#34/ja#None)
- `ja/friendtalkupgrade-api-guide.md`:
  - missing_in_target (ko#21/ja#None)
  - extra_in_target (ko#None/ja#22)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/Alimtalk`