### PR TITLE
chore(pre-align): align heading structure (5 docs) with ko

### DIFF
--- a/en/alimtalk-api-guide-v2.0.md
+++ b/en/alimtalk-api-guide-v2.0.md
@@ -1,3 +1,5 @@
+<!-- pre-align:aligned sig=6622ebb72190 -->
+
 ## Notification > KakaoTalk Bizmessage > AlimTalk > API v2.0 Guide
 
 <a id="alimtalk"></a>
@@ -472,15 +474,6 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
-#### Status of Sending SMS/LMS
-| Value | Description                                      |
-| ----- | ------------------------------------------------ |
-| RSC01 | No target of resending                           |
-| RSC02 | Target of resending(resent, if delivery fails.) |
-| RSC03 | Resending                                        |
-| RSC04 | Resending successful                             |
-| RSC05 | Resending failed                                 |
-
 <a id="get-messages"></a>
 
 ### Get Messages
@@ -910,6 +903,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 
 ### List Messages
 
+<a id="request-3"></a>
+
 #### Request
 
 [URL]
@@ -958,7 +953,7 @@ Content-Type: application/json;charset=UTF-8
 * Delivery request data before 90 days cannot be queried.
 * Delivery can be requested within 30 days to the maximum.   
 
-<a id="request-3"></a>
+<a id="response-7"></a>
 
 #### Response
 ```
@@ -1047,17 +1042,6 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/auth/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
-
-<a id="response-7"></a>
-
-#### Status of Resending SMS/LMS
-| Value | Description                                     |
-| ----- | ----------------------------------------------- |
-| RSC01 | No target of resending                          |
-| RSC02 | Target of resending(resent, if sending fails.) |
-| RSC03 | Resending                                       |
-| RSC04 | Resending successful                            |
-| RSC05 | Resending failed                                |
 
 <a id="get-messages-2"></a>
 

--- a/en/alimtalk-api-guide-v2.1.md
+++ b/en/alimtalk-api-guide-v2.1.md
@@ -1,3 +1,5 @@
+<!-- pre-align:aligned sig=59b3050f8882 -->
+
 ## Notification > KakaoTalk Bizmessage > AlimTalk > API v2.1 Guide
 
 <a id="alimtalk"></a>
@@ -470,15 +472,6 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
-#### Status of Sending SMS/LMS
-| Value | Description                                      |
-| ----- | ------------------------------------------------ |
-| RSC01 | No target of resending                           |
-| RSC02 | Target of resending(resent, if delivery fails.) |
-| RSC03 | Resending                                        |
-| RSC04 | Resending successful                             |
-| RSC05 | Resending failed                                 |
-
 <a id="get-messages"></a>
 
 ### Get Messages
@@ -908,6 +901,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 
 ### List Messages
 
+<a id="request-3"></a>
+
 #### Request
 
 [URL]
@@ -956,7 +951,7 @@ Content-Type: application/json;charset=UTF-8
 * Delivery request data before 90 days cannot be queried.
 * Delivery can be requested within 30 days to the maximum.   
 
-<a id="request-3"></a>
+<a id="response-7"></a>
 
 #### Response
 ```
@@ -1045,17 +1040,6 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/auth/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
-
-<a id="response-7"></a>
-
-#### Status of Resending SMS/LMS
-| Value | Description                                     |
-| ----- | ----------------------------------------------- |
-| RSC01 | No target of resending                          |
-| RSC02 | Target of resending(resent, if sending fails.) |
-| RSC03 | Resending                                       |
-| RSC04 | Resending successful                            |
-| RSC05 | Resending failed                                |
 
 <a id="get-messages-2"></a>
 

--- a/en/alimtalk-api-guide-v2.2.md
+++ b/en/alimtalk-api-guide-v2.2.md
@@ -1,3 +1,5 @@
+<!-- pre-align:aligned sig=ff88f5bc1ceb -->
+
 ## Notification > KakaoTalk Bizmessage > AlimTalk > API v2.2 Guide
 
 <a id="alimtalk"></a>

--- a/en/alimtalk-api-guide.md
+++ b/en/alimtalk-api-guide.md
@@ -24,8 +24,8 @@
 <a id="overview-of-v23-api"></a>
 
 ## Overview of v2.3 API
-1. Added Quick Reply, Item List, Talk Biz plugin, Main Link, and Business Form button.
 
+1. Added Quick Reply, Item List, Talk Biz plugin, Main Link, and Business Form button.
 2. Added the AlimTalk item highlight image registration API.
 3. Added APIs to register, modify, delete, and retrieve AlimTalk plugins.
 4. Removed the buttons field from the API to retrieve message list.
@@ -36,7 +36,7 @@
 
 <a id="request-of-sending-replaced-messages"></a>
 
-### Request of Sending Replaced Messages
+### Send Message with Replacement Variables
 
 [URL]
 
@@ -47,20 +47,22 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name |	Type|	Description|
-|---|---|---|
-|appkey|	String|	Unique appkey|
+| Name | Type | Description |
+|--------|---------|---------|
+| appkey | String | Unique app key |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|X-Secret-Key|	String| O | Can be created on console.   |
-|X-NC-API-IDEMPOTENCY-KEY|	String| X | Key used to recognize subsequent retries of the same request<br>If a request is made with the same key for 10 minutes, the request will be failed. |
+
+| Name | Type | Required | Description |
+|--------------------------|---------|-----|-----------------------------------------------------------------------------------------------|
+| X-Secret-Key | String | O | Can be created in the console. |
+| X-NC-API-IDEMPOTENCY-KEY | String | X | Key for deduplicating message send requests<br>If a request is made with the same key for 10 minutes, the request will be failed. |
 
 [Request body]
 
@@ -77,11 +79,11 @@ Content-Type: application/json;charset=UTF-8
             String: String
         },
         "resendParameter": {
-          "isResend" : boolean,
-          "resendType" : String,
-          "resendTitle" : String,
-          "resendContent" : String,
-          "resendSendNo" : String
+          "isResend": boolean,
+          "resendType": String,
+          "resendTitle": String,
+          "resendContent": String,
+          "resendSendNo": String
         },
         "buttons": [
           {
@@ -111,54 +113,55 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|senderKey|	String|	O | Sender key(40 characters) |
-|templateCode|	String|	O | Registered delivery template code(up to 20 characters) |
-|requestDate| String | X| Date and time of request(yyyy-MM-dd HH:mm)<br>(send immediately, if it is left blank)<br>Can be scheduled up to 60 days later |
-|senderGroupingKey| String | X| Sender's grouping key(up to 100 characters) |
-|createUser| String | X| Registrant(saved as user UUID when sending from console)|
-|recipientList|	List|	O|	List of recipients(up to 1000 persons) |
-|- recipientNo|	String|	O|	Recipient number(up to 15 characters) |
-|- templateParameter|	Object|	X|	Template parameter<br>(required, if it includes a variable to be replaced for template) |
-|-- key|	String|	X |	Replacement key(#{key})|
-|-- value| String |	X |	Value which is mapped for replacement key|
-|- resendParameter|	Object|	X| Alternative delivery information |
-|-- isResend|	boolean|	X|	Whether to resend text, if delivery fails<br>Resent by default, if alternative delivery is set on console. |
-|-- resendType|	String|	X|	Alternative delivery type(SMS,LMS)<br>Categorized by the length of template body if value is unavailable. |
-|-- resendTitle|	String|	X|	Title of alternative delivery for LMS<br>(resent with PlusFriend ID if value is unavailable.) |
-|-- resendContent|	String|	X|	Alternative delivery content<br>(resent with [Message body and web link button name - web link mobile link] if value is unavailable.) |
-|-- resendSendNo | String| X| Sender number for alternative delivery<br><span style="color:red">(Alternative delivery may fail, if the sender number is not registered on the SMS service.)</span> |
-|- buttons|	List|	X| Additional information for buttons |
-|-- ordering            | Integer  | X        |	Button sequence(required, if there is a button)|
-|-- chatExtra|	String|	X| Meta information to send for BC(Bot for Consultation) or BT(Bot Transfer) type buttons |
-|-- chatEvent|	String|	X| Bot event name to connect for BT(Bot Transfer) type button |
-|-- relayId|	String|	X| Value passed via the X-Kakao-Plugin-Relay-Id header when the plugin is executed |
-|-- oneClickId|	String|	X| Payment information used in the one click payment plugin |
-|-- productId|	String|	X| Payment information used in the one click payment plugin |
-|-- target|	String|	X |	In the case of a web link button, out link used when adding "target":"out" attribute<br>Send with the default in-app link |
-| -- telNumber           | 	String  | 	X  | When you press the TN (call) type button, the phone number to be transferred                                                                    |
-|- quickReplies|	List|	X| Quick reply information |
-|-- ordering            | Integer  | X        |	Quick reply order(required when quick reply exists)|
-|-- chatExtra|	String|	X| Meta information to send for BC(Bot for Consultation) or BT(Bot Transfer) type |
-|-- chatEvent|	String|	X| Bot event name to connect for BT(Bot Transfer) type |
-|-- target|	String|	X |	In the case of a web link type, out link used when adding "target":"out" attribute<br>Send with the default in-app link |
-|- recipientGroupingKey|	String|	X|	Recipient grouping key(up to 100 characters) |
-|messageOption | Object |	X | Message Option |
-|- price | Integer |	X | Price/amount/payment amount included in message(message to be delivered to user)(related to moment advertisement) |
-|- currencyType | String |	X| Use of international currency codes such as KRW, USD, EUR, which is the currency unit of the price/amount/payment amount included in the message(message to be delivered to the user)(related to moment advertisement) |
-| statsId | String |	X | Statistics ID(not included in the delivery search conditions, up to 8 characters) |
+| Name | Type | Required | Description |
+|------------------------|----------|-----|-----------------------------------------------------------------------------------------------|
+| senderKey | String | O | Sender Key (40 characters) |
+| templateCode | String | O | Registered delivery template code (up to 20 characters) |
+| requestDate | String | X | Request date/time (yyyy-MM-dd HH:mm)<br>(If not specified, sent immediately)<br>Can be scheduled up to 60 days in advance |
+| senderGroupingKey | String | X | Sender grouping key (up to 100 characters) |
+| createUser | String | X | Creator (stored as user UUID when sent from the console) |
+| recipientList | List | O | Recipient list (up to 1,000) |
+| - recipientNo | String | O | Recipient number (up to 15 characters) |
+| - templateParameter | Object | X | Template parameter<br>(Required if the template contains replacement variables) |
+| -- key | String | X | Replacement key (#{key}) |
+| -- value | String | X | Value mapped to the replacement key |
+| - resendParameter | Object | X | Alternative delivery information |
+| -- isResend | boolean | X | Whether to use SMS fallback on delivery failure<br>If alternative delivery is configured in the console, fallback is used by default. |
+| -- resendType | String | X | Alternative delivery type (SMS, LMS)<br>If no value is specified, the type is determined based on the template body length. |
+| -- resendTitle | String | X | LMS alternative delivery title<br>(If no value is specified, the Plus Friend ID is used instead.) |
+| -- resendContent | String | X | Alternative delivery content<br>(resent with [Message body and web link button name - web link mobile link] if value is unavailable.) |
+| -- resendSendNo | String | X | Alternative delivery sender number<br><span style="color:red">(Fallback may fail, if the sender number is not registered on the SMS service.)</span> |
+| - buttons | List | X | Additional button information |
+| -- ordering | Integer | X | Button order (required if buttons are present) |
+| -- chatExtra | String | X | Metadata to pass for BC (consultation chat switch) / BT (bot switch) type buttons |
+| -- chatEvent | String | X | Bot event name to connect for BT (bot switch) type buttons |
+| -- relayId | String | X | Value passed via the X-Kakao-Plugin-Relay-Id header when the plugin is executed |
+| -- oneClickId | String | X | Payment information used in the one-click payment plugin |
+| -- productId | String | X | Payment information used in the one-click payment plugin |
+| -- target | String | X | For web link buttons, adding "target":"out" attribute sets an outbound link<br>Sent as an in-app link by default |
+| -- telNumber | String | X | Phone number to pass for TN (call) type buttons |
+| - quickReplies | List | X | Quick Reply information |
+| -- ordering | Integer | X | Quick Reply order (required if quick replies are present) |
+| -- chatExtra | String | X | Metadata to pass for BC (consultation chat switch) / BT (bot switch) types |
+| -- chatEvent | String | X | Bot event name to connect for BT (bot switch) types |
+| -- target | String | X | For web link types, adding "target":"out" attribute sets an outbound link<br>Sent as an in-app link by default |
+| - recipientGroupingKey | String | X | Recipient grouping key (up to 100 characters) |
+| messageOption | Object | X | Message option |
+| - price | Integer | X | Price/amount/payment amount included in the message to be delivered to the user (related to moment advertisement) |
+| - currencyType | String | X | Use of international currency codes such as KRW, USD, EUR, which is the currency unit of the price/amount/payment amount included in the message (message to be delivered to the user) (related to moment advertisement) |
+| statsId | String | X | Statistics ID (not included in delivery search conditions, up to 8 characters) |
 
-* <b>Request date and time can be set up to 60 days since a point of calling.</b>
-* <b>Since alternative delivery is made in the SMS service, field values must follow the API specifications for SMS(e.g. Sender number registered at the SMS service, or restriction in the field length). </b>
-* <b>The SMS Service supports international SMS only. For international receiver numbers, the resendType(alternative delivery type) must be changed to SMS to allow sending without fail. </b>
-* <b>Title or content for alternative delivery that exceeds specified byte size may be cut for delivery.(see [[Caution](https://docs.toast.com/ko/Notification/SMS/ko/api-guide/#_1)] for reference)</b>
- * <b>If you add the `\s` character to the end of the templateTitle and templateItemHighlight.title fields with a substitution and templateParameter, you can apply the strikethrough style</b>
-     * <b>But, this does not apply if you pre-add \s to the fields when registering the template</b>.
+* <b>The request date/time can be set up to 60 days from the time of the call.</b>
+* <b>Since fallback is made in the SMS service, field values must follow the API specifications for SMS (e.g., Sender number registered at the SMS service, or restriction in the field length).</b>
+* <b>Fallback delivery is available via SMS and LMS. For international fallback, only SMS is supported. For international receiver numbers, the resendType (fallback type) must be changed to SMS to allow sending without fail.</b>
+* <b>A fallback title or content that exceeds the byte limit of the specified fallback type may be truncated. (See [[SMS notes](https://docs.toast.com/ko/Notification/SMS/ko/api-guide/#_1)].)</b>
+* <b>You can apply a strikethrough style by appending a `\s` character to the end of the templateTitle and templateItemHighlight.title fields using a replacement variable and templateParameter.</b>
+    * <b>However, this does not apply if `\s` is added to the field in advance when registering the template.</b>
 
 [Example]
+
 ```
-curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages -d '{"senderKey":"{outgoing key}","templateCode":"{template code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{incoming number}","templateParameter":{"{replacer field}":"{replacement data}"}}]}'
+curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages -d '{"senderKey":"{sender key}","templateCode":"{template code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{recipient number}","templateParameter":{"{replacement variable field}":"{replacement data}"}}]}'
 ```
 
 <a id="response"></a>
@@ -188,25 +191,25 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 }
 ```
 
-| Name |	Type|	Description|
-|---|---|---|
-|header|	Object|	Header area|
-|- resultCode|	Integer|	Result code|
-|- resultMessage|	String| Result message|
-|- isSuccessful|	Boolean| Successful or not|
-|message|	Object|	Body area|
-|- requestId | String |	Request ID |
-|- senderGroupingKey | String |	Sender's grouping key |
-|- sendResults | Object | Result of delivery request |
-|-- recipientSeq | Integer | Recipient sequence number |
-|-- recipientNo | String | Recipient number |
-|-- resultCode | Integer | Result code of delivery request |
-|-- resultMessage | String | Result message of delivery request |
-|-- recipientGroupingKey | String | Recipient's grouping key |
+| Name | Type | Not Null | Description |
+|-------------------------|---------|:--------:|--------------|
+| header | Object | O | Header area |
+| - resultCode | Integer | O | Result code |
+| - resultMessage | String | O | Result message |
+| - isSuccessful | Boolean | O | Success |
+| message | Object | X | Body area |
+| - requestId | String | X | Request ID |
+| - senderGroupingKey | String | X | Sender grouping key |
+| - sendResults | Object | O | Delivery request result |
+| -- recipientSeq | Integer | O | Recipient sequence number |
+| -- recipientNo | String | X | Recipient number |
+| -- resultCode | Integer | O | Delivery request result code |
+| -- resultMessage | String | O | Delivery request result message |
+| -- recipientGroupingKey | String | X | Recipient grouping key |
 
 <a id="request-of-sending-full-text"></a>
 
-### Request of Sending Full Text
+### Send Raw Message Request
 
 [URL]
 
@@ -215,21 +218,24 @@ POST  /alimtalk/v2.3/appkeys/{appkey}/raw-messages
 Content-Type: application/json;charset=UTF-8
 ```
 
-[Path Parameter]
+[Path parameter]
 
-| Name |	Type|	Description|
-|---|---|---|
-|appkey|	String|	Unique appkey|
+| Name     | 	Type     | 	Description     |
+|--------|---------|---------|
+| appkey | 	String | 	Unique app key |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|X-Secret-Key|	String| O | Can be created on console.   |
+
+| Name                       | 	Type     | 	Required | 	Description                                                        |
+|--------------------------|---------|-----|------------------------------------------------------------|
+| X-Secret-Key             | 	String | O   | Can be created in the console.                                           |
+| X-NC-API-IDEMPOTENCY-KEY | 	String | X   | Key used as the criterion for duplicate message sending requests<br>If a request is made with the same key for 10 minutes, the request will be failed. |
 
 [Request Body]
 
@@ -244,30 +250,30 @@ Content-Type: application/json;charset=UTF-8
         {
             "recipientNo": String,
             "content": String,
-            "templateTitle" : String,
-            "templateHeader" : String,
-            "templateItem" : {
-              "list" : [{
+            "templateTitle": String,
+            "templateHeader": String,
+            "templateItem": {
+              "list": [{
                 "title": String,
                 "description": String
               }],
-              "summary" : {
+              "summary": {
                 "title": String,
                 "description": String
               }
             },
-            "templateItemHighlight" : {
+            "templateItemHighlight": {
               "title": String,
               "description": String,
               "imageUrl": String
             },
-            "templateRepresentLink" : {
+            "templateRepresentLink": {
               "linkMo": String,
               "linkPc": String,
               "schemeIos": String,
               "schemeAndroid": String,
             },
-            "buttons" : [
+            "buttons": [
                 {
                     "ordering": Integer,
                     "type": String,
@@ -278,7 +284,7 @@ Content-Type: application/json;charset=UTF-8
                     "schemeAndroid": String,
                     "chatExtra": String,
                     "chatEvent": String,
-                    "bizFormId": String,
+                    "bizFormId": Integer,
                     "pluginId": String,
                     "relayId": String,
                     "oneClickId": String,
@@ -287,7 +293,7 @@ Content-Type: application/json;charset=UTF-8
                     "telNumber": String
                 }
             ],
-            "quickReplies" : [
+            "quickReplies": [
                 {
                     "ordering": Integer,
                     "type": String,
@@ -298,16 +304,16 @@ Content-Type: application/json;charset=UTF-8
                     "schemeAndroid": String,
                     "chatExtra": String,
                     "chatEvent": String,
-                    "bizFormId": String,
+                    "bizFormId": Integer,
                     "target": String
                 }
             ],
             "resendParameter": {
-              "isResend" : boolean,
-              "resendType" : String,
-              "resendTitle" : String,
-              "resendContent" : String,
-              "resendSendNo" : String
+              "isResend": boolean,
+              "resendType": String,
+              "resendTitle": String,
+              "resendContent": String,
+              "resendSendNo": String
             },
             "recipientGroupingKey": String
         }
@@ -320,82 +326,85 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|senderKey|	String|	O | Sender key(40 characters) |
-|templateCode|	String|	O | Registered delivery template code(up to 20 characters) |
-|requestDate| String | X| Date and time of request(yyyy-MM-dd HH:mm)<br>(send immediately, if it is left blank)<br>Can be scheduled up to 60 days later |
-|senderGroupingKey| String | X| Sender's grouping key(up to 100 characters) |
-|createUser| String | X| Registrant(saved as user UUID when sending from console)|
-|recipientList|	List|	O|	List of recipients(up to 1,000 persons) |
-|- recipientNo|	String|	O|	Recipient number(up to 15 characters) |
-|- content|	String|	O|	Message(up to 1,300 characters) |
-|- templateTitle| String| X| Title(up to 50 characters) |
-|- templateHeader| String| X| Template header(up to 16 characters) |
-|- templateItem | Object | X| Item |
-|-- list | List | X | Item list(at least 2, up to 10) |
-|--- title | String | X | Title(up to 6 characters) |
-|--- description | String | X | Description(up to 23 characters) |
-|-- summary | Object | X | Item summary information |
-|--- title | String | X | Title(up to 6 characters) |
-|--- description | String | X | Description(Only variables and monetary units, numbers, commas, and periods, up to 14 characters) |
-|- templateItemHighlight | Object | X| Item highlight |
-|--- title | String | X | Title(up to 30 characters, 21 characters with a thumbnail image) |
-|--- description | String | X | Description(up to 19 characters, 13 with a thumbnail image) |
-|--- imageUrl | String | X | Thumbnail image address |
-|- templateRepresentLink | Object | X| Main link |
-|-- linkMo| String |	X |	Mobile web link(up to 500 characters)|
-|-- linkPc | String |	X |PC web link(up to 500 characters) |
-|-- schemeIos | String | X |	iOS app link(up to 500 characters) |
-|-- schemeAndroid | String | X |	Android app link(up to 500 characters) |
-|- buttons|	List |	X | List of buttons(up to 5) |
-|-- ordering|	Integer|	X |	Button sequence(required, if there is a button)|
-|-- type| String |	X |	Button type(WL: Web link, AL: App link, DS: Delivery search, BK: Bot keyword, MD: Message delivery, BC: Bot for Consultation, BT: Bot Transfer, AC: Add channel, BF: Business form, P1: Image secure transmission plugin ID, P2: Personal information use plugin ID, P3: One-click payment plugin ID, TN: Call) |
-|-- name| String |	X |	Button name(required if there is a button, up to 14 characters)|
-|-- linkMo| String |	X |	Mobile web link(required for the WL type, up to 500 characters)|
-|-- linkPc | String |	X |PC web link(optional for the WL type, up to 500 characters) |
-|-- schemeIos | String | X |	iOS app link(required for the AL type, up to 500 characters) |
-|-- schemeAndroid | String | X |	Android app link(required for the AL type, up to 500 characters) |
-|-- chatExtra|	String|	X| Meta information to send for BC(Bot for Consultation) or BT(Bot Transfer) type buttons |
-|-- chatEvent|	String|	X| Bot event name to connect for BT(Bot Transfer) type button |
-|-- bizFormId|	Integer|	X |	Business form ID(required for BF type) |
-|-- pluginId|	String|	X |	Plugin ID(up to 24 characters) |
-|-- relayId|	String|	X| Value passed via the X-Kakao-Plugin-Relay-Id header when the plugin is executed |
-|-- oneClickId|	String|	X| Payment information used in the one click payment plugin |
-|-- productId|	String|	X| Payment information used in the one click payment plugin |
-|-- target|	String|	X |	In the case of a web link button, out link used when adding "target":"out" attribute<br>Send with the default in-app link |
-| -- telNumber           | 	String  | 	X  | When you press the TN (call) button, the phone number to be transferred                                                                    |
-|- quickReplies|	List |	X | Quick reply list(up to 5) |
-|-- ordering|	Integer|	X |	Quick reply order(required  when quick reply exists)|
-|-- type| String |	X |	Qucik reply type(WL: Web link, AL: App link, BK: Bot keyword, BC: Bot for Consultation, BT: Bot Transfer, BF: Business form) |
-|-- name| String |	X |	Quick reply name(required when quick reply exists, up to 14 characters)|
-|-- linkMo| String |	X |	Mobile web link(required for the WL type, up to 500 characters)|
-|-- linkPc | String |	X |PC web link(optional for the WL type, up to 500 characters) |
-|-- schemeIos | String | X |	iOS app link(required for the AL type, up to 500 characters) |
-|-- schemeAndroid | String | X |	Android app link(required for the AL type, up to 500 characters) |
-|-- pluginId|	String|	X |	Plugin ID(up to 24 characters) |
-|-- target|	String|	X |	In the case of a web link type, out link used when adding "target":"out" attribute<br>Send with the default in-app link |
-|- resendParameter|	Object|	X| Alternative delivery information |
-|-- isResend|	boolean|	X|	Whether to resend text, if delivery fails<br>Resent by default, if alternative delivery is set on console. |
-|-- resendType|	String|	X|	Alternative delivery type(SMS,LMS)<br>Categorized by the length of template message, if value is unavailable. |
-|-- resendTitle|	String|	X|	Title of alternative delivery for LMS<br>(resent with PlusFriend ID if value is unavailable.) |
-|-- resendContent|	String|	X|	Alternative delivery content<br>(resent with [Message body and web link button name - web link mobile link] if value is unavailable.) |
-|-- resendSendNo | String| X| Sender number for alternative delivery<br><span style="color:red">(Alternative delivery may fail, if the sender number is not registered on the SMS service.)</span> |
-|- recipientGroupingKey|	String|	X|	Recipient's grouping key(up to 100 characters) |
-| messageOption | Object |	X | Message Option |
-|- price | Integer |	X | Price/amount/payment amount included in message(message to be delivered to user)(related to moment advertisement) |
-|- currencyType | String |	X| Use of international currency codes such as KRW, USD, EUR, which is the currency unit of the price/amount/payment amount included in the message(message to be delivered to the user)(related to moment advertisement) |
-| statsId | String |	X | Statistics ID(not included in the delivery search conditions, up to 8 characters) |
+| Name                      | 	Type      | 	Required | 	Description                                                                                                                                                                        |
+|-------------------------|----------|-----|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| senderKey               | 	String  | 	O  | Sender Key (40 characters)                                                                                                                                                                  |
+| templateCode            | 	String  | 	O  | Registered template code for sending (up to 20 characters)                                                                                                                                                      |
+| requestDate             | String   | X   | Request date and time (yyyy-MM-dd HH:mm)<br>(If not entered, sent immediately)<br>Can be scheduled up to 60 days in advance                                                                                                         |
+| senderGroupingKey       | String   | X   | Sender grouping key (up to 100 characters)                                                                                                                                                          |
+| createUser              | String   | X   | Registrant (when sending from the console, saved as the user's UUID)                                                                                                                                                |
+| recipientList           | 	List    | 	O  | 	Recipient list (up to 1,000)                                                                                                                                                        |
+| - recipientNo           | 	String  | 	O  | 	Recipient number (up to 15 characters)                                                                                                                                              |
+| - content               | 	String  | 	O  | 	Content (up to 1,300 characters)                                                                                                                                              |
+| - templateTitle         | String   | X   | Title (up to 50 characters)                                                                                                                                                                 |
+| - templateHeader        | String   | X   | Template header (up to 16 characters)                                                                                                                                             |
+| - templateItem          | Object   | X   | Item                                                                                                                                                                        |
+| -- list                 | List     | X   | Item list (minimum 2, maximum 10)                                                                                                                                                     |
+| --- title               | String   | X   | Title (up to 6 characters)                                                                                                                                                                 |
+| --- description         | String   | X   | Description (up to 23 characters)                                                                                                                                              |
+| -- summary              | Object   | X   | Item summary information                                                                                                                                                                  |
+| --- title               | String   | X   | Title (up to 6 characters)                                                                                                                                                                 |
+| --- description         | String   | X   | Description (Only variables and monetary units, numbers, commas, and periods, up to 14 characters)                                                                                                                              |
+| - templateItemHighlight | Object   | X   | Item highlight                                                                                                                                                                  |
+| --- title               | String   | X   | Title (up to 30 characters, up to 21 characters if a thumbnail image is present)                                                                                                                                            |
+| --- description         | String   | X   | Description (up to 19 characters, up to 13 characters if a thumbnail image is present)                                                                                                                                          |
+| --- imageUrl            | String   | X   | Thumbnail image URL                                                                                                                                                                 |
+| - templateRepresentLink | Object   | X   | Representative link                                                                                                                                                                      |
+| -- linkMo               | String   | 	X  | 	Mobile web link (up to 500 characters)                                                                                                                                                         |
+| -- linkPc               | String   | 	X  | PC web link (up to 500 characters)                                                                                                                                           |
+| -- schemeIos            | String   | X   | 	iOS app link (up to 500 characters)                                                                                                                                                         |
+| -- schemeAndroid        | String   | X   | 	Android app link (up to 500 characters)                                                                                                                                                       |
+| - buttons               | 	List    | 	X  | Button list (up to 5)                                                                                                                                                              |
+| -- ordering             | 	Integer | 	X  | 	Button order (required if there are buttons)                                                                                                                                                       |
+| -- type                 | String   | 	X  | 	Button type (WL: Web link, AL: App link, DS: Delivery search, BK: Bot keyword, MD: Message delivery, BC: Bot for Consultation, BT: Bot Transfer, AC: Add channel, BF: Business form, P1: Image secure transmission plugin ID, P2: Personal information use plugin ID, P3: One-click payment plugin ID, TN: Call) |
+| -- name                 | String   | 	X  | 	Button name (required if there are buttons, up to 14 characters)                                                                                                                                               |
+| -- linkMo               | String   | 	X  | 	Mobile web link (required for the WL type, up to 500 characters)                                                                                                                                        |
+| -- linkPc               | String   | 	X  | PC web link (optional for the WL type, up to 500 characters)                                                                                                                                          |
+| -- schemeIos            | String   | X   | 	iOS app link (required for the AL type, up to 500 characters)                                                                                                                                        |
+| -- schemeAndroid        | String   | X   | 	Android app link (required for the AL type, up to 500 characters)                                                                                                                                      |
+| -- chatExtra            | 	String  | 	X  | Meta information to send for BC (Bot for Consultation) or BT (Bot Transfer) type buttons                                                                                                                                    |
+| -- chatEvent            | 	String  | 	X  | Bot event name to connect for BT (Bot Transfer) type buttons                                                                                                                               |
+| -- bizFormId            | 	Integer | 	X  | 	Business form ID (required for the BF type)                                                                                                                                                    |
+| -- pluginId             | 	String  | 	X  | 	Plugin ID (up to 24 characters)                                                                                                                                           |
+| -- relayId              | 	String  | 	X  | Value passed via the X-Kakao-Plugin-Relay-Id header when the plugin is executed                                                                                                                            |
+| -- oneClickId           | 	String  | 	X  | Payment information used in the one-click payment plugin                                                                                                                                                   |
+| -- productId            | 	String  | 	X  | Payment information used in the one-click payment plugin                                                                                                                                                   |
+| -- target               | 	String  | 	X  | 	For web link buttons, adding the "target":"out" attribute creates an outbound link<br>Sent as an in-app link by default                                                                                                                 |
+| -- telNumber           | 	String  | 	X  | Phone number to send for TN (Call) type buttons                                                                                                                                                   |
+| - quickReplies          | 	List    | 	X  | Quick Reply list (up to 5)                                                                                                                                                            |
+| -- ordering             | 	Integer | 	X  | 	Quick Reply order (required if Quick Reply is included)                                                                                                                                                   |
+| -- type                 | String   | 	X  | 	Quick reply type (WL: Web link, AL: App link, BK: Bot keyword, BC: Bot for Consultation, BT: Bot Transfer, BF: Business form)                                                                                                   |
+| -- name                 | String   | 	X  | 	Quick Reply name (required if Quick Reply is included, up to 14 characters)                                                                                                                           |
+| -- linkMo               | String   | 	X  | 	Mobile web link (required for the WL type, for up to 500 characters)                                                                                                                                        |
+| -- linkPc               | String   | 	X  | PC web link (optional for the WL type, up to 500 characters)                                                                                                                                          |
+| -- schemeIos            | String   | X   | 	iOS app link (required for the AL type, for up to 500 characters)                                                                                                                                        |
+| -- schemeAndroid        | String   | X   | 	Android app link (required for the AL type, for up to 500 characters)                                                                                                                                      |
+| -- bizFormId            | 	Integer | 	X  | 	Business form ID (required for the BF type)                                                                                                                                                    |
+| -- target               | 	String  | 	X  | 	For web link types, adding the "target":"out" attribute sets it to an out-link<br>Sent as an in-app link by default                                                                                                                 |
+| - resendParameter       | 	Object  | 	X  | Alternative Delivery information                                                                                                                                                                   |
+| -- isResend             | 	boolean | 	X  | 	Whether to send an alternative SMS when delivery fails<br>If alternative delivery is configured in the console, it is sent as the default.                                                                                                                   |
+| -- resendType           | 	String  | 	X  | 	Alternative delivery type (SMS, LMS)<br>Categorized by the length of template body, if value is unavailable.                                                                                                                   |
+| -- resendTitle          | 	String  | 	X  | 	LMS alternative delivery title<br>(Resent with the Plus Friend ID if value is unavailable.)                                                                                                                           |
+| -- resendContent        | 	String  | 	X  | 	Alternative delivery content<br>(resent with [Message body and web link button name - web link mobile link] if value is unavailable.)                                                                                                     |
+| -- resendSendNo         | String   | X   | Alternative delivery sender number<br><span style="color:red">(Fallback may fail, if the sender number is not registered on the SMS service.)</span>                                                                              |
+| - recipientGroupingKey  | 	String  | 	X  | 	Recipient grouping key (up to 100 characters)                                                                                                                                        |
+| messageOption           | Object   | 	X  | Message options                                                                                                                                                                     |
+| - price                 | Integer  | 	X  | Price/amount/payment amount included in the message to be delivered to the user (related to moment advertisement)                                                                                                                                |
+| - currencyType          | String   | 	X  | Use of international currency codes such as KRW, USD, EUR, which is the currency unit of the price/amount/payment amount included in the message (message to be delivered to the user) (related to moment advertisement)                                                                                             |
+| statsId                 | String   | 	X  | Statistics ID (not included in the delivery search conditions, up to 8 characters)                                                                                                                                         |
 
-* <b>Enter data completed with replacement for the body and button. </b>
-* <b>Request date and time can be set up to 60 days since a point of calling.</b>
-* <b>Since alternative delivery is made in the SMS service, field values must follow the API specifications for SMS(e.g. Sender number registered at the SMS service, or restriction in the field length). </b>
-* <b>The SMS Service supports international SMS only. For international receiver numbers, the resendType(alternative delivery type) must be changed to SMS to allow sending without fail. </b>
-* <b>Title or content for alternative delivery that exceeds specified byte size may be cut for delivery.(see [[Caution](https://docs.toast.com/ko/Notification/SMS/ko/api-guide/#_1)] for reference)</b>
+* <b>Enter data with all replacements completed in the body and buttons.</b>
+* <b>The request date and time can be set up to 60 days from the time of the call.</b>
+* <b>Since fallback is made in the SMS service, field values must follow the API specifications for SMS (e.g., Sender number registered at the SMS service, or restriction in the field length).</b>
+* <b>Alternative delivery can be sent via SMS or LMS. International alternative delivery supports SMS only. For international receiver numbers, the resendType (fallback type) must be changed to SMS to allow sending without fail.</b>
+* <b>Alternative delivery titles or content that exceed the byte limit of the specified alternative delivery type may be truncated. (See [[SMS Notes](https://docs.toast.com/ko/Notification/SMS/ko/api-guide/#_1)])</b>
+* <b>Adding the `\s` character at the end of the templateTitle and templateItemHighlight.title fields at the time of sending applies a strikethrough style.</b>
+    * <b>However, this does not apply if `\s` is added to the fields in advance when registering the template.</b>
 
 [Example]
+
 ```
-curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/raw-messages -d '{"senderKey":"{outgoing key}","templateCode":"{template code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{incoming number}","content":"{content}","buttons":[{"ordering":"{button sequence}","type":"{button type}","name":"{button name}","linkMo":"{mobile web link}"}]}]}'
+curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/raw-messages -d '{"senderKey":"{sender key}","templateCode":"{template code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{recipient number}","content":"{content}","buttons":[{"ordering":"{button order}","type":"{button type}","name":"{button name}","linkMo":"{mobile web link}"}]}]}'
 ```
 
 <a id="response-2"></a>
@@ -425,21 +434,21 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 }
 ```
 
-| Name |	Type|	Description|
-|---|---|---|
-|header|	Object|	Header area|
-|- resultCode|	Integer|	Result code|
-|- resultMessage|	String| Result message|
-|- isSuccessful|	Boolean| Successful or not|
-|message|	Object|	Body area|
-|- requestId | String |	Request ID |
-|- senderGroupingKey | String |	Sender's grouping key |
-|- sendResults | Object | Result of delivery request |
-|-- recipientSeq | Integer | Recipient sequence number |
-|-- recipientNo | String | Recipient number |
-|-- resultCode | Integer | Result code of delivery request |
-|-- resultMessage | String | Result message of delivery request |
-|-- recipientGroupingKey | String | Recipient's grouping key |
+| Name                    | Type    | Not Null | Description                          |
+|-------------------------|---------|:--------:|--------------------------------------|
+| header                  | Object  |    O     | Header area                          |
+| - resultCode            | Integer |    O     | Result code                          |
+| - resultMessage         | String  |    O     | Result message                       |
+| - isSuccessful          | Boolean |    O     | Success                              |
+| message                 | Object  |    X     | Body area                            |
+| - requestId             | String  |    X     | Request ID                           |
+| - senderGroupingKey     | String  |    X     | Sender grouping key                  |
+| - sendResults           | Object  |    O     | Delivery request result              |
+| -- recipientSeq         | Integer |    O     | Recipient sequence number            |
+| -- recipientNo          | String  |    X     | Recipient number                     |
+| -- resultCode           | Integer |    O     | Result code of delivery request      |
+| -- resultMessage        | String  |    O     | Result message of delivery request   |
+| -- recipientGroupingKey | String  |    X     | Recipient grouping key               |
 
 <a id="list-messages"></a>
 
@@ -458,117 +467,121 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name |	Typ|	Description|
-|---|---|---|
-|appkey|	String|	Unique appkey|
+| Name     | 	Type     | 	Description     |
+|--------|---------|---------|
+| appkey | 	String | 	Unique app key |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| Name |	Typ|	Required|	Description|
-|---|---|---|---|
-|X-Secret-Key|	String| O | Can be created on console.   |
 
-[Query parameter] No. 1 or(2, 3) is conditionally required
+| Name           | 	Type     | 	Required | 	Description              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | Can be created in the console. |
 
-| Name |	Typ|	Required|	Description|
-|---|---|---|---|
-|requestId|	String|	Conditionally required(no.1) | Request ID |
-|startRequestDate|	String|	Conditionally required(no.2) | Start date of delivery request(yyyy-MM-dd HH:mm)|
-|endRequestDate|	String| Conditionally required(no.2) |	End date of delivery request(yyyy-MM-dd HH:mm) |
-|startCreateDate|  String| Conditionally required(no.3) | Start date of registration(mm:HH dd-MM-yyyy)|
-|endCreateDate|  String| Conditionally required(no.3) | End date of registration(mm:HH dd-MM-yyyy) |
-|recipientNo|	String|	X |	Recipient number |
-|senderKey|	String|	X |	Sender Key |
-|templateCode|	String|	X |	Template code|
-|senderGroupingKey| String | X| Sender's grouping key |
-|recipientGroupingKey|	String|	X|	Recipient's grouping key |
-|messageStatus| String |	X | Request status(COMPLETED -> successful, FAILED -> failed, CANCEL -> cancelled )	|
-|resultCode| String |	X | Delivery result(MRC01 -> Successful, MRC02 ->Failed)	|
-|createUser| String | X| Registrant(saved as user UUID when sending from console)|
-|pageNum|	Integer|	X|	Page number(default: 1)|
-|pageSize|	Integer|	X|	Number of queries(default: 15, Max: 1000)|
+[Query parameter] No.1 or (No.2, No.3) is conditionally required
 
-* Cannot query data requested for delivery which are dated before 90 days.
-* The maximum available days for delivery request is 30 days.
+| Name                   | 	Type      | 	Required        | 	Description                                                   |
+|----------------------|----------|------------|-------------------------------------------------------|
+| requestId            | 	String  | 	Conditionally required (No.1) | Request ID                                                |
+| startRequestDate     | 	String  | 	Conditionally required (No.2) | Start date of delivery request (yyyy-MM-dd HH:mm)                       |
+| endRequestDate       | 	String  | Conditionally required (No.2)  | 	End date of delivery request (yyyy-MM-dd HH:mm)                       |
+| startCreateDate      | String   | Conditionally required (No.3)  | Start date of registration (yyyy-MM-dd HH:mm)                           |
+| endCreateDate        | String   | Conditionally required (No.3)  | End date of registration (yyyy-MM-dd HH:mm)                            |
+| recipientNo          | 	String  | 	X         | 	Recipient number                                                 |
+| senderKey            | 	String  | 	X         | 	Sender Key                                                 |
+| templateCode         | 	String  | 	X         | 	Template Code                                               |
+| senderGroupingKey    | String   | X          | Sender grouping key                                              |
+| recipientGroupingKey | 	String  | 	X         | 	Recipient grouping key                                            |
+| messageStatus        | String   | 	X         | Request status (COMPLETED -> successful, FAILED -> failed, CANCEL -> canceled)	 |
+| resultCode           | String   | 	X         | Delivery result (MRC01 -> successful, MRC02 -> failed)	                     |
+| createUser           | String   | X          | Registrant (saved as user UUID when sending from console)                           |
+| pageNum              | 	Integer | 	X         | 	Page number (Default: 1)                                   |
+| pageSize             | 	Integer | 	X         | 	Number of records to retrieve (Default: 15, Max: 1,000)                        |
+
+* Delivery request data before 90 days cannot be queried.
+* The delivery request period range is up to 30 days.
 
 <a id="response-3"></a>
 
 #### Response
+
 ```
 {
-  "header" : {
-      "resultCode" :  Integer,
-      "resultMessage" :  String,
-      "isSuccessful" :  boolean
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
   },
-  "messageSearchResultResponse" : {
-    "messages" : [
+  "messageSearchResultResponse": {
+    "messages": [
     {
-      "requestId" :  String,
-      "recipientSeq" : Integer,
-      "plusFriendId" :  String,
-      "senderKey" : String,
-      "templateCode" :  String,
-      "recipientNo" :  String,
-      "content" :  String,
-      "requestDate" :  String,
-      "createDate" : String,
-      "receiveDate" : String,
-      "resendStatus" :  String,
-      "resendStatusName" :  String,
-      "messageStatus" :  String,
-      "resultCode" :  String,
-      "resultCodeName" : String,
-      "createUser" : String,
+      "requestId": String,
+      "recipientSeq": Integer,
+      "plusFriendId": String,
+      "senderKey": String,
+      "templateCode": String,
+      "recipientNo": String,
+      "content": String,
+      "requestDate": String,
+      "createDate": String,
+      "receiveDate": String,
+      "resendStatus": String,
+      "resendStatusName": String,
+      "messageStatus": String,
+      "resultCode": String,
+      "resultCodeName": String,
+      "createUser": String,
       "senderGroupingKey": String,
       "recipientGroupingKey": String
     }
     ],
-    "totalCount" :  Integer
+    "totalCount": Integer
   }
 }
 ```
 
-| Name |	Type|	Description|
-|---|---|---|
-|header|	Object|	Header area|
-|- resultCode|	Integer|	Result code|
-|- resultMessage|	String| Result message|
-|- isSuccessful|	Boolean| Successful or not|
-|messageSearchResultResponse|	Object|	Body area|
-|- messages | List |	List of messages |
-|-- requestId | String |	Request ID |
-|-- recipientSeq | Integer |	Recipient sequence number |
-|-- plusFriendId | String |	PlusFriend ID |
-|-- senderKey    | String | Sender Key    |
-|-- templateCode | String |	Template code |
-|-- recipientNo | String |	Recipient number |
-|-- content | String |	Body message |
-|-- requestDate | String |	Date and time of request |
-|-- createDate | String | Registered date and time |
-|-- receiveDate | String |	Date and time of receiving |
-|-- resendStatus | String |	Status code of resending(RSC01, RSC02, RSC03, RSC04, RSC05)<br>([Refer to [Status code of resending table](http://docs.toast.com/en/Notification/KakaoTalk%20Bizmessage/en/alimtalk-api-guide/#smslms)] below) |
-|-- resendStatusName | String |	Status code name of resending |
-|-- messageStatus | String |	Request status(COMPLETED -> successful, FAILED -> failed, CANCEL -> cancelled ) |
-|-- createUser | String | Registrant(saved as user UUID when sending from console) |
-|-- resultCode | String |	Result code of receiving |
-|-- resultCodeName | String |	Result code name of receiving |
-|-- senderGroupingKey | String | Sender's grouping key |
-|-- recipientGroupingKey | String |	Recipient grouping key |
-|- totalCount | Integer | Total Count |
+| Name                          | Type      | Not Null | Description                                                                                                                                                                     |
+|-----------------------------|---------|:--------:|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| header                      | Object  |    O     | Header area                                                                                                                                                                  |
+| - resultCode                | Integer |    O     | Result code                                                                                                                                                                  |
+| - resultMessage             | String  |    O     | Result message                                                                                                                                                                 |
+| - isSuccessful              | Boolean |    O     | Success                                                                                                                                                                  |
+| messageSearchResultResponse | Object  |    X     | Body area                                                                                                                                                                  |
+| - messages                  | List    |    O     | Message list                                                                                                                                                                |
+| -- requestId                | String  |    O     | Request ID                                                                                                                                                                 |
+| -- recipientSeq             | Integer |    O     | Recipient sequence number                                                                                                                                             |
+| -- plusFriendId             | String  |    O     | PlusFriend ID                                                                                                                                               |
+| -- senderKey                | String  |    O     | Sender Key                                                                                                                                                                   |
+| -- templateCode             | String  |    O     | Template Code                                                                                                                                                                 |
+| -- recipientNo              | String  |    O     | Recipient number                                                                                                                                                                  |
+| -- content                  | String  |    X     | Body                                                                                                                                                                     |
+| -- requestDate              | String  |    O     | Request date and time                                                                                                                                                                  |
+| -- createDate               | String  |    O     | Registration date and time                                                                                                                                                  |
+| -- receiveDate              | String  |    X     | Received date and time                                                                                                                                                  |
+| -- resendStatus             | String  |    O     | Status code of resending (RSC01, RSC02, RSC03, RSC04, RSC05)\<br\>(See the [[resending status table below](http://docs.toast.com/ko/Notification/KakaoTalk%20Bizmessage/ko/alimtalk-api-guide/#smslms)]) |
+| -- resendStatusName         | String  |    O     | Status code name of resending                                                                                                                                           |
+| -- messageStatus            | String  |    O     | Request status (COMPLETED -> successful, FAILED -> failed, CANCEL -> canceled)                                                                                                                                |
+| -- createUser               | String  |    X     | Registrant (saved as user UUID when sending from console)                                                                                                                                            |
+| -- resultCode               | String  |    X     | Recipient result code                                                                                                                                               |
+| -- resultCodeName           | String  |    X     | Recipient result code name                                                                                                                                              |
+| -- senderGroupingKey        | String  |    X     | Sender grouping key                                                                                                                                               |
+| -- recipientGroupingKey     | String  |    X     | Recipient grouping key                                                                                                                                              |
+| - totalCount                | Integer |    X     | Total count                                                                                                                                                                    |
 
 [Example]
+
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
 <a id="get-messages"></a>
 
-### Get Messages
+### Get Message
 
 <a id="request-2"></a>
 
@@ -583,23 +596,26 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name |	Type|	Description|
-|---|---|---|
-|appkey|	String|	Unique appkey |
-|requestId|	String|	Request ID |
-|recipientSeq|	Integer|	Recipient sequence number |
+| Name           | 	Type      | 	Description              |
+|--------------|----------|-------------|
+| appkey       | 	String  | 	Unique app key     |
+| requestId    | 	String  | 	Request ID     |
+| recipientSeq | 	Integer | 	Recipient sequence number |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|X-Secret-Key|	String| O | Can be created on console.   |
+
+| Name           | 	Type     | 	Required | 	Description              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | Can be created in the console. |
 
 [Example]
+
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}/{recipientSeq}"
 ```
@@ -607,79 +623,60 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 <a id="response-4"></a>
 
 #### Response
+
 ```
 {
-  "header" : {
-      "resultCode" :  Integer,
-      "resultMessage" :  String,
-      "isSuccessful" :  boolean
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
   },
-  "message" : {
-      "requestId" :  String,
-      "recipientSeq" : Integer,
-      "plusFriendId" :  String,
-      "senderKey" : String,
-      "templateCode" :  String,
-      "recipientNo" :  String,
-      "content" :  String,
-      "templateTitle" : String,
-      "templateSubtitle" : String,
-      "templateExtra" : String,
-      "templateAd" : String,
-      "templateHeader" : String,
-      "templateItem" : {
-        "list" : [{
+  "message": {
+      "requestId": String,
+      "recipientSeq": Integer,
+      "plusFriendId": String,
+      "senderKey": String,
+      "templateCode": String,
+      "recipientNo": String,
+      "content": String,
+      "templateTitle": String,
+      "templateSubtitle": String,
+      "templateExtra": String,
+      "templateAd": String,
+      "templateHeader": String,
+      "templateItem": {
+        "list": [{
           "title": String,
           "description": String
         }],
-        "summary" : {
+        "summary": {
           "title": String,
           "description": String
         }
       },
-      "templateItemHighlight" : {
+      "templateItemHighlight": {
         "title": String,
         "description": String,
         "imageUrl": String
       },
-      "templateRepresentLink" : {
+      "templateRepresentLink": {
         "linkMo": String,
         "linkPc": String,
         "schemeIos": String,
         "schemeAndroid": String,
       },
-      "requestDate" :  String,
-      "receiveDate" : String,
-      "createDate" : String,
-      "resendStatus" :  String,
-      "resendStatusName" :  String,
-      "resendResultCode" : String,
-      "resendRequestId" : String,
-      "messageStatus" :  String,
-      "resultCode" :  String,
-      "resultCodeName" : String,
-      "createUser" : String,
-      "buttons" : [
-        {
-          "ordering" :  Integer,
-          "type" :  String,
-          "name" :  String,
-          "linkMo" :  String,
-          "linkPc": String,
-          "schemeIos": String,
-          "schemeAndroid": String,
-          "chatExtra": String,
-          "chatEvent": String,
-          "bizFormId": String,
-          "pluginId": String,
-          "relayId": String,
-          "oneClickId": String,
-          "productId": String,
-          "target": String,
-          "telNumber": String
-        }
-      ],
-      "quickReplies" : [
+      "requestDate": String,
+      "receiveDate": String,
+      "createDate": String,
+      "resendStatus": String,
+      "resendStatusName": String,
+      "resendResultCode": String,
+      "resendRequestId": String,
+      "messageStatus": String,
+      "resultCode": String,
+      "resultCodeName": String,
+      "createUser": String,
+      "buttons": [
         {
           "ordering": Integer,
           "type": String,
@@ -690,7 +687,27 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
           "schemeAndroid": String,
           "chatExtra": String,
           "chatEvent": String,
-          "bizFormId": String,
+          "bizFormId": Integer,
+          "pluginId": String,
+          "relayId": String,
+          "oneClickId": String,
+          "productId": String,
+          "target": String,
+          "telNumber": String
+        }
+      ],
+      "quickReplies": [
+        {
+          "ordering": Integer,
+          "type": String,
+          "name": String,
+          "linkMo": String,
+          "linkPc": String,
+          "schemeIos": String,
+          "schemeAndroid": String,
+          "chatExtra": String,
+          "chatEvent": String,
+          "bizFormId": Integer,
           "target": String
           }
       ],
@@ -704,103 +721,105 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 }
 ```
 
-| Name |	Type| 	Description                                                                                                                                                                                                       |
-|---|---|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|header|	Object| 	Header area                                                                                                                                                                                                       |
-|- resultCode|	Integer| 	Result code                                                                                                                                                                                                       |
-|- resultMessage|	String| Result message                                                                                                                                                                                                     |
-|- isSuccessful|	Boolean| Successful or not                                                                                                                                                                                                  |
-|message|	Object| 	Message                                                                                                                                                                                                           |
-|- requestId | String | 	Request ID                                                                                                                                                                                                        |
-|- recipientSeq | Integer | 	Recipient sequence number                                                                                                                                                                                         |
-|- plusFriendId | String | 	PlusFriend ID                                                                                                                                                                                                     |
-|- senderKey    | String | Sender Key                                                                                                                                                                                                         |
-|- templateCode | String | 	Template code                                                                                                                                                                                                     |
-|- recipientNo | String | 	Recipient number                                                                                                                                                                                                  |
-|- content | String | 	Body message                                                                                                                                                                                                      |
-|- templateTitle | String | Template title                                                                                                                                                                                                     |
-|- templateSubtitle | String | Auxiliary template phrase                                                                                                                                                                                          |
-|- templateExtra | String | Additional template information                                                                                                                                                                                    |
-|- templateAd | String | Request for consent of receiving within template or simple ad phrases                                                                                                                                              |
-|- templateHeader| String| Template header(up to 16 characters)                                                                                                                                                                               |
-|- templateItem | Object | Item                                                                                                                                                                                                               |
-|-- list | List | Item list(at least 2, up to 10)                                                                                                                                                                                    |
-|--- title | String | Title(up to 6 characters)                                                                                                                                                                                          |
-|--- description | String | Description(up to 23 characters)                                                                                                                                                                                   |
-|-- summary | Object | Item summary information                                                                                                                                                                                           |
-|--- title | String | Title(up to 6 characters)                                                                                                                                                                                          |
-|--- description | String | Description(Only variables and monetary units, numbers, commas, and periods, up to 14 characters)                                                                                                                  |
-|- templateItemHighlight | Object | Item highlight                                                                                                                                                                                                     |
-|--- title | String | Title(up to 30 characters, 21 characters with a thumbnail image)                                                                                                                                                   |
-|--- description | String | Description(up to 19 characters, 13 with a thumbnail image)                                                                                                                                                        |
-|--- imageUrl | String | Thumbnail image address                                                                                                                                                                                            |
-|- templateRepresentLink | Object | Main link                                                                                                                                                                                                          |
-|-- linkMo| String | 	Mobile web link(up to 500 characters)                                                                                                                                                                             |
-|-- linkPc | String | PC web link(up to 500 characters)                                                                                                                                                                                  |
-|-- schemeIos | String | 	iOS app link(up to 500 characters) |
-|-- schemeAndroid | String | 	Android app link(up to 500 characters) |
-|- requestDate | String | 	Date and time of request                                                                                                                                                                                          |
-|- receiveDate | String | 	Date and time of receiving                                                                                                                                                                                        |
-|- createDate | String | Registered date and time                                                                                                                                                                                           |
-|- resendStatus | String | 	Status code of resending(RSC01, RSC02, RSC03, RSC04, RSC05)<br>([Refer to [Status code of resending table](http://docs.toast.com/en/Notification/KakaoTalk%20Bizmessage/en/alimtalk-api-guide/#smslms)] below)    |
-|- resendStatusName | String | 	Status code name of resending                                                                                                                                                                                     |
-|- resendResultCode | String | Result code of resending [Result code of SMS sending](https://docs.toast.com/en/Notification/SMS/en/error-code/#api)                                                                                               |
-|- resendRequestId | String | Resending SMS request ID                                                                                                                                                                                           |
-|- messageStatus | String | 	Request status(COMPLETED -> successful, FAILED -> failed, CANCEL -> cancelled )                                                                                                                                   |
-|- resultCode | String | 	Result code of receiving                                                                                                                                                                                          |
-|- resultCodeName | String | 	Result code name of receiving                                                                                                                                                                                     |
-|- createUser | String | Registrant(saved as user UUID when sending from console)                                                                                                                                                           |
-|- buttons | List | 	List of buttons                                                                                                                                                                                                   |
-|-- ordering | Integer | 	Button sequence                                                                                                                                                                                                   |
-|-- type| String |	Button type(WL: Web link, AL: App link, DS: Delivery search, BK: Bot keyword, MD: Message delivery, BC: Bot for Consultation, BT: Bot Transfer, AC: Add channel, BF: Business form, P1: Image secure transmission plugin ID, P2: Personal information use plugin ID, P3: One-click payment plugin ID, TN: Call) |
-|-- name | String | 	Button name                                                                                                                                                                                                       |
-|-- linkMo | String | 	Mobile web link(required for the WL type)                                                                                                                                                                         |
-|-- linkPc | String | 	PC web link(optional for the WL type)                                                                                                                                                                             |
-|-- schemeIos | String | 	iOS app link(required for the AL type)                                                                                                                                                                            |
-|-- schemeAndroid | String | 	Android app link(required for the AL type)                                                                                                                                                                        |
-|-- chatExtra|	String| 	Meta information to send for BC(Bot for Consultation) or BT(Bot Transfer) type buttons                                                                                                                            |
-|-- chatEvent|	String| Bot event name to connect for BT(Bot Transfer) type button                                                                                                                                                         |
-|-- bizFormId|	Integer|	Business form ID(required for BF type) |
-|-- pluginId|	String| 	Plugin ID(up to 24 characters) |
-|-- relayId|	String|  Value passed via the X-Kakao-Plugin-Relay-Id header when the plugin is executed |
-|-- oneClickId|	String| 	 Payment information used in the one click payment plugin |
-|-- productId|	String| 	 Payment information used in the one click payment plugin |
-|-- target|	String| 	In the case of a web link button, out link used when adding "target":"out" attribute<br>Send with the default in-app link                                                                                         |
-|- quickReplies|	List | 	 Quick reply list(up to 5) |
-|-- ordering|	Integer| 	Quick reply order(required  when quick reply exists)|
-|-- type| String |	Qucik reply type(WL: Web link, AL: App link, BK: Bot keyword, BC: Bot for Consultation, BT: Bot Transfer, BF: Business form) |
-|-- name| String |	Quick reply name(required  when quick reply exists, up to 14 characters)|
-|-- linkMo| String | 	Mobile web link(required for the WL type, for up to 500 characters)|
-|-- linkPc | String | 	PC web link(required for the WL type, for up to 500 characters) |
-|-- schemeIos | String |	iOS app link(required for the AL type, for up to 500 characters) |
-|-- schemeAndroid | String |	Android app link(required for the AL type, for up to 500 characters) |
-|-- pluginId|	String| 	Plugin ID(up to 24 characters) |
-|-- target|	String| 	In the case of a web link type, out link used when adding "target":"out" attribute<br>Send with the default in-app link |
-| -- telNumber           | 	String  | 	X  | When you press the TN (call) button, the phone number to be transferred                                                                   |
-|- messageOption | Object | 	Message Option                                                                                                                                                                                                    |
-|-- price | Integer | 	Price/amount/payment amount included in message(message to be delivered to user)(related to moment advertisement)                                                                                                 |
-|-- currencyType | String | 	Use of international currency codes such as KRW, USD, EUR, which is the currency unit of the price/amount/payment amount included in the message(message to be delivered to the user)(related to moment advertisement) |
-|- senderGroupingKey | String | Sender's grouping key                                                                                                                                                                                              |
-|- recipientGroupingKey | String | 	Recipient's grouping key                                                                                                                                                                                          |
+-----
+
+| Name                    | Type    | Not Null | Description                                                                                                                                                                                   |
+|-------------------------|---------|:--------:|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| header                  | Object  |    O     | Header area                                                                                                                                                                                   |
+| - resultCode            | Integer |    O     | Result code                                                                                                                                                                                   |
+| - resultMessage         | String  |    O     | Result message                                                                                                                                                                                |
+| - isSuccessful          | Boolean |    O     | Success                                                                                                                                                                                       |
+| message                 | Object  |    X     | Message                                                                                                                                                                                       |
+| - requestId             | String  |    O     | Request ID                                                                                                                                                                                    |
+| - recipientSeq          | Integer |    O     | Recipient sequence number                                                                                                                                                                     |
+| - plusFriendId          | String  |    O     | PlusFriend ID                                                                                                                                                                                 |
+| - senderKey             | String  |    O     | Sender Key                                                                                                                                                                                    |
+| - templateCode          | String  |    O     | Template Code                                                                                                                                                                                 |
+| - recipientNo           | String  |    X     | Recipient Number                                                                                                                                                                              |
+| - content               | String  |    X     | Body                                                                                                                                                                                          |
+| - templateTitle         | String  |    X     | Template title                                                                                                                                                                                |
+| - templateSubtitle      | String  |    X     | Template subtitle                                                                                                                                                                             |
+| - templateExtra         | String  |    X     | Template additional content                                                                                                                                                                   |
+| - templateAd            | String  |    X     | Request for consent of receiving within template or simple ad phrases                                                                                                                         |
+| - templateHeader        | String  |    X     | Template header (up to 16 characters)                                                                                                                                                         |
+| - templateItem          | Object  |    X     | Item                                                                                                                                                                                          |
+| -- list                 | List    |    X     | Item list (at least 2, up to 10)                                                                                                                                                              |
+| --- title               | String  |    X     | Title (up to 6 characters)                                                                                                                                                                    |
+| --- description         | String  |    X     | Description (up to 23 characters)                                                                                                                                                             |
+| -- summary              | Object  |    X     | Item summary information                                                                                                                                                                      |
+| --- title               | String  |    X     | Title (up to 6 characters)                                                                                                                                                                    |
+| --- description         | String  |    X     | Description (Only variables and monetary units, numbers, commas, and periods, up to 14 characters)                                                                                            |
+| - templateItemHighlight | Object  |    X     | Item highlight                                                                                                                                                                                |
+| --- title               | String  |    X     | Title (up to 30 characters, 21 characters with a thumbnail image)                                                                                                                             |
+| --- description         | String  |    X     | Description (up to 19 characters, 13 characters with a thumbnail image)                                                                                                                       |
+| --- imageUrl            | String  |    X     | Thumbnail image URL                                                                                                                                                                           |
+| - templateRepresentLink | Object  |    X     | Representative link                                                                                                                                                                           |
+| -- linkMo               | String  |    X     | Mobile web link (up to 500 characters)                                                                                                                                                        |
+| -- linkPc               | String  |    X     | PC web link (up to 500 characters)                                                                                                                                                            |
+| -- schemeIos            | String  |    X     | iOS app link (up to 500 characters)                                                                                                                                                           |
+| -- schemeAndroid        | String  |    X     | Android app link (up to 500 characters)                                                                                                                                                       |
+| - requestDate           | String  |    O     | Request date and time                                                                                                                                                                         |
+| - receiveDate           | String  |    X     | Received date and time                                                                                                                                                                        |
+| - createDate            | String  |    O     | Registration date and time                                                                                                                                                                    |
+| - resendStatus          | String  |    O     | Status code of resending (RSC01, RSC02, RSC03, RSC04, RSC05)\<br\>([[resending status table below](http://docs.toast.com/ko/Notification/KakaoTalk%20Bizmessage/ko/alimtalk-api-guide/#smslms)] See) |
+| - resendStatusName      | String  |    O     | Name of the resending status code                                                                                                                                                             |
+| - resendResultCode      | String  |    X     | Resending result code [SMS result code](https://docs.toast.com/ko/Notification/SMS/ko/error-code/#api)                                                                                        |
+| - resendRequestId       | String  |    X     | Resending SMS request ID                                                                                                                                                                      |
+| - messageStatus         | String  |    O     | Request status (COMPLETED -> successful, FAILED -> failed, CANCEL -> canceled)                                                                                                                |
+| - resultCode            | String  |    X     | Received result code                                                                                                                                                                          |
+| - resultCodeName        | String  |    X     | Received result code name                                                                                                                                                                     |
+| - createUser            | String  |    X     | Creator (saved as user UUID when sent from the console)                                                                                                                                            |
+| - buttons               | List    |    X     | Button list                                                                                                                                                                 |
+| -- ordering             | Integer |    X     | Button order                                                                                                                                                                  |
+| -- type                 | String  |    X     | Button type (WL: Web Link, AL: App Link, DS: Delivery Search, BK: Bot Keyword, MD: Message Delivery, BC: Bot for Consultation, BT: Bot Transfer, AC: Add Channel, BF: Business Form, P1: Image secure transmission plugin ID, P2: Personal information use plugin ID, P3: One-click payment plugin ID, TN: Call) |
+| -- name                 | String  |    X     | Button name                                                                                                                                                                  |
+| -- linkMo               | String  |    X     | Mobile web link (required for the WL type)                                                                                                                                              |
+| -- linkPc               | String  |    X     | PC web link (optional for the WL type)                                                                                                                                               |
+| -- schemeIos            | String  |    X     | iOS app link (required for the AL type)                                                                                                                                              |
+| -- schemeAndroid        | String  |    X     | Android app link (required for the AL type)                                                                                                                                            |
+| -- chatExtra            | String  |    X     | Meta information to send for BC (Bot for Consultation) or BT (Bot Transfer) type buttons                                                                                                                                |
+| -- chatEvent            | String  |    X     | Bot event name to connect for BT (Bot Transfer) type buttons                                                                                                                                           |
+| -- bizFormId            | Integer |    X     | Business form ID (required for the BF type)                                                                                                                                                 |
+| -- pluginId             | String  |    X     | Plugin ID (up to 24 characters)                                                                                                                                                        |
+| -- relayId              | String  |    X     | Value passed via the X-Kakao-Plugin-Relay-Id header when the plugin is executed                                                                                                                        |
+| -- oneClickId           | String  |    X     | Payment information used by the one-click payment plugin                                                                                                                               |
+| -- productId            | String  |    X     | Payment information used by the one-click payment plugin                                                                                                                               |
+| -- target               | String  |    X     | For web link buttons, adding the "target":"out" attribute sets it to an out-link\<br\>Sent as an in-app link by default                                                                                                            |
+| - quickReplies          | List    |    X     | Quick Reply list (up to 5)                                                                                                                                                        |
+| -- ordering             | Integer |    X     | Quick Reply order (required if Quick Replies are included)                                                                                                                                                |
+| -- type                 | String  |    X     | Quick Reply type (WL: Web Link, AL: App Link, BK: Bot Keyword, BC: Bot for Consultation, BT: Bot Transfer, BF: Business Form)                                                                                                |
+| -- name                 | String  |    X     | Quick Reply name (required if Quick Replies are included, up to 14 characters)                                                                                                                                        |
+| -- linkMo               | String  |    X     | Mobile web link (required for the WL type, up to 500 characters)                                                                                                                                     |
+| -- linkPc               | String  |    X     | PC web link (optional for the WL type, up to 500 characters)                                                                                                                                      |
+| -- schemeIos            | String  |    X     | iOS app link (required for the AL type, up to 500 characters)                                                                                                                                     |
+| -- schemeAndroid        | String  |    X     | Android app link (required for the AL type, up to 500 characters)                                                                                                                                   |
+| -- pluginId             | String  |    X     | Plugin ID (up to 24 characters)                                                                                                                                                        |
+| -- target               | String  |    X     | For the web link type, adding the "target":"out" attribute sets it to an out-link\<br\>Sent as an in-app link by default                                                                                                            |
+| -- telNumber           | 	String  | 	X  | Phone number to send for TN (Call) type buttons                                                                                    |
+| - messageOption         | Object  |    X     | Message options                                                                                                                                                                 |
+| -- price                | Integer |    X     | Price/amount/payment amount included in the message to be delivered to the user (related to moment advertisement)                                                                                                                            |
+| -- currencyType         | String  |    X     | Use of international currency codes such as KRW, USD, EUR, which is the currency unit of the price/amount/payment amount included in the message to be delivered to the user (related to moment advertisement)                                                                                         |
+| - senderGroupingKey     | String  |    X     | Sender grouping key                                                                                                                                                               |
+| - recipientGroupingKey  | String  |    X     | Recipient grouping key                                                                                                                                                              |
 
 <a id="authentication-messages"></a>
 
 ## Authentication Messages
 
 <span id="precautions-authword"></span>
+
 1. Guide for authentication words required to be included for Authentication Messages API
 
-| Category  | Authentication Words |
-| --- | --- |
-| Authentication Messages | auth, password, verif, にんしょう, 認証, password, authentication |
+| Category | Authentication Words |
+|--------|--------------------------------------------|
+| Authentication Messages | auth, password, verif, にんしょう, 認証, 비밀번호, 인증 |
 
-- Example 1-1) Delivery shall fail if the full text(including template replacement) does not include authentication words, in the request of Authentication Messages API(for emergency)
+- Example 1-1) Delivery shall fail if the full text (including template replacement) does not include authentication words, in the request of Authentication Messages API (for emergency)
 - Example 1-2) Validity for English words shall be checked regardless of small or capital letters
-
 
 <a id="request-of-sending-replaced-messages-2"></a>
 
-### Request of Sending Replaced Messages
+### Send Replacement Message Request
 
 [URL]
 
@@ -811,27 +830,29 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name |	Type|	Description|
-|---|---|---|
-|appkey|	String|	Unique appkey|
+| Name     | 	Type     | 	Description     |
+|--------|---------|---------|
+| appkey | 	String | 	Unique app key |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|X-Secret-Key|	String| O | Can be created on console.   |
-|X-NC-API-IDEMPOTENCY-KEY|	String| X | Key used to recognize subsequent retries of the same request<br>If a request is made with the same key for 10 minutes, the request will be failed. |
+
+| Name                       | 	Type     | 	Required | 	Description                                                        |
+|--------------------------|---------|-----|------------------------------------------------------------|
+| X-Secret-Key             | 	String | O   | Can be created in the console.                                           |
+| X-NC-API-IDEMPOTENCY-KEY | 	String | X   | Key used as the criteria for duplicate message delivery requests<br>If a request is made with the same key for 10 minutes, the request will be failed. |
 
 [Request body]
-[Same as the above](./alimtalk-api-guide/#request-of-sending-replaced-messages)
+[Same as above](./alimtalk-api-guide/#_3)
 
 <a id="request-of-sending-full-text-2"></a>
 
-### Request of Sending Full Text
+### Send Full Text Message Request
 
 [URL]
 
@@ -842,23 +863,25 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name |	Type|	Description|
-|---|---|---|
-|appkey|	String|	Unique appkey|
+| Name     | 	Type     | 	Description     |
+|--------|---------|---------|
+| appkey | 	String | 	Unique app key |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|X-Secret-Key|	String| O | Can be created on console.   |
-|X-NC-API-IDEMPOTENCY-KEY|	String| X | Key used to recognize subsequent retries of the same request<br>If a request is made with the same key for 10 minutes, the request will be failed. |
+
+| Name                       | 	Type     | 	Required | 	Description                                                        |
+|--------------------------|---------|-----|------------------------------------------------------------|
+| X-Secret-Key             | 	String | O   | Can be created in the console.                                           |
+| X-NC-API-IDEMPOTENCY-KEY | 	String | X   | Key used as the criteria for duplicate message delivery requests<br>If a request is made with the same key for 10 minutes, the request will be failed. |
 
 [Request Body]
-[Same as the above](./alimtalk-api-guide/#request-of-sending-full-text)
+[Same as above](./alimtalk-api-guide/#_5)
 
 <a id="list-messages-2"></a>
 
@@ -877,26 +900,28 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name |	Type|	Description|
-|---|---|---|
-|appkey|	String|	Unique appkey|
+| Name     | 	Type     | 	Description     |
+|--------|---------|---------|
+| appkey | 	String | 	Unique app key |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|X-Secret-Key|	String| O | Can be created on console.   |
+
+| Name           | 	Type     | 	Required | 	Description              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | Can be created in the console. |
 
 [Query parameter]
-[Same as the above](./alimtalk-api-guide/#list-messages)
+[Same as above](./alimtalk-api-guide/#_7)
 
 <a id="get-messages-2"></a>
 
-### Get Messages
+### Get Message
 
 <a id="request-4"></a>
 
@@ -911,23 +936,26 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name |	Type|	Description|
-|---|---|---|
-|appkey|	String|	Unique appkey |
-|requestId|	String|	Request ID |
-|recipientSeq|	Integer|	Recipient sequence number |
+| Name           | 	Type      | 	Description         |
+|--------------|----------|-------------|
+| appkey       | 	String  | 	Unique app key     |
+| requestId    | 	String  | 	Request ID     |
+| recipientSeq | 	Integer | 	Recipient sequence number |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|X-Secret-Key|	String| O | Can be created on console.  |
+
+| Name           | 	Type     | 	Required | 	Description              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | Can be created in the console. |
 
 [Example]
+
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/messages/{requestId}/{recipientSeq}"
 ```
@@ -935,14 +963,16 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 <a id="response-5"></a>
 
 #### Response
-[Same as the above](./alimtalk-api-guide/#get-messages)
+
+[Same as above](./alimtalk-api-guide/#_9)
 
 <a id="message"></a>
 
-## Message
+## Messages
+
 <a id="cancel-sending-messages"></a>
 
-### Cancel Sending Messages
+### Cancel Message Delivery
 
 <a id="request-5"></a>
 
@@ -957,57 +987,61 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name |	Type|	Description|
-|---|---|---|
-|appkey|	String|	Unique appkey|
-|requestId| String| Request ID|
+| Name | Type | Description |
+|-----------|---------|---------|
+| appkey | String | Unique app key |
+| requestId | String | Request ID |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|X-Secret-Key|	String| O | Can be created on console.   |
+
+| Name | Type | Required | Description |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | String | O | Can be created in the console. |
 
 [Query parameter]
 
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|recipientSeq|	String|	X | Recipient sequence number<br>(to cancel all deliveries of request ID, if the value is left blank) |
+| Name | Type | Required | Description |
+|--------------|---------|-----|---------------------------------------------|
+| recipientSeq | String | X | Recipient sequence number<br>(to cancel all deliveries of request ID, if the value is left blank) |
 
 * Both general and authentication messages can be canceled by the same API.
 
 <a id="response-6"></a>
 
 #### Response
+
 ```
 {
-  "header" : {
-      "resultCode" :  Integer,
-      "resultMessage" :  String,
-      "isSuccessful" :  boolean
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
   }
 }
 ```
 
-| Name |	Type|	Description|
-|---|---|---|
-|header|	Object|	Header area|
-|- resultCode|	Integer|	Result code|
-|- resultMessage|	String| Result message|
-|- isSuccessful|	Boolean| Successful or not|
+| Name | Type | Not Null | Description |
+|-----------------|---------|:--------:|--------|
+| header | Object | O | Header area |
+| - resultCode | Integer | O | Result code |
+| - resultMessage | String | O | Result message |
+| - isSuccessful | Boolean | O | Success |
 
 [Example]
+
 ```
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
 ```
 
 <a id="query-updates-of-message-result"></a>
 
-### Query Updates of Message Result
+### Query Message Result Updates
 
 <a id="request-6"></a>
 
@@ -1022,80 +1056,84 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name |	Type|	Description|
-|---|---|---|
-|appkey|	String|	Unique appkey|
+| Name | Type | Description |
+|--------|---------|---------|
+| appkey | String | Unique app key |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|X-Secret-Key|	String| O | Can be created on console.   |
+
+| Name | Type | Required | Description |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | String | O | Can be created in the console. |
 
 [Query parameter]
 
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|startUpdateDate|	String|	O | Start date of querying result updates(yyyy-MM-dd HH:mm)|
-|endUpdateDate|	String| O |	End date of querying result updates(yyyy-MM-dd HH:mm) |
-|alimtalkMessageType|	String| X |	AlimTalk message type(NORMAL, AUTH) |
-|pageNum|	Integer|	X|	Page number(default: 1)|
-|pageSize|	Integer|	X|	Number of queries(default: 15, Max: 1000)|
+| Name | Type | Required | Description |
+|---------------------|----------|-----|-------------------------------------|
+| startUpdateDate | String | O | Start time of querying result updates (yyyy-MM-dd HH:mm) |
+| endUpdateDate | String | O | End time of querying result updates (yyyy-MM-dd HH:mm) |
+| alimtalkMessageType | String | X | AlimTalk message type (NORMAL, AUTH) |
+| pageNum | Integer | X | Page number (default: 1) |
+| pageSize | Integer | X | Number of results (Default: 15, Max: 1,000) |
 
 <a id="response-7"></a>
 
 #### Response
+
 ```
 {
-  "header" : {
-      "resultCode" :  Integer,
-      "resultMessage" :  String,
-      "isSuccessful" :  boolean
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
   },
-  "messages" : [
+  "messages": [
     {
-      "requestId" :  String,
-      "recipientSeq" : Integer,
-      "requestDate" :  String,
-      "createDate" :  String,
-      "receiveDate" : String,
-      "resendStatus" :  String,
-      "resendStatusName" :  String,
-      "resendResultCode" :  String,
-      "resendRequestId" :  String,
-      "messageStatus" :  String,
-      "resultCode" :  String,
-      "resultCodeName" : String
+      "requestId": String,
+      "recipientSeq": Integer,
+      "requestDate": String,
+      "createDate": String,
+      "receiveDate": String,
+      "resendStatus": String,
+      "resendStatusName": String,
+      "resendResultCode": String,
+      "resendRequestId": String,
+      "messageStatus": String,
+      "resultCode": String,
+      "resultCodeName": String
     }
   ]
 }
 ```
 
-| Name |	Type|	Description|
-|---|---|---|
-|header|	Object|	Header area|
-|- resultCode|	Integer|	Result code|
-|- resultMessage|	String| Result message|
-|- isSuccessful|	Boolean| Successful or not|
-|messages|	List|	List of messages|
-|- requestId | String |	Request ID |
-|- recipientSeq | Integer |	Recipient sequence number |
-|- requestDate | String |	Date and time of request |
-|- createDate  | String |	Date and time of creation |
-|- receiveDate | String |	Date and time of receiving |
-|- resendStatus | String |	Status code of resending(RSC01, RSC02, RSC03, RSC04, RSC05)<br>([Refer to [Status code of resending table](http://docs.toast.com/en/Notification/KakaoTalk%20Bizmessage/en/alimtalk-api-guide/#smslms)] below) |
-|- resendStatusName | String |	Status code name of resending |
-|- resendResultCode | String | Result code of resending [Result code of SMS sending](https://docs.toast.com/en/Notification/SMS/en/error-code/#api) |
-|- resendRequestId | String | ID requesting of resending SMS |
-|- messageStatus | String |	Request status(COMPLETED -> Successful, FAILED -> Failed, CANCEL -> Canceled) |
-|- resultCode | String |	Result code of receiving |
-|- resultCodeName | String |	Result code name of receiving |
+| Name | Type | Not Null | Description |
+|--------------------|---------|:--------:|--------------------------------------------------------------------------------------------------------|
+| header | Object | O | Header area |
+| - resultCode | Integer | O | Result code |
+| - resultMessage | String | O | Result message |
+| - isSuccessful | Boolean | O | Success |
+| messages | List | X | Message list |
+| - requestId | String | O | Request ID |
+| - recipientSeq | Integer | O | Recipient sequence number |
+| - requestDate | String | O | Request date and time |
+| - createDate | String | O | Created date and time |
+| - receiveDate | String | X | Received date and time |
+| - resendStatus | String | O | Status code of resending (RSC01, RSC02, RSC03, RSC04, RSC05)\<br\>(See [[SMS/LMS Resending Status Table below](http://docs.toast.com/ko/Notification/KakaoTalk%20Bizmessage/ko/alimtalk-api-guide/#smslms)]) |
+| - resendStatusName | String | O | Resending status code name |
+| - resendResultCode | String | X | Resending result code [SMS Result Code](https://docs.toast.com/ko/Notification/SMS/ko/error-code/#api) |
+| - resendRequestId | String | X | SMS request ID for resending |
+| - messageStatus | String | O | Request status (COMPLETED -> successful, FAILED -> failed, CANCEL -> canceled) |
+| - resultCode | String | X | Received result code |
+| - resultCodeName | String | X | Received result code name |
 
 [Example]
+
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/message-results?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
 ```
@@ -1117,9 +1155,9 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name     | 	Type     | 	Description     |
+| Name | Type | Description |
 |--------|---------|---------|
-| appkey | 	String | 	Unique appkey |
+| appkey | String | Unique app key |
 
 [Header]
 
@@ -1129,17 +1167,17 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name           | 	Type     | 	Required | 	Description              |
+| Name | Type | Required | Description |
 |--------------|---------|-----|------------------|
-| X-Secret-Key | 	String | O   | Create it in the console. |
+| X-Secret-Key | String | O | Can be created in the console. |
 
 [Query parameter]
 
-| Name                  | 	Type      | 	Required | 	Description                                 |
+| Name | Type | Required | Description |
 |---------------------|----------|-----|-------------------------------------|
-| startUpdateDate     | 	String  | 	O  | Result update query start time (yyyy-MM-dd HH:mm)  |
-| endUpdateDate       | 	String  | O   | 	Result update query end time (yyyy-MM-dd HH:mm) |
-| alimtalkMessageType | 	String  | X   | 	AlimTalk message type (NORMAL, AUTH)           |
+| startUpdateDate | String | O | Start time of querying result updates (yyyy-MM-dd HH:mm) |
+| endUpdateDate | String | O | End time of querying result updates (yyyy-MM-dd HH:mm) |
+| alimtalkMessageType | String | X | AlimTalk message type (NORMAL, AUTH) |
 
 <a id="response-8"></a>
 
@@ -1156,13 +1194,13 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name              | Type      | Not Null | Description     |
+| Name | Type | Not Null | Description |
 |-----------------|---------|:--------:|--------|
-| header          | Object  |    O     | Header area  |
-| - resultCode    | Integer |    O     | Result code  |
-| - resultMessage | String  |    O     | Result message |
-| - isSuccessful  | Boolean |    O     | Successful or not  |
-| totalCount      | Integer |    O     | Total cases   |
+| header | Object | O | Header area |
+| - resultCode | Integer | O | Result code |
+| - resultMessage | String | O | Result message |
+| - isSuccessful | Boolean | O | Success |
+| totalCount | Integer | O | Total count |
 
 [Example]
 
@@ -1172,18 +1210,20 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 
 <a id="status-code-of-smslms-resending"></a>
 
-### Status Code of SMS/LMS Resending
-| Name |	Description|
-|---|---|
-|RSC01|	No target of resending|
-|RSC02|	Target of resending(If sending fails, resending is performed.)|
-|RSC03|	Resending in progress|
-|RSC04|	Resending successful|
-|RSC05|	Resending failed|
+### Status Codes for SMS/LMS Resending
+
+| Name | Description |
+|-------|--------------------------------------|
+| RSC01 | Not applicable for resending |
+| RSC02 | Target of resending (If sending fails, resending is performed.) |
+| RSC03 | Resending in progress |
+| RSC04 | Resending successful |
+| RSC05 | Resending failed |
 
 <a id="mass-delivery"></a>
 
 ## Mass Delivery
+
 <a id="list-mass-delivery-requests"></a>
 
 ### List Mass Delivery Requests
@@ -1191,17 +1231,19 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 <a id="request-8"></a>
 
 #### Request
+
 [URL]
+
 ```
 GET /alimtalk/v2.3/appkeys/{appKey}/mass-messages
 Content-Type: application/json;charset=UTF-8
 ```
 
-[Path parameter]
+[Path Parameter]
 
-| Name |	Type|	Description|
-|---|---|---|
-|appKey|	String|	Unique appkey|
+| Name     | 	Type     | 	Description     |
+|--------|---------|---------|
+| appKey | 	String | 	Unique app key |
 
 [Header]
 
@@ -1211,26 +1253,28 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name |	Type|	Description|
-|---|---|---|
-|X-Secret-Key|	String|	Unique secret key |
+| Name           | 	Type     | 	Description       |
+|--------------|---------|-----------|
+| X-Secret-Key | 	String | 	Unique secret key |
 
-[Query parameter]
+[Query Parameter]
+
 * One of the following is required: requestId, startRequestDate + endRequestDate, or startCreateDate + endCreateDate.
 
-| Name |	Type| Max. Length |	Required|	Description|
-|---|---|---|---|---|
-| requestId | String | - | O | Request ID |
-| startRequestDate | String | - | O | Start date of delivery |
-| endRequestDate | String | - | O | End date of delivery |
-| startCreateDate |	String| - |	O |	Start date of registration |
-| endCreateDate |	String| - |	O |	End date of registration |
-| pageNum | optional, Integer | - | X | Page number |
-| pageSize | optional, Integer | 1000 | X | Search count |
+| Name               | 	Type               | Max Length | 	Required | 	Description       |
+|------------------|-------------------|-------|-----|-----------|
+| requestId        | String            | -     | O   | Request ID     |
+| startRequestDate | String            | -     | O   | Start delivery date  |
+| endRequestDate   | String            | -     | O   | End delivery date  |
+| startCreateDate  | 	String           | -     | 	O  | 	Start registration date |
+| endCreateDate    | 	String           | -     | 	O  | 	End registration date |
+| pageNum          | optional, Integer | -     | X   | Page number    |
+| pageSize         | optional, Integer | 1000  | X   | Number of results      |
 
 <a id="curl"></a>
 
 #### cURL
+
 ```
 curl -X GET \
 'https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appKey}/'"${APP_KEY}"'/mass-messages?requestId='"${REQUEST_ID}" \
@@ -1241,12 +1285,13 @@ curl -X GET \
 <a id="response-9"></a>
 
 #### Response
+
 ```
 {
   "header": {
-    "resultCode" :  Integer,
-    "resultMessage" :  String,
-    "isSuccessful" :  boolean
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
   },
   "body": {
     "messages": [
@@ -1270,39 +1315,38 @@ curl -X GET \
 }
 ```
 
-| Name |	Type|	Description|
-|---|---|---|
-| header | Object |	Header area |
-| - resultCode |	Integer |	Result code |
-| - resultMessage |	String | Result message |
-| - isSuccessful |	Boolean | Successful or not |
-| body | Object | Body area |
-| - messages | Object | List of messages |
-| -- requestId | String | Request ID |
-| -- requestDate | String | Date of request |
-| -- createDate | String | Date of creation |
-| -- createUser | String | Date of creation |
-| -- plusFriendId | String | PlusFriend ID |
-| -- senderKey | String| Sender key(40 characters) |
-| -- masterStatusCode | String | Mass delivery status code(WAIT, READY, SENDREADY, SENDWAIT, SENDING, COMPLETE, CANCEL, FAIL) |
-| -- content | String | Content |
-| -- fileId | String | Attachment ID |
-| -- templateCode |	String | Template code(up to 20 characters) |
-| -- autoSendYn | String | Auto sending or not |
-| -- statsId | String | Statistics ID |
-| -- createDate | String | Date of creation |
-| -- createUser | String | User who created the request(saved as user UUID when sending from console) |
-| - totalCount | Integer | Total count |
-
+| Name                  | Type      | Not Null | Description                                                                             |
+|---------------------|---------|:--------:|--------------------------------------------------------------------------------|
+| header              | Object  |    O     | Header area                                                                          |
+| - resultCode        | Integer |    O     | Result code                                                                          |
+| - resultMessage     | String  |    O     | Result message                                                                         |
+| - isSuccessful      | Boolean |    O     | Success                                                                          |
+| body                | Object  |    X     | Body area                                                                          |
+| - messages          | Object  |    X     | Message list                                                                        |
+| -- requestId        | String  |    O     | Request ID                                                                          |
+| -- requestDate      | String  |    O     | Request date                                                                          |
+| -- plusFriendId     | String  |    O     | Plus Friend ID                                                                      |
+| -- senderKey        | String  |    O     | Sender Key (40 characters)                                                                      |
+| -- masterStatusCode | String  |    O     | Mass delivery status code (WAIT, READY, SENDREADY, SENDWAIT, SENDING, COMPLETE, CANCEL, FAIL) |
+| -- content          | String  |    X     | Content                                                                             |
+| -- fileId           | String  |    X     | Attachment ID                                                                       |
+| -- templateCode     | String  |    O     | Template Code (up to 20 characters)                                                                 |
+| -- autoSendYn       | String  |    X     | Whether auto-delivery is enabled                                                                       |
+| -- statsId          | String  |    X     | Statistics ID                                                                          |
+| -- createDate       | String  |    O     | Creation date                                                                          |
+| -- createUser       | String  |    X     | User who created the request (saved as user UUID when sending from console)                                                 |
+| - totalCount        | Integer |    X     | Total count                                                                            |
 
 <a id="list-mass-delivery-recipients"></a>
 
-### List Mass Delivery Recipients
+### Retrieve Recipients of Mass Delivery Requests
 
 <a id="request-9"></a>
 
 #### Request
+
 [URL]
+
 ```
 GET /alimtalk/v2.3/appkeys/{appKey}/mass-messages/{requestId}/recipients
 Content-Type: application/json;charset=UTF-8
@@ -1310,10 +1354,10 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name |	Type|	Description|
-|---|---|---|
-| appKey |	String |	Unique appkey |
-| requestId |	String |	Request ID |
+| Name        | 	Type     | 	Description     |
+|-----------|---------|---------|
+| appKey    | 	String | 	Unique app key |
+| requestId | 	String | 	Request ID  |
 
 [Header]
 
@@ -1323,24 +1367,24 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name |	Type|	Description|
-|---|---|---|
-| X-Secret-Key |	String|	Unique secret key |
+| Name           | 	Type     | 	Description       |
+|--------------|---------|-----------|
+| X-Secret-Key | 	String | 	Unique secret key |
 
-
-| Name |	Type| Max. Length |	Required|	Description|
-|---|---|---|---|---|
-| requestId | String | - | O | Request ID |
-| startRequestDate | String | - | X | Start date of delivery |
-| endRequestDate | String | - | X | End date of delivery |
-| startCreateDate |	String| - |	X |	Start date of registration |
-| endCreateDate |	String| - |	X |	End date of registration |
-| pageNum | optional, Integer | - | X | Page number |
-| pageSize | optional, Integer | 1000 | X | Search count |
+| Name               | 	Type               | Max Length | 	Required | 	Description       |
+|------------------|-------------------|-------|-----|-----------|
+| requestId        | String            | -     | O   | Request ID     |
+| startRequestDate | String            | -     | X   | Start date for delivery  |
+| endRequestDate   | String            | -     | X   | End date for delivery  |
+| startCreateDate  | 	String           | -     | 	X  | 	Start date for registration |
+| endCreateDate    | 	String           | -     | 	X  | 	End date for registration |
+| pageNum          | optional, Integer | -     | X   | Page number    |
+| pageSize         | optional, Integer | 1000  | X   | Number of results      |
 
 <a id="curl-2"></a>
 
 #### cURL
+
 ```
 curl -X GET \
 'https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appKey}/'"${APP_KEY}"'/mass-messages/recipients?requestId='"${REQUEST_ID}" \
@@ -1351,12 +1395,13 @@ curl -X GET \
 <a id="response-10"></a>
 
 #### Response
+
 ```
 {
     "header": {
-      "resultCode" :  Integer,
-      "resultMessage" :  String,
-      "isSuccessful" :  boolean
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
     },
     "body": {
         "recipients": [
@@ -1376,32 +1421,34 @@ curl -X GET \
 }
 ```
 
-| Name |	Type|	Description|
-|---|---|---|
-| header | Object |	Header area |
-| - resultCode |	Integer |	Result code |
-| - resultMessage |	String | Result message |
-| - isSuccessful |	Boolean | Successful or not |
-| body | Object | Body area |
-| - messages | Object | List of messages |
-| -- requestId | String | Request ID |
-| -- recipientSeq | String | Recipient sequence number |
-| -- recipientNo | String | Recipient number |
-| -- requestDate | String | Date of request |
-| -- receiveDate | String | Date of receiving |
-| -- messageStatus | String | Message status |
-| -- resultCode | String | Result code |
-| -- resultCodeName | String | Result code content |
-| - totalCount | Integer | Total count |
+| Name                | Type      | Not Null | Description         |
+|-------------------|---------|:--------:|------------|
+| header            | Object  |    O     | Header area      |
+| - resultCode      | Integer |    O     | Result code      |
+| - resultMessage   | String  |    O     | Result message     |
+| - isSuccessful    | Boolean |    O     | Success      |
+| body              | Object  |    X     | Body area      |
+| - messages        | Object  |    X     | Message list    |
+| -- requestId      | String  |    O     | Request ID      |
+| -- recipientSeq   | String  |    O     | Recipient sequence number |
+| -- recipientNo    | String  |    X     | Recipient number      |
+| -- requestDate    | String  |    O     | Request date      |
+| -- receiveDate    | String  |    X     | Receipt date      |
+| -- messageStatus  | String  |    O     | Message status     |
+| -- resultCode     | String  |    X     | Result code      |
+| -- resultCodeName | String  |    X     | Result code description   |
+| - totalCount      | Integer |    X     | Total count        |
 
 <a id="get-a-mass-delivery-recipient"></a>
 
-### Get a Mass Delivery Recipient
+### Retrieve a Mass Delivery Recipient
 
 <a id="request-10"></a>
 
 #### Request
+
 [URL]
+
 ```
 GET /alimtalk/v2.3/appkeys/{appKey}/mass-messages/{requestId}/recipients/{recipientSeq}
 Content-Type: application/json;charset=UTF-8
@@ -1409,11 +1456,11 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name |	Type|	Description|
-|---|---|---|
-| appKey |	String | Unique appkey |
-| requestId |	String | Request ID |
-| recipientSeq | String | Recipient sequence |
+| Name           | 	Type     | 	Description    |
+|--------------|---------|--------|
+| appKey       | 	String | Unique app key |
+| requestId    | 	String | Request ID  |
+| recipientSeq | String  | Recipient sequence number |
 
 [Header]
 
@@ -1423,24 +1470,24 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name |	Type|	Description|
-|---|---|---|
-|X-Secret-Key|	String|	Unique secret key |
+| Name           | 	Type     | 	Description       |
+|--------------|---------|-----------|
+| X-Secret-Key | 	String | 	Unique secret key |
 
-
-| Name |	Type| Max. Length |	Required|	Description|
-|---|---|---|---|---|
-| requestId | String | - | O | Request ID |
-| startRequestDate | String | - | X | Start date of delivery |
-| endRequestDate | String | - | X | End date of delivery |
-| startCreateDate |	String| - |	X |	Start date of registration |
-| endCreateDate |	String| - |	X |	End date of registration |
-| pageNum | optional, Integer | - | X | Page number |
-| pageSize | optional, Integer | 1000 | X | Search count |
+| Name               | 	Type               | Max Length | 	Required | 	Description       |
+|------------------|-------------------|-------|-----|-----------|
+| requestId        | String            | -     | O   | Request ID     |
+| startRequestDate | String            | -     | X   | Start delivery date  |
+| endRequestDate   | String            | -     | X   | End delivery date  |
+| startCreateDate  | 	String           | -     | 	X  | 	Start registration date |
+| endCreateDate    | 	String           | -     | 	X  | 	End registration date |
+| pageNum          | optional, Integer | -     | X   | Page number    |
+| pageSize         | optional, Integer | 1000  | X   | Search count      |
 
 <a id="curl-3"></a>
 
 #### cURL
+
 ```
 curl -X GET \
 'https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appKey}/'"${APP_KEY}"'/mass-messages/{requestId}/recipients/1" \
@@ -1451,12 +1498,13 @@ curl -X GET \
 <a id="response-11"></a>
 
 #### Response
+
 ```
 {
     "header": {
-      "resultCode" :  Integer,
-      "resultMessage" :  String,
-      "isSuccessful" :  boolean
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
     },
     "body": {
         "requestId": String,
@@ -1470,23 +1518,23 @@ curl -X GET \
         "templateSubtitle": String,
         "templateExtra": String,
         "templateAd": String,
-        "templateHeader" : String,
-        "templateItem" : {
-          "list" : [{
+        "templateHeader": String,
+        "templateItem": {
+          "list": [{
             "title": String,
             "description": String
           }],
-          "summary" : {
+          "summary": {
             "title": String,
             "description": String
           }
         },
-        "templateItemHighlight" : {
+        "templateItemHighlight": {
           "title": String,
           "description": String,
           "imageUrl": String
         },
-        "templateRepresentLink" : {
+        "templateRepresentLink": {
           "linkMo": String,
           "linkPc": String,
           "schemeIos": String,
@@ -1503,12 +1551,12 @@ curl -X GET \
         "resultCode": String,
         "resultCodeName": String,
         "createUser": String,
-        "buttons" : [
+        "buttons": [
           {
-            "ordering" :  Integer,
-            "type" :  String,
-            "name" :  String,
-            "linkMo" :  String,
+            "ordering": Integer,
+            "type": String,
+            "name": String,
+            "linkMo": String,
             "linkPc": String,
             "schemeIos": String,
             "schemeAndroid": String,
@@ -1523,7 +1571,7 @@ curl -X GET \
             "telNumber": String
           }
         ],
-        "quickReplies" : [
+        "quickReplies": [
           {
             "ordering": Integer,
             "type": String,
@@ -1537,84 +1585,84 @@ curl -X GET \
             "bizFormId": Integer,
             "target": String
             }
-        ],
+        ]
     }
 }
 ```
 
-| Name |	Type| 	Description                                                                                                                                                                                                      |
-|---|---|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| header | Object | 	Header area                                                                                                                                                                                                      |
-| - resultCode |	Integer | 	Result code                                                                                                                                                                                                      |
-| - resultMessage |	String | Result message                                                                                                                                                                                                    |
-| - isSuccessful |	Boolean | Successful or not                                                                                                                                                                                                 |
-| body | Object | Body area                                                                                                                                                                                                         |
-| - requestId | String | Request ID                                                                                                                                                                                                        |
-| - recipientSeq | String | Recipient sequence number                                                                                                                                                                                         |
-| - plusFriendId | String | PlusFriend ID                                                                                                                                                                                                     |
-| - senderKey | String | Sender ID                                                                                                                                                                                                         |
-| - templateCode |	String | Template code(up to 20 characters)                                                                                                                                                                                |
-| - recipientNo | String | Recipient number                                                                                                                                                                                                  |
-| - content | String | Content                                                                                                                                                                                                           |
-| - tempalteTitle| String | Template title(No more than 50 characters, Android: To be abbreviated if it exceeds 2 lines with more than 23 characters, iOS: To be abbreviated if it exceeds 2 lines with more than 27 characters)              |
-| - templateSubtitle| String | Auxiliary template phrase(No more than 50 characters, Android: To be abbreviated if it exceeds 18 characters, iOS: To be abbreviated if it exceeds 21 characters)                                                 |
-| - templateExtra | String | Additional template information(Required, if template message type is[Ad Included/Mixed Purposes])                                                                                                                |
-| - templateAd | String | Request for consent of receiving within template or simple ad phrases                                                                                                                                             |
-| - templateHeader| String|  Template header(up to 16 characters) |
-| - templateItem | Object |  Item |
-| -- list | List | Item list(at least 2, up to 10) |
-| --- title | String | Title(up to 6 characters) |
-| --- description | String |  Description(up to 23 characters) |
-| -- summary | Object |  Item summary information |
-| --- title | String |  Title(up to 6 characters) |
-| --- description | String |  Description(Only variables and monetary units, numbers, commas, and periods, up to 14 characters) |
-| - templateItemHighlight | Object |  Item highlight |
-| --- title | String |  Title(up to 30 characters, 21 characters with a thumbnail image) |
-| --- description | String |  Description(up to 19 characters, 13 with a thumbnail image) |
-| --- imageUrl | String |  Thumbnail image address |
-| - templateRepresentLink | Object |  Main link |
-| -- linkMo| String | 	Mobile web link(up to 500 characters)|
-| -- linkPc | String | PC web link(up to 500 characters) |
-| -- schemeIos | String |	iOS app link(up to 500 characters) |
-| -- schemeAndroid | String | 	Android app link(up to 500 characters) |
-| - requestDate | String | Date of request                                                                                                                                                                                                   |
-| - receiveDate | String | Date of receiving                                                                                                                                                                                                 |
-| - createDate | String | Date of creation                                                                                                                                                                                                  |
-| - resendStatus | String | Status code of resending(RSC01, RSC02, RSC03, RSC04, RSC05)<br>([Refer to [Status code of resending table](http://docs.toast.com/en/Notification/KakaoTalk%20Bizmessage/en/alimtalk-api-guide/#smslms)] below)    |
-| - resendStatusName | String | Status name of resending                                                                                                                                                                                          |
-| - resendResultCode | String | Result code of resending [Result code of SMS sending](https://docs.toast.com/en/Notification/SMS/en/error-code/#api)                                                                                              |
-| - resendRequestId | String | Resending SMS request ID                                                                                                                                                                                          |
-| - messageStatus | String | Mass recipient delivery status code(READY, COMPLETED, FAILED, CANCEL)                                                                                                                                             |
-| - resultCode | String | Result status code                                                                                                                                                                                                |
-| - resultCodeName | String | Result status name                                                                                                                                                                                                |
-| - createUser | String | User who created the request(saved as user UUID when sending from console)                                                                                                                                        |
-| - buttons | List | 	List of buttons                                                                                                                                                                                                  |
-| -- ordering | Integer | 	Button sequence                                                                                                                                                                                                  |
-| -- type| String |	Button type(WL: Web link, AL: App link, DS: Delivery search, BK: Bot keyword, MD: Message delivery, BC: Bot for Consultation, BT: Bot Transfer, AC: Add channel, BF: Business form, P1: Image secure transmission plugin ID, P2: Personal information use plugin ID, P3: One-click payment plugin ID, TN: Call) |
-| -- name | String | 	Button name                                                                                                                                                                                                      |
-| -- linkMo | String | 	Mobile web link(required for the WL type)                                                                                                                                                                        |
-| -- linkPc | String | 	PC web link(optional for the WL type)                                                                                                                                                                            |
-| -- schemeIos | String | 	iOS app link(required for the AL type)                                                                                                                                                                           |
-| -- schemeAndroid | String | 	Android app link(required for the AL type)                                                                                                                                                                       |
-| -- chatExtra|	String| 	Meta information to send for BC(Bot for Consultation) or BT(Bot Transfer) type buttons                                                                                                                           |
-| -- chatEvent|	String| Bot event name to connect for BT(Bot Transfer) type button                                                                                                                                                        |
-| -- bizFormId|	Integer| 	Business form ID(required for BF type)                                                                                                                                                                           |
-| -- pluginId|	String| 	Plugin ID(up to 24 characters)                                                                                                                                                                                   |
-| -- relayId|	String| Value passed via the X-Kakao-Plugin-Relay-Id header when the plugin is executed                                                                                                                                   |
-| -- oneClickId|	String| Payment information used in the one click payment plugin                                                                                                                                                          |
-| -- productId|	String| Payment information used in the one click payment plugin                                                                                                                                                          |
-| -- target|	String| 	In the case of a web link button, out link used when adding "target":"out" attribute<br>Send with the default in-app link                                                                                        |
-| -- telNumber           | 	String  | 	X  | When you press the TN (call) button, the phone number to be transferred                                                                  |
-| - quickReplies|	List | Quick reply list(up to 5)                                                                                                                                                                                         |
-| -- ordering|	Integer| 	Quick reply order(required  when quick reply exists)                                                                                                                                                             |
-| -- type| String | 	Qucik reply type(WL: Web link, AL: App link, BK: Bot keyword, BC: Bot for Consultation, BT: Bot Transfer, BF: Business form)                                                                                     |
-| -- name| String | 	Quick reply name(required  when quick reply exists, up to 14 characters)                                                                                                                                         |
-| -- linkMo| String | 	Mobile web link(required for the WL type, up to 500 characters)                                                                                                                                                  |
-| -- linkPc | String | PC web link(optional for the WL type, up to 500 characters)                                                                                                                                                       |
-| -- schemeIos | String | 	iOS app link(required for the AL type, up to 500 characters) |
-| -- schemeAndroid | String |	Android app link(required for the AL type, up to 500 characters) |
-| -- bizFormId|	String| 	Plugin ID(up to 24 characters) |
-| -- target|	String| 	In the case of a web link type, out link used when adding "target":"out" attribute<br>Send with the default in-app link |
+| Name                    | Type    | Not Null | Description                                                                                                                                                                                                                                  |
+|-------------------------|---------|:--------:|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| header                  | Object  |    O     | Header area                                                                                                                                                                                                                                  |
+| - resultCode            | Integer |    O     | Result code                                                                                                                                                                                                                                  |
+| - resultMessage         | String  |    O     | Result message                                                                                                                                                                                                                               |
+| - isSuccessful          | Boolean |    O     | Success                                                                                                                                                                                                                                      |
+| body                    | Object  |    X     | Body area                                                                                                                                                                                                                                    |
+| - requestId             | String  |    O     | Request ID                                                                                                                                                                                                                                   |
+| - recipientSeq          | String  |    O     | Recipient sequence number                                                                                                                                                                                                                    |
+| - plusFriendId          | String  |    O     | PlusFriend ID                                                                                                                                                                                                                                |
+| - senderKey             | String  |    O     | Sender ID                                                                                                                                                                                                                                    |
+| - templateCode          | String  |    O     | Template Code (up to 20 characters)                                                                                                                                                                                                          |
+| - recipientNo           | String  |    X     | Recipient Number                                                                                                                                                                                                                             |
+| - content               | String  |    X     | Content                                                                                                                                                                                                                                      |
+| - tempalteTitle         | String  |    X     | Template title (No more than 50 characters, Android: To be abbreviated if it exceeds 2 lines with more than 23 characters, iOS: To be abbreviated if it exceeds 2 lines with more than 27 characters)                                        |
+| - templateSubtitle      | String  |    X     | Auxiliary template phrase (No more than 50 characters, Android: To be abbreviated if it exceeds 18 characters, iOS: To be abbreviated if it exceeds 21 characters)                                                                           |
+| - templateExtra         | String  |    X     | Additional template information (Required, if template message type is [Ad Included/Mixed Purposes])                                                                                                                                         |
+| - templateAd            | String  |    X     | Request for consent of receiving within template or simple ad phrases                                                                                                                                                                        |
+| - templateHeader        | String  |    X     | Template header (up to 16 characters)                                                                                                                                                                                                        |
+| - templateItem          | Object  |    X     | Item                                                                                                                                                                                                                                         |
+| -- list                 | List    |    X     | Item list (minimum 2, maximum 10)                                                                                                                                                                                                            |
+| --- title               | String  |    X     | Title (up to 6 characters)                                                                                                                                                                                                                   |
+| --- description         | String  |    X     | Description (up to 23 characters)                                                                                                                                                                                                            |
+| -- summary              | Object  |    X     | Item summary information                                                                                                                                                                                                                     |
+| --- title               | String  |    X     | Title (up to 6 characters)                                                                                                                                                                                                                   |
+| --- description         | String  |    X     | Description (Only variables and monetary units, numbers, commas, and periods, up to 14 characters)                                                                                                                                           |
+| - templateItemHighlight | Object  |    X     | Item highlight                                                                                                                                                                                                                               |
+| --- title               | String  |    X     | Title (up to 30 characters, 21 characters with a thumbnail image)                                                                                                                                                                            |
+| --- description         | String  |    X     | Description (up to 19 characters, 13 characters with a thumbnail image)                                                                                                                                                                      |
+| --- imageUrl            | String  |    X     | Thumbnail image URL                                                                                                                                                                                                                          |
+| - templateRepresentLink | Object  |    X     | Representative link                                                                                                                                                                                                                          |
+| -- linkMo               | String  |    X     | Mobile web link (up to 500 characters)                                                                                                                                                                                                       |
+| -- linkPc               | String  |    X     | PC web link (up to 500 characters)                                                                                                                                                                                                           |
+| -- schemeIos            | String  |    X     | iOS app link (up to 500 characters)                                                                                                                                                                                                          |
+| -- schemeAndroid        | String  |    X     | Android app link (up to 500 characters)                                                                                                                                                                                                      |
+| - requestDate           | String  |    O     | Request date                                                                                                                                                                                                                                 |
+| - receiveDate           | String  |    X     | Received date                                                                                                                                                                                                                                |
+| - createDate            | String  |    O     | Creation date                                                                                                                                                                                                                                |
+| - resendStatus          | String  |    O     | Status code of resending (RSC01, RSC02, RSC03, RSC04, RSC05)\<br\>([[Resending status table below](http://docs.toast.com/ko/Notification/KakaoTalk%20Bizmessage/ko/alimtalk-api-guide/#smslms)] reference)                                   |
+| - resendStatusName      | String  |    O     | Resending status name                                                                                                                                                                                                                        |
+| - resendResultCode      | String  |    O     | Resending result code [SMS result code](https://docs.toast.com/ko/Notification/SMS/ko/error-code/#api)                                                                                                                                       |
+| - resendRequestId       | String  |    X     | Resending request ID                                                                                                                                                                                                                         |
+| - messageStatus         | String  |    O     | Mass recipient delivery status code (READY, COMPLETED, FAILED, CANCEL)                                                                                                                                                                       |
+| - resultCode            | String  |    X     | Result status code                                                                                                                                                                                                                           |
+| - resultCodeName        | String  |    X     | Result status name                                                                                                                                                                                                                           |
+| - createUser            | String  |    X     | User who created the message (stored as user UUID when sent from the console)                                                                                                                                         |
+| - buttons               | List    |    X     | Button list                                                                                                                                                                 |
+| -- ordering             | Integer |    X     | Button order                                                                                                                                                                  |
+| -- type                 | String  |    X     | Button type (WL: Web link, AL: App link, DS: Delivery search, BK: Bot keyword, MD: Message delivery, BC: Bot for Consultation, BT: Bot Transfer, AC: Add channel, BF: Business form, P1: Image secure transmission plugin ID, P2: Personal information use plugin ID, P3: One-click payment plugin ID, TN: Call) |
+| -- name                 | String  |    X     | Button name                                                                                                                                                                  |
+| -- linkMo               | String  |    X     | Mobile web link (required for the WL type)                                                                                                                              |
+| -- linkPc               | String  |    X     | PC web link (optional for the WL type)                                                                                                                               |
+| -- schemeIos            | String  |    X     | iOS app link (required for the AL type)                                                                                                                              |
+| -- schemeAndroid        | String  |    X     | Android app link (required for the AL type)                                                                                                                            |
+| -- chatExtra            | String  |    X     | Meta information to send for BC (Bot for Consultation) or BT (Bot Transfer) type buttons                                                                                                                                |
+| -- chatEvent            | String  |    X     | Bot event name to connect for BT (Bot Transfer) type buttons                                                                                                                                           |
+| -- bizFormId            | Integer |    X     | Business form ID (required for the BF type)                                                                                                                                                 |
+| -- pluginId             | String  |    X     | Plugin ID (up to 24 characters)                                                                                                                                        |
+| -- relayId              | String  |    X     | Value passed via the X-Kakao-Plugin-Relay-Id header when the plugin is executed                                                                                                                        |
+| -- oneClickId           | String  |    X     | Payment information used in the one-click payment plugin                                                                                                                               |
+| -- productId            | String  |    X     | Payment information used in the one-click payment plugin                                                                                                                               |
+| -- target               | String  |    X     | For web link buttons, adding the "target":"out" attribute sets an outbound link\<br\>Sent as an in-app link by default                                                                                                            |
+| -- telNumber            | String  |    X     | Phone number to send for TN (Call) type buttons                                                                    |
+| - quickReplies          | List    |    X     | Quick reply list (up to 5)                                                                                                                                                        |
+| -- ordering             | Integer |    X     | Quick reply order (required if quick replies are included)                                                                                                                                                |
+| -- type                 | String  |    X     | Quick reply type (WL: Web link, AL: App link, BK: Bot keyword, BC: Bot for Consultation, BT: Bot Transfer, BF: Business form)                                                                                                |
+| -- name                 | String  |    X     | Quick reply name (required if quick replies are included, up to 14 characters)                                                                                                                                        |
+| -- linkMo               | String  |    X     | Mobile web link (required for the WL type, up to 500 characters)                                                                                                                                     |
+| -- linkPc               | String  |    X     | PC web link (optional for the WL type, up to 500 characters)                                                                                                                                      |
+| -- schemeIos            | String  |    X     | iOS app link (required for the AL type, up to 500 characters)                                                                                                                                     |
+| -- schemeAndroid        | String  |    X     | Android app link (required for the AL type, up to 500 characters)                                                                                                                                   |
+| -- pluginId             | String  |    X     | Plugin ID (up to 24 characters)                                                                                                                                        |
+| -- target               | String  |    X     | For the web link type, adding the "target":"out" attribute sets an outbound link\<br\>Sent as an in-app link by default                                                                                                            |
 
 <a id="templates"></a>
 
@@ -1623,9 +1671,11 @@ curl -X GET \
 <a id="list-template-categories"></a>
 
 ### List Template Categories
+
 <a id="request-11"></a>
 
 #### Request
+
 [URL]
 
 ```
@@ -1635,30 +1685,33 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name |	Type|	Description|
-|---|---|---|
-|appkey|	String|	Unique appkey |
+| Name     | 	Type     | 	Description     |
+|--------|---------|---------|
+| appkey | 	String | 	Unique app key |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|X-Secret-Key|	String| O | Can be created on console.   |
+
+| Name           | 	Type     | 	Required | 	Description              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | Can be created in the console. |
 
 <a id="response-12"></a>
 
 #### Response
+
 ```
 
 {
-  "header" : {
-      "resultCode" :  Integer,
-      "resultMessage" :  String,
-      "isSuccessful" :  boolean
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
   },
   "categories": [
     {
@@ -1677,27 +1730,29 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name |	Type|	Description|
-|---|---|---|
-|header|	Object|	Header area|
-|- resultCode|	Integer|	Result code|
-|- resultMessage|	String| Result message|
-|- isSuccessful|	Boolean| Successful or not|
-|categories|	List|	List of categories |
-|- name | String | Category name |
-|- subCategories | List |	List of subcategories |
-|-- code | String | Category code(Used when registering/modifying templates) |
-|-- name | String |	Category name |
-|-- groupName | String |	Category group name |
-|-- inclusion | String |	Description of templates to which the category applies |
-|-- exclusion| String| Description of templates to which the category does not apply |
+| Name              | Type      | Not Null | Description                       |
+|-----------------|---------|:--------:|--------------------------|
+| header          | Object  |    O     | Header area                    |
+| - resultCode    | Integer |    O     | Result code                    |
+| - resultMessage | String  |    O     | Result message                   |
+| - isSuccessful  | Boolean |    O     | Success                    |
+| categories      | List    |    X     | Category list                 |
+| - name          | String  |    X     | Category name                  |
+| - subCategories | List    |    X     | Subcategory list              |
+| -- code         | String  |    X     | Category code (Used when registering/modifying templates) |
+| -- name         | String  |    X     | Category name                  |
+| -- groupName    | String  |    X     | Category group name                 |
+| -- inclusion    | String  |    X     | Description of templates to which the category applies        |
+| -- exclusion    | String  |    X     | Description of templates to which the category does not apply        |
 
 <a id="register-templates"></a>
 
-### Register Templates
+### Register Template
+
 <a id="request-12"></a>
 
 #### Request
+
 [URL]
 
 ```
@@ -1705,175 +1760,200 @@ POST  /alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates
 Content-Type: application/json;charset=UTF-8
 ```
 
-[Path parameter]
+[Path Parameter]
 
-| Name |	Type|	Description|
-|---|---|---|
-|appkey|	String|	Unique appkey |
-|senderKey|	String|	Sender Key |
+| Name        | 	Type     | 	Description     |
+|-----------|---------|---------|
+| appkey    | 	String | 	Unique app key |
+| senderKey | 	String | 	Sender Key   |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|X-Secret-Key|	String| O | Can be created on console.   |
+
+| Name           | 	Type     | 	Required | 	Description              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | Can be created in the console. |
 
 [Request Body]
 
 ```
 {
-  "templateCode" : String,
-  "templateName" : String,
-  "templateContent" : String,
+  "templateCode": String,
+  "templateName": String,
+  "templateContent": String,
   "templateMessageType": String,
-  "templateEmphasizeType" : String,
+  "templateEmphasizeType": String,
   "templateExtra": String,
-  "templateTitle" : String,
-  "templateSubtitle" : String,
-  "templateHeader" : String,
-  "templateItem" : {
-    "list" : [{
+  "templateTitle": String,
+  "templateSubtitle": String,
+  "templateHeader": String,
+  "templateItem": {
+    "list": [{
       "title": String,
       "description": String
     }],
-    "summary" : {
+    "summary": {
       "title": String,
       "description": String
     }
   },
-  "templateItemHighlight" : {
+  "templateItemHighlight": {
     "title": String,
     "description": String,
     "imageUrl": String
   },
-  "templateRepresentLink" : {
+  "templateRepresentLink": {
     "linkMo": String,
     "linkPc": String,
     "schemeIos": String,
     "schemeAndroid": String,
   },
-  "templateImageName" : String,
-  "templateImageUrl" : String,
+  "templateImageName": String,
+  "templateImageUrl": String,
   "securityFlag": Boolean,
   "categoryCode": String,
-  "buttons" : [
+  "buttons": [
     {
-      "ordering" : Integer,
-      "type" : String,
-      "name" : String,
-      "linkMo" : String,
-      "linkPc" : String,
-      "schemeIos" : String,
-      "schemeAndroid" : String
-      "bizFormId" : Integer,
-      "pluginId": String,
-      "telNumber": String      
-    }
-  ],
-  "quickReplies" : [
-    {
-      "ordering" : Integer,
-      "type" : String,
-      "name" : String,
-      "linkMo" : String,
-      "linkPc" : String,
-      "schemeIos" : String,
-      "schemeAndroid" : String
-      "bizFormId" : Integer
+      "ordering": Integer,
+      "type": String,
+      "name": String,
+      "linkMo": String,
+      "linkPc": String,
+      "schemeIos": String,
+      "schemeAndroid": String
+      "bizFormId": Integer,
       "pluginId": String,
       "telNumber": String
+    }
+  ],
+  "quickReplies": [
+    {
+      "ordering": Integer,
+      "type": String,
+      "name": String,
+      "linkMo": String,
+      "linkPc": String,
+      "schemeIos": String,
+      "schemeAndroid": String
+      "bizFormId": Integer
     }
   ]
 }
 ```
 
-| Name                  |	Type|	Required|	Description|
-|-----------------------|---|---|---|
-| templateCode          |	String |	O | Template code(up to 20 characters) |
-| templateName          |	String |	O | Template name(up to 150 characters) |
-| templateContent       |	String |	O | Template body(up to 1,300 characters) |
-| templateMessageType   | String | X |Types of template message(BA: Basic, EX: Extra Information, AD: Ad Included, MI: Mixed Purposes, default: Basic) |
-| templateEmphasizeType | String| X| Types of emphasized template(NONE: Basic, TEXT: Emphasized, IMAGE: Image type, ITEM_LIST: item list type, default:NONE)<br>- TEXT: templateTitle and templateSubtitle fields are required<br>IMAGE: templateImageName and templateImageUrl fields are required <br>ITEM_LIST: at least one of the following is required: image, header, item highlight, or item list.|
-| templateExtra         | String | X | Additional template information(Required, if template message type is[Ad Included/Mixed Purposes]) |
-| tempalteTitle         | String | X| Template title(No more than 50 characters, Android: To be abbreviated if it exceeds 2 lines with more than 23 characters, iOS: To be abbreviated if it exceeds 2 lines with more than 27 characters) |
-| templateSubtitle      | String | X| Auxiliary template phrase(No more than 50 characters, Android: To be abbreviated if it exceeds 18 characters, iOS: To be abbreviated if it exceeds 21 characters) |
-| templateHeader        | String| X| Template header(up to 16 characters) |
-| templateItem          | Object | X| Item |
-| - list                | List | X | Item list(at least 2, up to 10) |
-| -- title              | String | X | Title(up to 6 characters) |
-| -- description        | String | X | Description(up to 23 characters) |
-| - summary             | Object | X | Item summary information |
-| -- title              | String | X | Title(up to 6 characters) |
-| -- description        | String | X | Description(Only variables and monetary units, numbers, commas, and periods, up to 14 characters) |
-| templateItemHighlight | Object | X| Item highlight |
-| - title               | String | X | Title(up to 30 characters, 21 characters with a thumbnail image) |
-| - description         | String | X | Description(up to 19 characters, 13 with a thumbnail image) |
-| - imageUrl            | String | X | Thumbnail image address |
-| templateRepresentLink | Object | X| Main link |
-| - linkMo              | String |	X |	Mobile web link(up to 500 characters)|
-| - linkPc              | String |	X |PC web link(up to 500 characters) |
-| - schemeIos           | String | X |	iOS app link(up to 500 characters) |
-| - schemeAndroid       | String | X |	Android app link(up to 500 characters) |
-| templateImageName     | String |	X | Image name(name of uploaded file) |
-| templateImageUrl      | String |	X | Image URL |
-| securityFlag          | Boolean | X| Security template<br>Set for security messages such as OTP<br>If set, message text is unexposed to all devices except for the main device at the time of sending(default: false) |
-| categoryCode          | String | X | Template category code(Refer to API to View Template Category, default: 999999)<br>For other categories, screened by the lowest priority. |
-| buttons               |	List |	X | List of buttons(up to 5) |
-| -ordering             |	Integer |	X | Button sequence(1~5) |
-| - type                | String |	X |	Button type(WL: Web link, AL: App link, DS: Delivery search, BK: Bot keyword, MD: Message delivery, BC: Bot for Consultation, BT: Bot Transfer, AC: Add channel, BF: Business form, P1: Image secure transmission plugin ID, P2: Personal information use plugin ID, P3: One-click payment plugin ID, TN: Call) |
-| - name                | String |	X |	Button name(required, if there's a button, up to 14 characters)|
-| - linkMo              | String |	X |	Mobile web link(required for the WL type, up to 500 characters)|
-| - linkPc              | String |	X |PC web link(optional for the WL type, up to 500 characters) |
-| - schemeIos           | String | X |	iOS app link(required for the AL type, up to 500 characters) |
-| - schemeAndroid       | String | X |	Android app link(required for the AL type, up to 500 characters) |
-| - bizFormId           |	Integer|	X |	Business form ID(required for BF type) |
-| - pluginId            |	String|	X |	Plugin ID(up to 24 characters) |
-| -- telNumber           | 	String  | 	X  | When you press the TN (call) button, the phone number to be transferred                                                                    |
-| quickReplies          |	List |	X | Quick reply list(up to 5) |
-| - ordering            |	Integer|	X |	Quick reply order(required  when quick reply exists)|
-| - type                | String |	X |	Qucik reply type(WL: Web link, AL: App link, BK: Bot keyword, BC: Bot for Consultation, BT: Bot Transfer, BF: Business form) |
-| - name                | String |	X |	Quick reply name(required  when quick reply exists, up to 14 characters)|
-| - linkMo              | String |	X |	Mobile web link(required for the WL type, up to 500 characters)|
-| - linkPc              | String |	X |PC web link(optional for the WL type, up to 500 characters) |
-| - schemeIos           | String | X |	iOS app link(required for the AL type, up to 500 characters) |
-| - schemeAndroid       | String | X |	Android app link(required for the AL type, up to 500 characters) |
-| - bizFormId           |	Integer|	X |	Business form ID(required for BF type) |
+| Name                  | 	Type     | 	Required | 	Description                                                                                                                                                                                                                                                                                              |
+|-----------------------|----------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| templateCode          | 	String  | 	O        | Template Code (up to 20 characters)                                                                                                                                                                                                                                                                       |
+| templateName          | 	String  | 	O        | Template name (up to 150 characters)                                                                                                                                                                                                                                                                      |
+| templateContent       | 	String  | 	O        | Template body (up to 1,300 characters)                                                                                                                                                                                                                                                                    |
+| templateMessageType   | String   | X         | Types of template message (BA: Basic, EX: Extra Information, AD: Ad Included, MI: Mixed Purposes, default: BA)                                                                                                                                                                                            |
+| templateEmphasizeType | String   | X         | Template emphasis display type (NONE: Default, TEXT: Emphasis, IMAGE: Image type, ITEM_LIST: Item List Type, default: NONE)<br>- TEXT: templateTitle, templateSubtitle fields required<br>- IMAGE: templateImageName, templateImageUrl fields required<br>ITEM_LIST: At least one of image, header, item highlight, and item list is required |
+| templateExtra         | String   | X         | Template supplementary information (required if the template message type is [Extra Information/Mixed Purposes])                                                                                                                                                                                           |
+| tempalteTitle         | String   | X         | Template title (No more than 50 characters, Android: To be abbreviated if it exceeds 2 lines with more than 23 characters, iOS: To be abbreviated if it exceeds 2 lines with more than 27 characters)                                                                                                     |
+| templateSubtitle      | String   | X         | Auxiliary template phrase (No more than 50 characters, Android: To be abbreviated if it exceeds 18 characters, iOS: To be abbreviated if it exceeds 21 characters)                                                                                                                                        |
+| templateHeader        | String   | X         | Template header (up to 16 characters)                                                                                                                                                                                                                                                                     |
+| templateItem          | Object   | X         | Item                                                                                                                                                                                                                                                                                                      |
+| - list                | List     | X         | Item list (minimum 2, maximum 10)                                                                                                                                                                                                                                                                         |
+| -- title              | String   | X         | Title (up to 6 characters)                                                                                                                                                                                                                                                                                |
+| -- description        | String   | X         | Description (up to 23 characters)                                                                                                                                                                                                                                                                         |
+| - summary             | Object   | X         | Item summary information                                                                                                                                                                                                                                                                                   |
+| -- title              | String   | X         | Title (up to 6 characters)                                                                                                                                                                                                                                                                                |
+| -- description        | String   | X         | Description (Only variables and monetary units, numbers, commas, and periods, up to 14 characters)                                                                                                                                                                                                        |
+| templateItemHighlight | Object   | X         | Item highlight                                                                                                                                                                                                                                                                                            |
+| - title               | String   | X         | Title (up to 30 characters, 21 characters if a thumbnail image is present)                                                                                                                                                                                                                                |
+| - description         | String   | X         | Description (up to 19 characters, 13 characters if a thumbnail image is present)                                                                                                                                                                                                                          |
+| - imageUrl            | String   | X         | Thumbnail image URL                                                                                                                                                                                                                                                                                       |
+| templateRepresentLink | Object   | X         | Representative link                                                                                                                                                                                                                                                                                       |
+| - linkMo              | String   | 	X        | 	Mobile web link (up to 500 characters)                                                                                                                                                                                                                                                                   |
+| - linkPc              | String   | 	X        | PC web link (up to 500 characters)                                                                                                                                                                                                                                                                        |
+| - schemeIos           | String   | X         | 	iOS app link (up to 500 characters)                                                                                                                                                                                                                                                                      |
+| - schemeAndroid       | String   | X         | 	Android app link (up to 500 characters)                                                                                                                                                                                                                                                                  |
+| templateImageName     | String   | 	X        | Image name (uploaded file name)                                                                                                                                                                                                                                                                           |
+| templateImageUrl      | String   | 	X        | Image URL                                                                                                                                                                                                                                                                                                 |
+| securityFlag          | Boolean  | X         | Whether it is a security template<br>Set for security messages such as OTP<br>If set, message text is unexposed to all devices except for the main device at the time of sending (default: false)                                                                                                          |
+| categoryCode          | String   | X         | Template category code (refer to the Template Category Query API, default: 999999)<br>If the category is "Other," it will be reviewed with the lowest priority                                                                                                                                             |
+| buttons               | 	List    | 	X        | Button list (maximum 5)                                                                                                                                                                                                                                                                                   |
+| - ordering            | 	Integer | 	X        | Button order (1 to 5)                                                                                                                                                                                                                                                                                     |
+| - type                | String   | 	X        | 	Button type (WL: Web link, AL: App link, DS: Delivery search, BK: Bot keyword, MD: Message delivery, BC: Bot for Consultation, BT: Bot Transfer, AC: Add channel, BF: Business form, P1: Image secure transmission plugin ID, P2: Personal information use plugin ID, P3: One-click payment plugin ID, TN: Call) |
+| - name                | String   | 	X        | 	Button name (required if there is a button, up to 14 characters)                                                                                                                                                                                                                                         |
+| - linkMo              | String   | 	X  | 	Mobile web link (required for the WL type, for up to 500 characters)                                                                                                                                                                                                             |
+| - linkPc              | String   | 	X  | PC web link (optional for the WL type, for up to 500 characters)                                                                                                                                                                                                               |
+| - schemeIos           | String   | X   | 	iOS app link (required for the AL type, for up to 500 characters)                                                                                                                                                                                                             |
+| - schemeAndroid       | String   | X   | 	Android app link (required for the AL type, for up to 500 characters)                                                                                                                                                                                                           |
+| - bizFormId           | 	Integer | 	X  | 	Business form ID (required for the BF type)                                                                                                                                                                                                                         |
+| - pluginId            | 	String  | 	X  | 	Plugin ID (up to 24 characters)                                                                                                                                                                                                                                |
+| -- telNumber           | 	String  | 	X  | Phone number to send for a TN (Call) type button                                                                    |
+| quickReplies          | 	List    | 	X  | Quick reply list (up to 5 items)                                                                                                                                                                                                                                 |
+| - ordering            | 	Integer | 	X  | 	Quick reply order (required when quick reply exists)                                                                                                                                                                                                                        |
+| - type                | String   | 	X  | 	Quick reply type (WL: Web link, AL: App link, BK: Bot keyword, BC: Bot for Consultation, BT: Bot Transfer, BF: Business form)                                                                                                                                                                        |
+| - name                | String   | 	X  | 	Quick reply name (required when quick reply exists, up to 14 characters)                                                                                                                                                                                                                |
+| - linkMo              | String   | 	X  | 	Mobile web link (required for the WL type, for up to 500 characters)                                                                                                                                                                                                             |
+| - linkPc              | String   | 	X  | PC web link (optional for the WL type, for up to 500 characters)                                                                                                                                                                                                               |
+| - schemeIos           | String   | X   | 	iOS app link (required for the AL type, for up to 500 characters)                                                                                                                                                                                                             |
+| - schemeAndroid       | String   | X   | 	Android app link (required for the AL type, for up to 500 characters)                                                                                                                                                                                                           |
+| - bizFormId           | 	Integer | 	X  | 	Business form ID (required for the BF type)                                                                                                                                                                                                                         |
 
-* The templateAd value is fixed when registering the AD included(AD) or Mixed Purposes(MI) message type template.
-* The Add Chanel button must be in the first when registering the AD included(AD) or Mixed Purposes(MI) message type template.
-* The Add Channel(AC) button must be registered with a fixed button name of "Add Channel".
+* The templateAd value is fixed when registering the AD included (AD) or Mixed Purposes (MI) message type template.
+* The Add Channel button must be in the first position when registering the AD included (AD) or Mixed Purposes (MI) message type template.
+* The Add Channel (AC) button name must be fixed as 'Add channel' when registering.
 
+Refer to the following table for the availability of replacement variables (#{variable}) for each field.
+
+| Category | Field | Replaceable |
+|------|------|---------|
+| Basic | templateContent | O |
+| Basic | templateTitle | O |
+| Basic | templateSubtitle | X |
+| Basic | templateHeader | O |
+| Basic | templateExtra | X |
+| Basic | templateAd | X |
+| Button | name | X |
+| Button | linkMo, linkPc, schemeIos, schemeAndroid | O |
+| Quick Reply | name | X |
+| Quick Reply | linkMo, linkPc, schemeIos, schemeAndroid | O |
+| Template Item | title | X |
+| Template Item | description | O |
+| Template Item summary | title | X |
+| Template Item summary | description | O |
+| Template Item Highlight | title | O |
+| Template Item Highlight | description | O |
+| Template Item Highlight | imageUrl | X |
+| Representative Link | linkMo, linkPc, schemeIos, schemeAndroid | O |
 
 <a id="response-13"></a>
 
 #### Response
+
 ```
 {
-  "header" : {
-    "resultCode" :  Integer,
-    "resultMessage" :  String,
-    "isSuccessful" :  boolean
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
   }
 }
 ```
 
-| Name |	Type|	Description|
-|---|---|---|
-|header|	Object|	Header area|
-|- resultCode|	Integer|	Result code|
-|- resultMessage|	String| Result message|
-|- isSuccessful|	Boolean| Successful or not|
+| Name | Type | Not Null | Description |
+|-----------------|---------|:--------:|--------|
+| header | Object | O | Header area |
+| - resultCode | Integer | O | Result code |
+| - resultMessage | String | O | Result message |
+| - isSuccessful | Boolean | O | Success |
 
 <a id="modify-templates"></a>
 
 ### Modify Templates
+
 <a id="request-13"></a>
 
 #### Request
+
 [URL]
 
 ```
@@ -1883,168 +1963,174 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name |	Type|	Description|
-|---|---|---|
-|appkey|	String|	Unique appkey |
-|senderKey|	String|	Sender Key |
-|templateCode|	String|	Template code |
+| Name           | 	Type     | 	Description     |
+|--------------|---------|---------|
+| appkey       | 	String | 	Unique app key |
+| senderKey    | 	String | 	Sender Key   |
+| templateCode | 	String | 	Template Code |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|X-Secret-Key|	String| O | Can be created on console.   |
+
+| Name           | 	Type     | 	Required | 	Description              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | Can be created in the console. |
 
 [Request Body]
 
 ```
 {
-  "templateName" : String,
-  "templateContent" : String,
+  "templateName": String,
+  "templateContent": String,
   "templateMessageType": String,
-  "templateEmphasizeType" : String,
+  "templateEmphasizeType": String,
   "templateExtra": String,
-  "templateTitle" : String,
-  "templateSubtitle" : String,
-  "templateHeader" : String,
-  "templateItem" : {
-    "list" : [{
+  "templateTitle": String,
+  "templateSubtitle": String,
+  "templateHeader": String,
+  "templateItem": {
+    "list": [{
       "title": String,
       "description": String
     }],
-    "summary" : {
+    "summary": {
       "title": String,
       "description": String
     }
   },
-  "templateItemHighlight" : {
+  "templateItemHighlight": {
     "title": String,
     "description": String,
     "imageUrl": String
   },
-  "templateRepresentLink" : {
+  "templateRepresentLink": {
     "linkMo": String,
     "linkPc": String,
     "schemeIos": String,
     "schemeAndroid": String,
   },
-  "templateImageName" : String,
-  "templateImageUrl" : String,
+  "templateImageName": String,
+  "templateImageUrl": String,
   "securityFlag": Boolean,
   "categoryCode": String,
-  "buttons" : [
+  "buttons": [
     {
-      "ordering" : Integer,
-      "type" : String,
-      "name" : String,
-      "linkMo" : String,
-      "linkPc" : String,
-      "schemeIos" : String,
-      "schemeAndroid" : String
-      "bizFormId" : Integer,
+      "ordering": Integer,
+      "type": String,
+      "name": String,
+      "linkMo": String,
+      "linkPc": String,
+      "schemeIos": String,
+      "schemeAndroid": String
+      "bizFormId": Integer,
       "pluginId": String,
       "telNumber": String
     }
   ],
-  "quickReplies" : [
+  "quickReplies": [
     {
-      "ordering" : Integer,
-      "type" : String,
-      "name" : String,
-      "linkMo" : String,
-      "linkPc" : String,
-      "schemeIos" : String,
-      "schemeAndroid" : String
-      "bizFormId" : Integer
+      "ordering": Integer,
+      "type": String,
+      "name": String,
+      "linkMo": String,
+      "linkPc": String,
+      "schemeIos": String,
+      "schemeAndroid": String
+      "bizFormId": Integer
     }
   ]
 }
 ```
 
-| Name                  |	Type|	Required|	Description|
-|-----------------------|---|---|---|
-| templateName          |	String |	O | Template name(up to 150 characters) |
-| templateContent       |	String |	O | Template body(up to 1,300 characters) |
-| templateMessageType   | String | X | Types of template message(BA: Basic, EX: Extra Information, AD: Ad Included, MI: Mixed Purposes, default: Basic) |
-| templateEmphasizeType | String| X| Types of emphasized template(NONE: Basic, TEXT: Emphasized, IMAGE: Image type, default:NONE)<br>- TEXT: templateTitle and templateSubtitle fields are required<br>IMAGE: templateImageName and templateImageUrl fields are required|
-| templateExtra         | String | X | Additional template information(Required, if template message type is[Ad Included/Mixed Purposes]) |
-| tempalteTitle         | String | X| Template title(No more than 50 characters, Android: To be abbreviated if it exceeds 2 lines with more than 23 characters, iOS: To be abbreviated if it exceeds 2 lines with more than 27 characters) |
-| templateSubtitle      | String | X| Auxiliary template phrase(No more than 50 characters, Android: To be abbreviated if it exceeds 18 characters, iOS: To be abbreviated if it exceeds 21 characters) |
-| templateHeader        | String| X| Template header(up to 16 characters) |
-| templateItem          | Object | X| Item |
-| - list                | List | X | Item list(at least 2, up to 10) |
-| -- title              | String | X | Title(up to 6 characters) |
-| -- description        | String | X | Description(up to 23 characters) |
-| - summary             | Object | X | Item summary information |
-| -- title              | String | X | Title(up to 6 characters) |
-| -- description        | String | X | Description(Only variables and monetary units, numbers, commas, and periods, up to 14 characters) |
-| templateItemHighlight | Object | X| Item highlight |
-| - title               | String | X | Title(up to 30 characters, 21 characters with a thumbnail image) |
-| - description         | String | X | Description(up to 19 characters, 13 with a thumbnail image) |
-| - imageUrl            | String | X | Thumbnail image address |
-| templateRepresentLink | Object | X| Main link |
-| - linkMo              | String |	X |	Mobile web link(up to 500 characters)|
-| - linkPc              | String |	X |PC web link(up to 500 characters) |
-| - schemeIos           | String | X |	iOS app link(up to 500 characters) |
-| - schemeAndroid       | String | X |	Android app link(up to 500 characters) |
-| templateImageName     | String |	X | Image name(name of uploaded file) |
-| templateImageUrl      | String |	X | Image URL |
-| securityFlag          | Boolean | X| Security template<br>Set for security messages such as OTP<br>If set, message text is unexposed to all devices except for the main device at the time of sending(default: false) |
-| categoryCode          | String | X | Template category code(Refer to API to View Template Category, default: 999999)<br>For other categories, screened by the lowest priority. |
-| buttons               |	List |	X | List of buttons(up to 5) |
-| - ordering            |	Integer |	X | Button sequence(1~5) |
-| - type                | String |	X |	Button type(WL: Web link, AL: App link, DS: Delivery search, BK: Bot keyword, MD: Message delivery, BC: Bot for Consultation, BT: Bot Transfer, AC: Add channel, BF: Business form, P1: Image secure transmission plugin ID, P2: Personal information use plugin ID, P3: One-click payment plugin ID, TN: Call) |
-| - name                | String |	X |	Button name(required, if there's a button, up to 14 characters)|
-| - linkMo              | String |	X |	Mobile web link(required for the WL type, up to 500 characters)|
-| - linkPc              | String |	X |PC web link(optional for the WL type, up to 500 characters) |
-| - schemeIos           | String | X |	iOS app link(required for the AL type, up to 500 characters) |
-| - schemeAndroid       | String | X |	Android app link(required for the AL type, up to 500 characters) |
-| - bizFormId           |	Integer|	X |	Business form ID(required for BF type) |
-| - pluginId            |	String|	X |	Plugin ID(up to 24 characters) |
-| quickReplies          |	List |	X | Quick reply list(up to 5) |
-| - ordering            |	Integer|	X |	Quick reply order(required  when quick reply exists)|
-| - type                | String |	X |	Qucik reply type(WL: Web link, AL: App link, BK: Bot keyword, BC: Bot for Consultation, BT: Bot Transfer, BF: Business form) |
-| - name                | String |	X |	Quick reply name(required  when quick reply exists, up to 14 characters)|
-| - linkMo              | String |	X |	Mobile web link(required for the WL type, up to 500 characters)|
-| - linkPc              | String |	X |PC web link(optional for the WL type, up to 500 characters) |
-| - schemeIos           | String | X |	iOS app link(required for the AL type, up to 500 characters) |
-| - schemeAndroid       | String | X |	Android app link(required for the AL type, up to 500 characters) |
-| - bizFormId           |	Integer|	X |	Business form ID(required for BF type) |
+| Name                    | 	Type      | 	Required | 	Description                                                                                                                                                                        |
+|-----------------------|----------|-----|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| templateName          | 	String  | 	O  | Template name (up to 150 characters)                                                                                                                                                              |
+| templateContent       | 	String  | 	O  | Template body (up to 1,300 characters)                                                                                                                                                           |
+| templateMessageType   | String   | X   | Types of template message (BA: Basic, EX: Extra Information, AD: Ad Included, MI: Mixed Purposes)                                                                                                                                       |
+| templateEmphasizeType | String   | X   | Template emphasis type (NONE: Default, TEXT: Emphasized, IMAGE: Image type, default: NONE)<br>- TEXT: templateTitle, templateSubtitle fields required<br>- IMAGE: templateImageName, templateImageUrl fields required     |
+| templateExtra         | String   | X   | Additional template information (required if the template message type is [Extra Information/Mixed Purposes])                                                                                                                                 |
+| tempalteTitle         | String   | X   | Template title (No more than 50 characters, Android: To be abbreviated if it exceeds 2 lines with more than 23 characters, iOS: To be abbreviated if it exceeds 2 lines with more than 27 characters)                                                                                                                                         |
+| templateSubtitle      | String   | X   | Auxiliary template phrase (No more than 50 characters, Android: To be abbreviated if it exceeds 18 characters, iOS: To be abbreviated if it exceeds 21 characters)                                                                                                                              |
+| templateHeader        | String   | X   | Template header (up to 16 characters)                                                                                                                                                             |
+| templateItem          | Object   | X   | Item                                                                                                                                                                        |
+| - list                | List     | X   | Item list (minimum 2, maximum 10)                                                                                                                                                     |
+| -- title              | String   | X   | Title (up to 6 characters)                                                                                                                                                                 |
+| -- description        | String   | X   | Description (up to 23 characters)                                                                                                                                                              |
+| - summary             | Object   | X   | Item summary information                                                                                                                                                                  |
+| -- title              | String   | X   | Title (up to 6 characters)                                                                                                                                                                 |
+| -- description        | String   | X   | Description (Only variables and monetary units, numbers, commas, and periods, up to 14 characters)                                                                                                                              |
+| templateItemHighlight | Object   | X   | Item highlight                                                                                                                                                                  |
+| - title               | String   | X   | Title (up to 30 characters; up to 21 characters if a thumbnail image is included)                                                                                                                                            |
+| - description         | String   | X   | Description (up to 19 characters; up to 13 characters if a thumbnail image is included)                                                                                                                                          |
+| - imageUrl            | String   | X   | Thumbnail image URL                                                                                                                                                                 |
+| templateRepresentLink | Object   | X   | Representative link                                                                                                                                                                      |
+| - linkMo              | String   | 	X  | 	Mobile web link (up to 500 characters)                                                                                                                                                         |
+| - linkPc              | String   | 	X  | PC web link (up to 500 characters)                                                                                                                                                           |
+| - schemeIos           | String   | X   | 	iOS app link (up to 500 characters)                                                                                                                                                         |
+| - schemeAndroid       | String   | X   | 	Android app link (up to 500 characters)                                                                                                                                                       |
+| templateImageName     | String   | 	X  | Image name (name of the uploaded file)                                                                                                                                                             |
+| templateImageUrl      | String   | 	X  | Image URL                                                                                                                                                                    |
+| securityFlag          | Boolean  | X   | Whether the template is a security template<br>Set for security messages such as OTP<br>If set, message text is unexposed to all devices except for the main device at the time of sending (default: false)                                                                               |
+| categoryCode          | String   | X   | Template category code (see the Template Category Query API, default: 999999)<br>If the category is "Others," it is reviewed with the lowest priority                                                                                                              |
+| buttons               | 	List    | 	X  | Button list (maximum 5)                                                                                                                                                              |
+| - ordering            | 	Integer | 	X  | Button order (1 to 5)                                                                                                                                                                 |
+| - type                | String   | 	X  | 	Button type (WL: Web link, AL: App link, DS: Delivery search, BK: Bot keyword, MD: Message delivery, BC: Bot for Consultation, BT: Bot Transfer, AC: Add channel, BF: Business form, P1: Image secure transmission plugin ID, P2: Personal information use plugin ID, P3: One-click payment plugin ID, TN: Call) |
+| - name                | String   | 	X  | 	Button name (required if a button exists, up to 14 characters)                                                                                                                               |
+| - linkMo              | String   | 	X  | 	Mobile web link (required field if type is WL, up to 500 characters)                                                                                                                                        |
+| - linkPc              | String   | 	X  | PC web link (optional field if type is WL, up to 500 characters)                                                                                                                                          |
+| - schemeIos           | String   | X   | 	iOS app link (required field if type is AL, up to 500 characters)                                                                                                                                        |
+| - schemeAndroid       | String   | X   | 	Android app link (required field if type is AL, up to 500 characters)                                                                                                                                      |
+| - bizFormId           | 	Integer | 	X  | 	Business form ID (required if type is BF)                                                                                                                                                    |
+| - pluginId            | 	String  | 	X  | 	Plugin ID (up to 24 characters)                                                                                                                                                           |
+| -- telNumber           | 	String  | 	X  | Phone number to forward when using a TN (Call) type button                                                                    |
+| quickReplies          | 	List    | 	X  | Quick Reply list (maximum 5)                                                                                                                                                            |
+| - ordering            | 	Integer | 	X  | 	Quick Reply order (required if Quick Reply exists)                                                                                                                                                   |
+| - type                | String   | 	X  | 	Quick Reply type (WL: Web Link, AL: App Link, BK: Bot Keyword, BC: Bot for Consultation, BT: Bot Transfer, BF: Business Form)                                                                                                                   |
+| - name                | String   | 	X  | 	Quick Reply name (required if Quick Reply exists, up to 14 characters)                                                                                                                           |
+| - linkMo              | String   | 	X  | 	Mobile web link (required field if type is WL, up to 500 characters)                                                                                                                                        |
+| - linkPc              | String   | 	X  | PC web link (optional for the WL type, for up to 500 characters)                                                                                                                          |
+| - schemeIos           | String   | X   | 	iOS app link (required for the AL type, for up to 500 characters)                                                                                                                        |
+| - schemeAndroid       | String   | X   | 	Android app link (required for the AL type, for up to 500 characters)                                                                                                                      |
+| - bizFormId           | 	Integer | 	X  | 	Business form ID (required for the BF type)                                                                                                                                                    |
 
-* The templateAd value is fixed when modifying the AD included(AD) or Mixed Purposes(MI) message type template.
-* The Add Chanel button must be in the first when modifying the AD included(AD) or Mixed Purposes(MI) message type template.
-* The Add Channel(AC) button must be modified with a fixed button name of "Add Channel".
+* The templateAd value is fixed when modifying the AD included (AD) or Mixed Purposes (MI) message type template.
+* The Add Channel button must be in the first when modifying the AD included (AD) or Mixed Purposes (MI) message type template.
+* The button name of the Add Channel (AC) button must be fixed as "Add Channel" when modifying.
 
 <a id="response-14"></a>
 
 #### Response
+
 ```
 {
-  "header" : {
-    "resultCode" :  Integer,
-    "resultMessage" :  String,
-    "isSuccessful" :  boolean
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
   }
 }
 ```
 
-| Name |	Type|	Description|
-|---|---|---|
-|header|	Object|	Header area|
-|- resultCode|	Integer|	Result code|
-|- resultMessage|	String| Result message|
-|- isSuccessful|	Boolean| Successful or not|
+| Name              | Type      | Not Null | Description     |
+|-----------------|---------|:--------:|--------|
+| header          | Object  |    O     | Header     |
+| - resultCode    | Integer |    O     | Result code  |
+| - resultMessage | String  |    O     | Result message |
+| - isSuccessful  | Boolean |    O     | Success  |
 
 <a id="delete-templates"></a>
 
-### Delete Templates
+### Delete Template
+
 <a id="request-14"></a>
 
 #### Request
+
 [URL]
 
 ```
@@ -2054,49 +2140,53 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name |	Type|	Description|
-|---|---|---|
-|appkey|	String|	Unique appkey|
-|senderKey|	String|	Sender Key |
-|templateCode|	String|	Template code |
+| Name         | 	Type   | 	Description    |
+|--------------|---------|-----------------|
+| appkey       | 	String | 	Unique app key |
+| senderKey    | 	String | 	Sender Key     |
+| templateCode | 	String | 	Template Code  |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-* When an approved template is deleted, it is only deleted within NHN Cloud.(Only templates that have not been sent for 3 days can be deleted.)
-* In the case of an approved template, Kakao's internal data cannot be deleted due to the restrictions of KakaoTalk BizMessage.
-* A template remaining in Kakao becomes dormant if it is not used for 1 year, and gets deleted if it remains dormant for 1 year.(If a template becomes dormant or gets deleted on Kakao, the person in charge will be notified.)
 
+* When an approved template is deleted, it is only deleted within NHN Cloud. (Only templates that have not been sent for 3 days can be deleted.)
+* In the case of an approved template, Kakao's internal data cannot be deleted due to the restrictions of KakaoTalk BizMessage.
+* A template remaining in Kakao becomes dormant if it is not used for 1 year, and gets deleted if it remains dormant for 1 year. (If a template becomes dormant or gets deleted on Kakao, the person in charge will be notified.)
 
 <a id="response-15"></a>
 
 #### Response
+
 ```
 {
-  "header" : {
-    "resultCode" :  Integer,
-    "resultMessage" :  String,
-    "isSuccessful" :  boolean
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
   }
 }
 ```
 
-| Name |	Type|	Description|
-|---|---|---|
-|header|	Object|	Header area|
-|- resultCode|	Integer|	Result code|
-|- resultMessage|	String| Result message|
-|- isSuccessful|	Boolean| Successful or not|
+| Name            | Type    | Not Null | Description  |
+|-----------------|---------|:--------:|--------------|
+| header          | Object  |    O     | Header area  |
+| - resultCode    | Integer |    O     | Result code  |
+| - resultMessage | String  |    O     | Result message |
+| - isSuccessful  | Boolean |    O     | Success      |
 
 <a id="inquire-of-templates"></a>
 
-### Inquire of Templates
+### Comment on a Template
+
 <a id="request-15"></a>
 
 #### Request
+
 [URL]
 
 ```
@@ -2106,62 +2196,67 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name |	Type|	Description|
-|---|---|---|
-|appkey|	String|	Unique appkey|
-|senderKey|	String|	Sender Key |
-|templateCode|	String|	Template code |
+| Name         | 	Type   | 	Description  |
+|--------------|---------|---------------|
+| appkey       | 	String | 	App Key      |
+| senderKey    | 	String | 	Sender Key   |
+| templateCode | 	String | 	Template Code |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|X-Secret-Key|	String| O | Can be created on console.   |
+
+| Name         | 	Type   | 	Required | 	Description                       |
+|--------------|---------|-----------|-----------------------------------|
+| X-Secret-Key | 	String | O         | Can be created in the console. |
 
 [Request Body]
 
 ```
 {
-  "comment" : String
+  "comment": String
 }
 ```
 
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|comment|	String |	O | Inquiries |
+| Name    | 	Type   | 	Required | 	Description    |
+|---------|---------|-----------|----------------|
+| comment | 	String | 	O        | Inquiry content |
 
 * When commenting a template in the REJ status, it will be changed to the REQ status.
 
 <a id="response-16"></a>
 
 #### Response
+
 ```
 {
-  "header" : {
-    "resultCode" :  Integer,
-    "resultMessage" :  String,
-    "isSuccessful" :  boolean
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
   }
 }
 ```
 
-| Name |	Type|	Description|
-|---|---|---|
-|header|	Object|	Header area|
-|- resultCode|	Integer|	Result code|
-|- resultMessage|	String| Result message|
-|- isSuccessful|	Boolean| Successful or not|
+| Name            | Type    | Not Null | Description    |
+|-----------------|---------|:--------:|----------------|
+| header          | Object  |    O     | Header area    |
+| - resultCode    | Integer |    O     | Result code    |
+| - resultMessage | String  |    O     | Result message |
+| - isSuccessful  | Boolean |    O     | Success        |
 
 <a id="send-inquiry-on-templates-with-file-attachment"></a>
 
-### Send Inquiry on Templates with File Attachment
+### Submit a Template Inquiry with File Attachments
+
 <a id="request-16"></a>
 
 #### Request
+
 [URL]
 
 ```
@@ -2171,66 +2266,71 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name |	Type|	Description|
-|---|---|---|
-|appkey|	String|	Unique appkey|
-|senderKey|	String|	Sender Key |
-|templateCode|	String|	Template code |
+| Name           | 	Type     | 	Description     |
+|--------------|---------|---------|
+| appkey       | 	String | 	Unique App Key |
+| senderKey    | 	String | 	Sender Key   |
+| templateCode | 	String | 	Template Code |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|X-Secret-Key|	String| O | Can be created on console.   |
+
+| Name           | 	Type     | 	Required | 	Description              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | Can be created in the console. |
 
 [Request Body]
 
 ```
 {
-  "comment" : String,
-  "attachments" : File
+  "comment": String,
+  "attachments": File
 }
 ```
 
-| Name |	Type|	Required| 	Description                                                                                                                                                                                                           |
-|---|---|---|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|comment|	String |	O | Inquiries                                                                                                                                                                                                              |
-|attachments| List<File> | X | List of Attachment(Up to 10)<br>- Supported extensions ( .png, .jpg, .jpeg, .gif, .pdf, .hwp, .doc, .docx )<br>- Maximum size of each individual file 50mb<br>- Maximum total size of files that can be uploaded 100mb |
+| Name          | 	Type        | 	Required | 	Description                                                                                                                                        |
+|-------------|------------|-----|--------------------------------------------------------------------------------------------------------------------------------------------|
+| comment     | 	String    | 	O  | Inquiry content                                                                                                                                      |
+| attachments | List<File> | X   | List of attachments (up to 10)<br>- Supported file extensions: .png, .jpg, .jpeg, .gif, .pdf, .hwp, .doc, .docx<br>- Maximum size per individual file: 50 MB<br>- Maximum total upload size: 100 MB |
 
 * When commenting a template in the REJ status, it will be changed to the REQ status.
 
 <a id="response-17"></a>
 
 #### Response
+
 ```
 {
-  "header" : {
-    "resultCode" :  Integer,
-    "resultMessage" :  String,
-    "isSuccessful" :  boolean
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
   }
 }
 ```
 
-| Name |	Type|	Description|
-|---|---|---|
-|header|	Object|	Header area|
-|- resultCode|	Integer|	Result code|
-|- resultMessage|	String| Result message|
-|- isSuccessful|	Boolean| Successful or not|
+| Name              | Type      | Not Null | Description     |
+|-----------------|---------|:--------:|--------|
+| header          | Object  |    O     | Header area  |
+| - resultCode    | Integer |    O     | Result code  |
+| - resultMessage | String  |    O     | Result message |
+| - isSuccessful  | Boolean |    O     | Success  |
 
 <a id="change-template-to-channel-add-type"></a>
 
-### Change Template to Channel-Add Type
+### Change Template to Add Channel Type
 
 <a id="request-17"></a>
 
 #### Request
+
 [URL]
+
 ```
 PUT  /alimtalk/v2.3/appkeys/{appKey}/senders/{senderKey}/templates/{templateCode}/convert-add-channel
 Content-Type: application/json;charset=UTF-8
@@ -2238,47 +2338,50 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name |	Type|	Description|
-|---|---|---|
-|appkey|	String|	Unique appkey|
-|senderKey|	String|	Sender Key |
-|templateCode|	String|	Template code |
+| Name         | 	Type   | 	Description       |
+|--------------|---------|---------------------|
+| appkey       | 	String | 	Unique app key     |
+| senderKey    | 	String | 	Sender Key         |
+| templateCode | 	String | 	Template Code      |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|X-Secret-Key|	String| O | Can be created on console. |
 
-* The template registered in sender group cannot be converted to a add-channel type.
+| Name         | 	Type   | 	Required | 	Description                        |
+|--------------|---------|-----------|-------------------------------------|
+| X-Secret-Key | 	String | O         | Can be created in the console. |
+
+* Templates registered under a group Sender Profile cannot be converted to the Add Channel type.
 
 <a id="response-18"></a>
 
 #### Response
+
 ```
 {
-  "header" : {
-    "resultCode" :  Integer,
-    "resultMessage" :  String,
-    "isSuccessful" :  boolean
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
   }
 }
 ```
 
-| Name |	Type|	Description|
-|---|---|---|
-|header|	Object|	Header area|
-|- resultCode|	Integer|	Result code|
-|- resultMessage|	String| Result message|
-|- isSuccessful|	Boolean| Successful or not|
+| Name            | Type    | Not Null | Description    |
+|-----------------|---------|:--------:|----------------|
+| header          | Object  |    O     | Header area    |
+| - resultCode    | Integer |    O     | Result code    |
+| - resultMessage | String  |    O     | Result message |
+| - isSuccessful  | Boolean |    O     | Success        |
 
 <a id="single-query-for-template"></a>
 
-### Single Query for Template
+### Get Template
 
 <a id="request-18"></a>
 
@@ -2293,11 +2396,11 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name | Type | Description |
-|--------------|---------|---------|
-| appkey | String | Unique app key |
-| senderKey | String | Sender key |
-| templateCode | String | Template code |
+| Name         | 	Type    | 	Description   |
+|--------------|---------|----------------|
+| appkey       | 	String | 	Unique app key |
+| senderKey    | 	String | 	Sender Key     |
+| templateCode | String  | Template Code  |
 
 [Header]
 
@@ -2307,16 +2410,16 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name | Type | Required | Description |
-|--------------|---------|-----|------------------|
-| X-Secret-Key | String | O | Can be generated from the console. |
+| Name         | 	Type    | 	Required | 	Description                        |
+|--------------|---------|-----------|-------------------------------------|
+| X-Secret-Key | 	String | O         | Can be created in the console. |
 
 | Template Status Code | Description |
 |-----------|------|
-| TSC01 | Requested |
-| TSC02 | Reviewing |
-| TSC03 | Approved |
-| TSC04 | Rejected |
+| TSC01     | Requested   |
+| TSC02     | Reviewing   |
+| TSC03     | Approved    |
+| TSC04     | Rejected    |
 
 [Example]
 
@@ -2425,84 +2528,82 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 }
 ```
 
----
-
-| Name | Type | Not Null | Description |
-|----------------------------------------|---------|:--------:|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| header | Object | O | Header area |
-| - resultCode | Integer | O | Result code |
-| - resultMessage | String | O | Result message |
-| - isSuccessful | Boolean | O | Success status |
-| templates | Object | X | Template list |
-| - plusFriendId | String | O | KakaoTalk channel search ID or sender profile group name |
-| - senderKey | String | O | Sender key |
-| - plusFriendType | String | O | Plus Friend type (NORMAL, GROUP) |
-| - templateCode | String | O | Template code |
-| - kakaoTemplateCode | String | O | Original template code |
-| - templateName | String | O | Template name |
-| - templateMessageType | String | X | Template message type (BA: basic, EX: additional information, AD: channel addition, MI: complex) |
-| - templateEmphasizeType | String | X | Template highlight type (NONE: basic, TEXT: highlight, IMAGE: image, ITEM_LIST: item list) |
-| - templateContent | String | X | Template body |
-| - templateExtra | String | X | Template additional information |
-| - templateAd | String | X | Request for opt-in or simple advertising text within the template |
-| - templateTitle | String | X | Template title |
-| - templateSubtitle | String | X | Template additional text |
-| - templateHeader | String | X | Template header (maximum 16 characters) |
-| - templateItem | Object | X | Item |
-| -- list | List | X | List of items (minimum 2, maximum 10) |
-| --- title | String | X | Title (maximum 6 characters) |
-| --- description | String | X | Description (maximum 23 characters) |
-| -- summary | Object | X | Item summary information |
-| --- title | String | X | Title (maximum 6 characters) |
-| --- description | String | X | Description (variables, currency units, numbers, commas, and periods only, up to 14 characters) |
-| - templateItemHighlight | Object | X | Item highlight |
-| -- title | String | X | Title (up to 30 characters, 21 characters if thumbnail image available) |
-| -- description | String | X | Description (up to 19 characters, 13 characters if thumbnail image available) |
-| -- imageUrl | String | X | Thumbnail image address |
-| - templateRepresentLink | Object | X | Representative link |
-| -- linkMo | String | X | Mobile web link (up to 500 characters) |
-| -- linkPc | String | X | PC web link (up to 500 characters) |
-| -- schemeIos | String | X | iOS app link (up to 500 characters) |
-| -- schemeAndroid | String | X | Android app link (up to 500 characters) |
-| - templateImageName | String | X | Image name (uploaded file name) |
-| - templateImageUrl | String | X | Image URL |
-| - buttons | List | X | Button list |
-| -- ordering | Integer | X | Button order (1 to 5) |
-| -- type | String | X | Button type (WL: Web Link, AL: App Link, DS: Delivery Tracking, BK: Bot Keyword, MD: Message Forwarding, BC: Chat Conversion, BT: Bot Conversion, AC: Add Channel, BF: Business Form, P1: Image Security Transmission Plugin ID, P2: Personal Information Use Plugin ID, P3: One-Click Payment Plugin ID, TN: Call) |
-| -- name | String | X | Button name |
-| -- linkMo | String | X | Mobile web link (required field for WL type) |
-| -- linkPc | String | X | PC web link (optional field for WL type) |
-| -- schemeIos | String | X | iOS app link (required field for AL type) |
-| -- schemeAndroid | String | X | Android app link (required field for AL type) |
-| -- bizFormId | Integer | X | Business form ID (required for BF type) |
-| -- pluginId | String | X | Plugin ID (up to 24 characters) |
-| -- telNumber | String | X | Phone number to be sent when TN (Call) type button is pressed |
-| - quickReplies | List | X | Quick link list (up to 5) |
-| -- ordering | Integer | X | Quick link order (required if there is a quick link) |
-| -- type | String | X | Direct link type (WL: Web link, AL: App link, BK: Bot keyword, BC: Conversion to consultation chat, BT: Conversion to bot, BF: Business form) |
-| -- name | String | X | Direct link name (required if direct link is available, up to 14 characters) |
-| -- linkMo | String | X | Mobile web link (required field for WL type, up to 500 characters) |
-| -- linkPc | String | X | PC web link (optional field for WL type, up to 500 characters) |
-| -- schemeIos | String | X | iOS app link (required field for AL type, up to 500 characters) |
-| -- schemeAndroid | String | X | Android app link (required field for AL type, up to 500 characters) |
-| -- bizFormId | Integer | X | Business Form ID (required for BF type) |
-| - comments | List | X | Review result |
-| -- id | Integer | X | Inquiry ID |
-| -- content | String | X | Inquiry content |
-| -- userName | String | X | Author |
-| -- createAt | String | O | Registration date |
-| -- attachment | List | X | Attachment |
-| --- originalFileName | String | X | Attached file name |
-| --- filePath | String | X | Attached file path |
-| -- status | String | X | Comment status (INQ: Inquiry, APR: Approved, REJ: Rejected, REP: Reply, REQ: Under Review) |
-| - status | String | O | Template status |
-| - statusName | String | X | Template status name |
-| - securityFlag | Boolean | X | Secure template |
-| - categoryCode | String | X | Template category code |
-| - block | Boolean | X | Blocked |
-| - dormant | Boolean | X | Dormant |
-| - createDate | String | O | Created at |
-| - updateDate | String | X | Modified at |
+| Name                    | Type    | Not Null | Description                                                                                                                                                                                                                                                                         |
+|-------------------------|---------|:--------:|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| header                  | Object  |    O     | Header area                                                                                                                                                                                                                                                                         |
+| - resultCode            | Integer |    O     | Result code                                                                                                                                                                                                                                                                         |
+| - resultMessage         | String  |    O     | Result message                                                                                                                                                                                                                                                                      |
+| - isSuccessful          | Boolean |    O     | Success                                                                                                                                                                                                                                                                             |
+| templates               | Object  |    X     | Template list                                                                                                                                                                                                                                                                       |
+| - plusFriendId          | String  |    O     | KakaoTalk Channel search ID or Sender Profile group name                                                                                                                                                                                                                            |
+| - senderKey             | String  |    O     | Sender Key                                                                                                                                                                                                                                                                          |
+| - plusFriendType        | String  |    O     | PlusFriend type (NORMAL, GROUP)                                                                                                                                                                                                                                                     |
+| - templateCode          | String  |    O     | Template Code                                                                                                                                                                                                                                                                       |
+| - kakaoTemplateCode     | String  |    O     | Original template code                                                                                                                                                                                                                                                              |
+| - templateName          | String  |    O     | Template name                                                                                                                                                                                                                                                                       |
+| - templateMessageType   | String  |    X     | Types of template message (BA: Basic, EX: Extra Information, AD: Ad Included, MI: Mixed Purposes, default: Basic)                                                                                                                                                                   |
+| - templateEmphasizeType | String  |    X     | Types of emphasized template (NONE: Basic, TEXT: Emphasized, IMAGE: Image type, ITEM_LIST: Item List type, default: NONE)                                                                                                                                                           |
+| - templateContent       | String  |    X     | Template body                                                                                                                                                                                                                                                                       |
+| - templateExtra         | String  |    X     | Template additional information                                                                                                                                                                                                                                                     |
+| - templateAd            | String  |    X     | Request for consent of receiving within template or simple ad phrases                                                                                                                                                                                                               |
+| - tempalteTitle         | String  |    X     | Template title                                                                                                                                                                                                                                                                      |
+| - templateSubtitle      | String  |    X     | Template subtitle                                                                                                                                                                                                                                                                   |
+| - templateHeader        | String  |    X     | Template header (up to 16 characters)                                                                                                                                                                                                                                               |
+| - templateItem          | Object  |    X     | Item                                                                                                                                                                                                                                                                                |
+| -- list                 | List    |    X     | Item list (minimum 2, maximum 10)                                                                                                                                                                                                                                                   |
+| --- title               | String  |    X     | Title (up to 6 characters)                                                                                                                                                                                                                                                          |
+| --- description         | String  |    X     | Description (up to 23 characters)                                                                                                                                                                                                                                                   |
+| -- summary              | Object  |    X     | Item summary information                                                                                                                                                                                                                                                            |
+| --- title               | String  |    X     | Title (up to 6 characters)                                                                                                                                                                                                                                                          |
+| --- description         | String  |    X     | Description (only variables and monetary units, numbers, commas, and periods, up to 14 characters)                                                                                                                                                                                  |
+| - templateItemHighlight | Object  |    X     | Item highlight                                                                                                                                                                                                                                                                      |
+| -- title                | String  |    X     | Title (up to 30 characters; up to 21 characters if a thumbnail image is present)                                                                                                                                                                                                    |
+| -- description          | String  |    X     | Description (up to 19 characters; up to 13 characters if a thumbnail image is present)                                                                                                                                                                                              |
+| -- imageUrl             | String  |    X     | Thumbnail image URL                                                                                                                                                                                                                                                                 |
+| - templateRepresentLink | Object  |    X     | Representative link                                                                                                                                                                                                                                                                 |
+| -- linkMo               | String  |    X     | Mobile web link (up to 500 characters)                                                                                                                                                                                                                                              |
+| -- linkPc               | String  |    X     | PC web link (up to 500 characters)                                                                                                                                                                                                                                                  |
+| -- schemeIos            | String  |    X     | iOS app link (up to 500 characters)                                                                                                                                                                                                                                                 |
+| -- schemeAndroid        | String  |    X     | Android app link (up to 500 characters)                                                                                                                                                                                                                                             |
+| - templateImageName     | String  |    X     | Image name (uploaded file name)                                                                                                                                                                                                                                                     |
+| - templateImageUrl      | String  |    X     | Image URL                                                                                                                                                                                                                                                                           |
+| - buttons               | List    |    X     | Button list                                                                                                                                                                                                                                                                         |
+| -- ordering             | Integer |    X     | Button order (1 to 5)                                                                                                                                                                                                                                                               |
+| -- type                 | String  |    X     | Button type (WL: Web link, AL: App link, DS: Delivery search, BK: Bot keyword, MD: Message delivery, BC: Bot for Consultation, BT: Bot Transfer, AC: Add channel, BF: Business form, P1: Image secure transmission plugin ID, P2: Personal information use plugin ID, P3: One-click payment plugin ID, TN: Call) |
+| -- name                 | String  |    X     | Button name                                                                                                                                                                                                                                                                         |
+| -- linkMo               | String  |    X     | Mobile web link (required for the WL type)                                                                                                                                                        |
+| -- linkPc               | String  |    X     | PC web link (optional for the WL type)                                                                                                                                                         |
+| -- schemeIos            | String  |    X     | iOS app link (required for the AL type)                                                                                                                                                        |
+| -- schemeAndroid        | String  |    X     | Android app link (required for the AL type)                                                                                                                                                      |
+| -- bizFormId            | Integer |    X     | Business form ID (required for the BF type)                                                                                                                                                           |
+| -- pluginId             | String  |    X     | Plugin ID (up to 24 characters)                                                                                                                                                                  |
+| -- telNumber            | 	String  | 	X  | Phone number to send for TN (Call) type buttons                                                                                                                                                       |
+| - quickReplies          | List    |    X     | Quick reply list (up to 5 items)                                                                                                                                                                  |
+| -- ordering             | Integer |    X     | Quick reply order (required when quick reply exists)                                                                                                                                                          |
+| -- type                 | String  |    X     | Quick reply type (WL: Web link, AL: App link, BK: Bot keyword, BC: Bot for Consultation, BT: Bot Transfer, BF: Business form)                                                                                                          |
+| -- name                 | String  |    X     | Quick reply name (required when quick reply exists, up to 14 characters)                                                                                                                                                  |
+| -- linkMo               | String  |    X     | Mobile web link (required for the WL type, for up to 500 characters)                                                                                                                                               |
+| -- linkPc               | String  |    X     | PC web link (optional for the WL type, for up to 500 characters)                                                                                                                                                |
+| -- schemeIos            | String  |    X     | iOS app link (required for the AL type, for up to 500 characters)                                                                                                                                               |
+| -- schemeAndroid        | String  |    X     | Android app link (required for the AL type, for up to 500 characters)                                                                                                                                             |
+| -- bizFormId            | Integer |    X     | Business form ID (required for the BF type)                                                                                                                                                           |
+| - comments              | List    |    X     | Review result                                                                                                                                                                            |
+| -- id                   | Integer |    X     | Inquiry ID                                                                                                                                                                           |
+| -- content              | String  |    X     | Inquiry content                                                                                                                                                                            |
+| -- userName             | String  |    X     | Author                                                                                                                                                                              |
+| -- createAt             | String  |    O     | Registration date                                                                                                                                                                            |
+| -- attachment           | List    |    X     | Attachment                                                                                                                                                                    |
+| --- originalFileName    | String  |    X     | Attachment file name                                                                                                                                                                           |
+| --- filePath            | String  |    X     | Attachment file path                                                                                                                                                                         |
+| -- status               | String  |    X     | Comment status (INQ: Inquired, APR: Approved, REJ: Rejected, REP: Replied, REQ: Under Review)                                                                                                                             |
+| - status                | String  |    O     | Template Status                                                                                                                                                                           |
+| - statusName            | String  |    X     | Template status name                                                                                                                                                                          |
+| - securityFlag          | Boolean |    X     | Whether the template is a security template                                                                                                                                                        |
+| - categoryCode          | String  |    X     | Template category code                                                                                                                                                                      |
+| - block                 | Boolean |    X     | Whether blocked                                                                                                                                                                            |
+| - dormant               | Boolean |    X     | Whether dormant                                                                                                                                                                            |
+| - createDate            | String  |    O     | Creation date                                                                                                                                                                             |
+| - updateDate            | String  |    X     | Modification date                                                                                                                                                                             |
 
 <a id="list-templates"></a>
 
@@ -2521,39 +2622,42 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name |	Type|	Description|
-|---|---|---|
-|appkey|	String|	Unique appkey|
-|senderKey|	String|	Sender Key |
+| Name        | 	Type     | 	Description     |
+|-----------|---------|---------|
+| appkey    | 	String | 	Unique appkey |
+| senderKey | 	String | 	Sender Key   |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|X-Secret-Key|	String| O | Can be created on console.   |
+
+| Name           | 	Type     | 	Required | 	Description              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | Can be created in the console. |
 
 [Query parameter]
 
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|templateCode|	String|	X |	Template code|
-|templateName|	String|	X |	Template name|
-|templateStatus| String |	X | Template status code|
-|pageNum|	Integer|	X|	Page number(default:1)|
-|pageSize|	Integer|	X|	Number of queries(default: 15, Max: 1000)|
+| Name             | 	Type      | 	Required | 	Description                            |
+|----------------|----------|-----|--------------------------------|
+| templateCode   | 	String  | 	X  | 	Template Code                        |
+| templateName   | 	String  | 	X  | 	Template name                        |
+| templateStatus | String   | 	X  | Template status code                      |
+| pageNum        | 	Integer | 	X  | 	Page number (Default: 1)            |
+| pageSize       | 	Integer | 	X  | 	Number of records to retrieve (Default: 15, Max: 1,000) |
 
-|Template status code| Description|
-|---|---|
-| TSC01 | Request |
-| TSC02 | Inspecting |
-| TSC03 | Approved |
-| TSC04 | Rejected |
+| Template status code | Description   |
+|-----------|------|
+| TSC01     | Requested   |
+| TSC02     | Reviewing |
+| TSC03     | Approved   |
+| TSC04     | Rejected   |
 
 [Example]
+
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates?templateStatus={template status code}"
 ```
@@ -2561,13 +2665,14 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 <a id="response-20"></a>
 
 #### Response
+
 ```
 
 {
-  "header" : {
-      "resultCode" :  Integer,
-      "resultMessage" :  String,
-      "isSuccessful" :  boolean
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
   },
   "templateListResponse": {
       "templates": [
@@ -2576,60 +2681,63 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
               "senderKey": String,
               "plusFriendType": String,
               "templateCode": String,
+              "kakaoTemplateCode": String,
               "templateName": String,
-              "templateMessageType" : String,
+              "templateMessageType": String,
               "templateEmphasizeType": String,
               "templateContent": String,
-              "templateExtra" : String,
-              "templateAd" : String,
-              "templateTitle" : String,
-              "templateSubtitle" : String,
-              "templateHeader" : String,
-              "templateItem" : {
-                "list" : [{
+              "templateExtra": String,
+              "templateAd": String,
+              "templateTitle": String,
+              "templateSubtitle": String,
+              "templateHeader": String,
+              "templateItem": {
+                "list": [{
                   "title": String,
                   "description": String
                 }],
-                "summary" : {
+                "summary": {
                   "title": String,
                   "description": String
                 }
               },
-              "templateItemHighlight" : {
+              "templateItemHighlight": {
                 "title": String,
                 "description": String,
                 "imageUrl": String
               },
-              "templateRepresentLink" : {
+              "templateRepresentLink": {
                 "linkMo": String,
                 "linkPc": String,
                 "schemeIos": String,
                 "schemeAndroid": String,
               },
-              "templateImageName" : String,
-              "templateImageUrl" : String,
+              "templateImageName": String,
+              "templateImageUrl": String,
               "buttons": [
                 {
-                    "ordering":Integer,
+                    "ordering": Integer,
                     "type": String,
                     "name": String,
                     "linkMo": String,
                     "linkPc": String,
                     "schemeIos": String,
                     "schemeAndroid": String,
+                    "bizFormId": Integer,
+                    "pluginId": String,
                     "telNumber": String
                 }
               ],
-              "quickReplies" : [
+              "quickReplies": [
                 {
-                  "ordering" : Integer,
-                  "type" : String,
-                  "name" : String,
-                  "linkMo" : String,
-                  "linkPc" : String,
-                  "schemeIos" : String,
-                  "schemeAndroid" : String
-                  "bizFormId" : Integer
+                    "ordering": Integer,
+                    "type": String,
+                    "name": String,
+                    "linkMo": String,
+                    "linkPc": String,
+                    "schemeIos": String,
+                    "schemeAndroid": String,
+                    "bizFormId": Integer
                 }
               ],
               "comments": [
@@ -2651,93 +2759,93 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
               "categoryCode": String,
               "createDate": String,
               "updateDate": String
-            }
-        ],
-        "totalCount": Integer
-    }
+          }
+      ],
+      "totalCount": Integer
+  }
 }
 ```
 
-| Name                     |	Type| 	Description                                                                                                                                                                                                                                                                                           |
-|--------------------------|---|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| header                   |	Object| 	Header area                                                                                                                                                                                                                                                                                           |
-| - resultCode             |	Integer| 	Result code                                                                                                                                                                                                                                                                                           |
-| - resultMessage          |	String| Result message                                                                                                                                                                                                                                                                                         |
-| - isSuccessful           |	Boolean| Successful or not                                                                                                                                                                                                                                                                                      |
-| templateListResponse     |	Object| 	Body area                                                                                                                                                                                                                                                                                             |
-| - templates              | List | 	Template list                                                                                                                                                                                                                                                                                         |
-| -- plusFriendId          | String | 	PlusFriend ID                                                                                                                                                                                                                                                                                         |
-| -- senderKey             | String | Sender Key                                                                                                                                                                                                                                                                                             |
-| -- plusFriendType        | String | PlusFriend type(NORMAL, GROUP)                                                                                                                                                                                                                                                                         |
-| -- templateCode          | String | 	Template code                                                                                                                                                                                                                                                                                         |
-| -- kakaoTemplateCode     | String | 	Kakao's origin template code                                                                                                                                                                                                                                                                          |
-| -- templateName          | String | 	Template name                                                                                                                                                                                                                                                                                         |
-| -- templateMessageType   | String | Types of template message(BA: Basic, EX: Extra Information, AD: Ad Included, MI: Mixed Purposes)                                                                                                                                                                                                       |
-| -- templateEmphasizeType | String| Types of emphasized template(NONE: Basic, TEXT: Emphasized, IMAGE: Image type, default:NONE)                                                                                                                                                                                                           |
-| -- templateContent       | String | 	Template body                                                                                                                                                                                                                                                                                         |
-| -- templateExtra         | String | Additional template information                                                                                                                                                                                                                                                                        |
-| -- templateAd            | String | Request for consent of receiving within template or simple ad phrases                                                                                                                                                                                                                                  |
-| -- tempalteTitle         | String | Template title                                                                                                                                                                                                                                                                                         |
-| -- templateSubtitle      | String | Auxiliary template phrase                                                                                                                                                                                                                                                                              |
-| - templateHeader         | String| Template header(up to 16 characters)                                                                                                                                                                                                                                                                   |
-| - templateItem           | Object | Item                                                                                                                                                                                                                                                                                                   |
-| -- list                  | List | Item list(at least 2, up to 10)                                                                                                                                                                                                                                                                        |
-| --- title                | String | Title(up to 6 characters)                                                                                                                                                                                                                                                                              |
-| --- description          | String | Description(up to 23 characters)                                                                                                                                                                                                                                                                       |
-| -- summary               | Object | Item summary information                                                                                                                                                                                                                                                                               |
-| --- title                | String | Title(up to 6 characters)                                                                                                                                                                                                                                                                              |
-| --- description          | String | Description(Only variables and monetary units, numbers, commas, and periods, up to 14 characters)                                                                                                                                                                                                      |
-| - templateItemHighlight  | Object | Item highlight                                                                                                                                                                                                                                                                                         |
-| -- title                 | String | Title(up to 30 characters, 21 characters with a thumbnail image)                                                                                                                                                                                                                                       |
-| -- description           | String | Description(up to 19 characters, 13 with a thumbnail image)                                                                                                                                                                                                                                            |
-| -- imageUrl              | String | Thumbnail image address                                                                                                                                                                                                                                                                                |
-| -templateRepresentLink   | Object | Main link                                                                                                                                                                                                                                                                                              |
-| -- linkMo                | String | 	Mobile web link(up to 500 characters)                                                                                                                                                                                                                                                                 |
-| -- linkPc                | String | PC web link(up to 500 characters)                                                                                                                                                                                                                                                                      |
-| -- schemeIos             | String | 	iOS app link(up to 500 characters)                                                                                                                                                                                                                                                                    |
-| -- schemeAndroid         | String | 	Android app link(up to 500 characters)                                                                                                                                                                                                                                                                |
-| -- templateImageName     | String | Image name(name of uploaded file)                                                                                                                                                                                                                                                                      |
-| -- templateImageUrl      | String | 	Image URL                                                                                                                                                                                                                                                                                             |
-| -- buttons               | List | 	List of buttons                                                                                                                                                                                                                                                                                       |
-| --- ordering             | Integer | 	Button sequence(1~5)                                                                                                                                                                                                                                                                                  |
-| --- type                 | String | 	Button type(WL: Web link, AL: App link, DS: Delivery search, BK: Bot keyword, MD: Message delivery, BC: Bot for Consultation, BT: Bot Transfer, AC: Add channel, BF: Business form, P1: Image secure transmission plugin ID, P2: Personal information use plugin ID, P3: One-click payment plugin ID, TN: Call) |
-| --- name                 | String | 	Button name                                                                                                                                                                                                                                                                                           |
-| --- linkMo               | String | 	Mobile web link(required for the WL type)                                                                                                                                                                                                                                                             |
-| --- linkPc               | String | 	PC web link(optional for the WL type)                                                                                                                                                                                                                                                                 |
-| --- schemeIos            | String | 	iOS app link(required for the AL type)                                                                                                                                                                                                                                                                |
-| --- schemeAndroid        | String | 	Android app link(required for the AL type)                                                                                                                                                                                                                                                            |
-| --- bizFormId            |	Integer| 	X                                                                                                                                                                                                                                                                                                     |	Business form ID(required for BF type) |
-| --- pluginId             |	String| 	X                                                                                                                                                                                                                                                                                                     |	Plugin ID(up to 24 characters) |
-| --- telNumber            | 	String  | 	X  | When you press the TN (call) button, the phone number to be transferred                                                                    |
-| -- quickReplies          |	List | 	X                                                                                                                                                                                                                                                                                                     | Quick reply list(up to 5) |
-| --- ordering             |	Integer| 	X                                                                                                                                                                                                                                                                                                     |	Quick reply order(required  when quick reply exists)|
-| --- type                 | String | 	X                                                                                                                                                                                                                                                                                                     |	Qucik reply type(WL: Web link, AL: App link, BK: Bot keyword, BC: Bot for Consultation, BT: Bot Transfer, BF: Business form) |
-| --- name                 | String | 	X                                                                                                                                                                                                                                                                                                     |	Quick reply name(required  when quick reply exists, up to 14 characters)|
-| --- linkMo               | String | 	X                                                                                                                                                                                                                                                                                                     |	Mobile web link(required for the WL type, up to 500 characters)|
-| --- linkPc               | String | 	X                                                                                                                                                                                                                                                                                                     |PC web link(optional for the WL type, up to 500 characters) |
-| --- schemeIos            | String | X                                                                                                                                                                                                                                                                                                      |	iOS app link(required for the AL type, up to 500 characters) |
-| --- schemeAndroid        | String | X                                                                                                                                                                                                                                                                                                      |	Android app link(required for the AL type, up to 500 characters) |
-| --- bizFormId            |	Integer| 	X                                                                                                                                                                                                                                                                                                     |	Business form ID(required for BF type) |
-| -- comments              | List | Inspection result                                                                                                                                                                                                                                                                                      |
-| --- id                   | Integer | Inquiry ID                                                                                                                                                                                                                                                                                             |
-| --- content              |  String | Inquiries                                                                                                                                                                                                                                                                                              |
-| --- userName             | String | Creator                                                                                                                                                                                                                                                                                                |
-| --- createAt             | String | Date of registration                                                                                                                                                                                                                                                                                   |
-| --- attachment           | List | Attachment                                                                                                                                                                                                                                                                                             |
-| ---- originalFileName    | String | Attachment file name                                                                                                                                                                                                                                                                                   |
-| ---- filePath            | String | Attachment file path                                                                                                                                                                                                                                                                                   |
-| --- status               | String | Comment status(INQ: Inquired, APR: Approved, REJ: Rejected, REP: Replied, REQ: Under inspection)                                                                                                                                                                                                       |
-| -- status                | String | Template status                                                                                                                                                                                                                                                                                        |
-| -- statusName            | String | Template status name                                                                                                                                                                                                                                                                                   |
-| -- securityFlag          | Boolean | Whether it is a security template                                                                                                                                                                                                                                                                      |
-| -- categoryCode          | String | Template category code                                                                                                                                                                                                                                                                                 |
-| -- createDate            | String | Date of creation                                                                                                                                                                                                                                                                                       |
-| -- updateDate            | String | Date of modification                                                                                                                                                                                                                                                                                   |
-| - totalCount             | Integer | Total count                                                                                                                                                                                                                                                                                            |
+| Name                     | Type    | Not Null | Description                                                                                                                                                                                                                                       |
+|--------------------------|---------|:--------:|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| header                   | Object  |    O     | Header area                                                                                                                                                                                                                                       |
+| - resultCode             | Integer |    O     | Result code                                                                                                                                                                                                                                       |
+| - resultMessage          | String  |    O     | Result message                                                                                                                                                                                                                                    |
+| - isSuccessful           | Boolean |    O     | Success                                                                                                                                                                                                                                           |
+| templateListResponse     | Object  |    X     | Body area                                                                                                                                                                                                                                         |
+| - templates              | List    |    X     | Template list                                                                                                                                                                                                                                     |
+| -- plusFriendId          | String  |    O     | KakaoTalk Channel search ID or Sender Profile group name                                                                                                                                                                                          |
+| -- senderKey             | String  |    O     | Sender Key                                                                                                                                                                                                                                        |
+| -- plusFriendType        | String  |    O     | PlusFriend type (NORMAL, GROUP)                                                                                                                                                                                                                   |
+| -- templateCode          | String  |    O     | Template Code                                                                                                                                                                                                                                     |
+| -- kakaoTemplateCode     | String  |    O     | Original template code                                                                                                                                                                                                                            |
+| -- templateName          | String  |    O     | Template name                                                                                                                                                                                                                                     |
+| -- templateMessageType   | String  |    X     | Types of template message (BA: Basic, EX: Extra Information, AD: Ad Included, MI: Mixed Purposes, default: Basic)                                                                                                                                 |
+| -- templateEmphasizeType | String  |    X     | Template emphasis display type (NONE: Default, TEXT: Emphasis, IMAGE: Image type, ITEM_LIST: Item List type)                                                                                                                                      |
+| -- templateContent       | String  |    X     | Template body                                                                                                                                                                                                                                     |
+| -- templateExtra         | String  |    X     | Template additional information                                                                                                                                                                                                                   |
+| -- templateAd            | String  |    X     | Consent to receive request or simple advertisement text within the template                                                                                                                                                                       |
+| -- tempalteTitle         | String  |    X     | Template title                                                                                                                                                                                                                                    |
+| -- templateSubtitle      | String  |    X     | Template subtitle                                                                                                                                                                                                                                 |
+| - templateHeader         | String  |    X     | Template header (up to 16 characters)                                                                                                                                                                                                             |
+| - templateItem           | Object  |    X     | Item                                                                                                                                                                                                                                              |
+| -- list                  | List    |    X     | Item list (minimum 2, maximum 10)                                                                                                                                                                                                                 |
+| --- title                | String  |    X     | Title (up to 6 characters)                                                                                                                                                                                                                        |
+| --- description          | String  |    X     | Description (up to 23 characters)                                                                                                                                                                                                                 |
+| -- summary               | Object  |    X     | Item summary information                                                                                                                                                                                                                          |
+| --- title                | String  |    X     | Title (up to 6 characters)                                                                                                                                                                                                                        |
+| --- description          | String  |    X     | Description (Only variables and monetary units, numbers, commas, and periods, up to 14 characters)                                                                                                                                                |
+| - templateItemHighlight  | Object  |    X     | Item highlight                                                                                                                                                                                                                                    |
+| -- title                 | String  |    X     | Title (up to 30 characters; up to 21 characters if a thumbnail image is present)                                                                                                                                                                  |
+| -- description           | String  |    X     | Description (up to 19 characters; up to 13 characters if a thumbnail image is present)                                                                                                                                                            |
+| -- imageUrl              | String  |    X     | Thumbnail image URL                                                                                                                                                                                                                               |
+| - templateRepresentLink  | Object  |    X     | Representative link                                                                                                                                                                                                                               |
+| -- linkMo                | String  |    X     | Mobile web link (up to 500 characters)                                                                                                                                                                                                            |
+| -- linkPc                | String  |    X     | PC web link (up to 500 characters)                                                                                                                                                                                                                |
+| -- schemeIos             | String  |    X     | iOS app link (up to 500 characters)                                                                                                                                                                                                               |
+| -- schemeAndroid         | String  |    X     | Android app link (up to 500 characters)                                                                                                                                                                                                           |
+| -- templateImageName     | String  |    X     | Image name (uploaded file name)                                                                                                                                                                                                                   |
+| -- templateImageUrl      | String  |    X     | Image URL                                                                                                                                                                                                                                         |
+| -- buttons               | List    |    X     | Button list                                                                                                                                                                                                                                       |
+| --- ordering             | Integer |    X     | Button order (1 to 5)                                                                                                                                                                                                                             |
+| --- type                 | String  |    X     | Button type (WL: Web link, AL: App link, DS: Delivery search, BK: Bot keyword, MD: Message delivery, BC: Bot for Consultation, BT: Bot Transfer, AC: Add channel, BF: Business form, P1: Image secure transmission plugin ID, P2: Personal information use plugin ID, P3: One-click payment plugin ID, TN: Call) |
+| --- name                 | String  |    X     | Button name                                                                                                                                                                                                                                       |
+| --- linkMo               | String  |    X     | Mobile web link (required for the WL type)                                                                                                                                                                                                        |
+| --- linkPc               | String  |    X     | PC web link (optional for the WL type)                                                                                                                                               |
+| --- schemeIos            | String  |    X     | iOS app link (required for the AL type)                                                                                                                                              |
+| --- schemeAndroid        | String  |    X     | Android app link (required for the AL type)                                                                                                                                            |
+| --- bizFormId            | Integer |    X     | Business form ID (required for the BF type)                                                                                                                                                 |
+| --- pluginId             | String  |    X     | Plugin ID (up to 24 characters)                                                                                                                                                        |
+| --- telNumber            | 	String  | 	X  | Phone number to send for TN (call) type buttons                                                                                                    |
+| -- quickReplies          | List    |    X     | Quick reply list (up to 5)                                                                                                                                                        |
+| --- ordering             | Integer |    X     | Quick reply order (required when quick reply exists)                                                                                                                                                |
+| --- type                 | String  |    X     | Quick reply type (WL: Web link, AL: App link, BK: Bot keyword, BC: Bot for Consultation, BT: Bot Transfer, BF: Business form)                                                                                                |
+| --- name                 | String  |    X     | Quick reply name (required when quick reply exists, up to 14 characters)                                                                                                                                        |
+| --- linkMo               | String  |    X     | Mobile web link (required for the WL type, for up to 500 characters)                                                                                                                                     |
+| --- linkPc               | String  |    X     | PC web link (required for the WL type, for up to 500 characters)                                                                                                                                      |
+| --- schemeIos            | String  |    X     | iOS app link (required for the AL type, for up to 500 characters)                                                                                                                                     |
+| --- schemeAndroid        | String  |    X     | Android app link (required for the AL type, for up to 500 characters)                                                                                                                                   |
+| --- bizFormId            | Integer |    X     | Business form ID (required for the BF type)                                                                                                                                                 |
+| -- comments              | List    |    X     | Inspection results                                                                                                                                                                  |
+| --- id                   | Integer |    X     | Inquiry ID                                                                                                                                                                 |
+| --- content              | String  |    X     | Inquiry content                                                                                                                                                                  |
+| --- userName             | String  |    X     | Author                                                                                                                                                                    |
+| --- createAt             | String  |    O     | Registration date                                                                                                                                                                  |
+| --- attachment           | List    |    X     | Attachments                                                                                                                                                                  |
+| ---- originalFileName    | String  |    X     | Attachment file name                                                                                                                                                                 |
+| ---- filePath            | String  |    X     | Attachment file path                                                                                                                                                               |
+| --- status               | String  |    X     | Comment status (INQ: Inquired, APR: Approved, REJ: Rejected, REP: Replied, REQ: Under Review)                                                                                                                   |
+| -- status                | String  |    O     | Template status                                                                                                                                                                 |
+| -- statusName            | String  |    X     | Template status name                                                                                                                                                                |
+| -- securityFlag          | Boolean |    X     | Whether the template is a security template                                                                                                                                              |
+| -- categoryCode          | String  |    X     | Template category code                                                                                                                                                            |
+| -- createDate            | String  |    O     | Creation date                                                                                                                                                                   |
+| -- updateDate            | String  |    X     | Modification date                                                                                                                                                                   |
+| - totalCount             | Integer |    X     | Total count                                                                                                                                                                    |
 
 <a id="list-template-modifications"></a>
 
-### List Template modifications
+### List Template Modifications
 
 <a id="request-20"></a>
 
@@ -2752,23 +2860,26 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name |	Type|	Description|
-|---|---|---|
-|appkey|	String|	Unique appkey|
-|senderKey|	String|	Sender Key |
-|templateCode|	String|	Template code |
+| Name         | 	Type   | 	Description      |
+|--------------|---------|-------------------|
+| appkey       | 	String | 	Unique app key   |
+| senderKey    | 	String | 	Sender Key       |
+| templateCode | 	String | 	Template Code    |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|X-Secret-Key|	String| O | Can be created on console.   |
+
+| Name         | 	Type   | 	Required | 	Description                          |
+|--------------|---------|-----------|---------------------------------------|
+| X-Secret-Key | 	String | O         | Can be created in the console. |
 
 [Example]
+
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}/modifications"
 ```
@@ -2776,13 +2887,14 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 <a id="response-21"></a>
 
 #### Response
+
 ```
 
 {
-  "header" : {
-      "resultCode" :  Integer,
-      "resultMessage" :  String,
-      "isSuccessful" :  boolean
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
   },
   "templateModificationsResponse": {
       "templates": [
@@ -2792,37 +2904,37 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
               "plusFriendType": String,
               "templateCode": String,
               "templateName": String,
-              "templateMessageType" : String,
+              "templateMessageType": String,
               "templateEmphasizeType": String,
               "templateContent": String,
-              "templateExtra" : String,
-              "templateAd" : String,
-              "templateTitle" : String,
-              "templateSubtitle" : String,
-              "templateHeader" : String,
-              "templateItem" : {
-                "list" : [{
+              "templateExtra": String,
+              "templateAd": String,
+              "templateTitle": String,
+              "templateSubtitle": String,
+              "templateHeader": String,
+              "templateItem": {
+                "list": [{
                   "title": String,
                   "description": String
                 }],
-                "summary" : {
+                "summary": {
                   "title": String,
                   "description": String
                 }
               },
-              "templateItemHighlight" : {
+              "templateItemHighlight": {
                 "title": String,
                 "description": String,
                 "imageUrl": String
               },
-              "templateRepresentLink" : {
+              "templateRepresentLink": {
                 "linkMo": String,
                 "linkPc": String,
                 "schemeIos": String,
                 "schemeAndroid": String,
               },
-              "templateImageName" : String,
-              "templateImageUrl" : String,
+              "templateImageName": String,
+              "templateImageUrl": String,
               "buttons": [
                 {
                     "ordering":Integer,
@@ -2831,10 +2943,23 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
                     "linkMo": String,
                     "linkPc": String,
                     "schemeIos": String,
-                    "schemeAndroid": String
+                    "schemeAndroid": String,
+                    "telNumber": String
                 }
-                ],
-                "comments": [
+              ],
+              "quickReplies": [
+                {
+                    "ordering": Integer,
+                    "type": String,
+                    "name": String,
+                    "linkMo": String,
+                    "linkPc": String,
+                    "schemeIos": String,
+                    "schemeAndroid": String,
+                    "bizFormId": Integer
+                }
+              ],
+              "comments": [
                   {
                       "id": Integer,
                       "content": String,
@@ -2845,93 +2970,105 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
                         "filePath": String
                       }],
                       "status": String
-                    }  
-                ],
-                "status": String,
-                "statusName": String,
-                "securityFlag": Boolean,
-                "categoryCode": String,
-                "activated": boolean,
-                "createDate": String,
-                "updateDate": String
-            }
-        ],
-        "totalCount": Integer
-    }
+                  }  
+              ],
+              "status": String,
+              "statusName": String,
+              "securityFlag": Boolean,
+              "categoryCode": String,
+              "activated": boolean,
+              "createDate": String,
+              "updateDate": String
+          }
+      ],
+      "totalCount": Integer
+  }
 }
 ```
 
-| Name |	Type|	Description|
-|---|---|---|
-|header|	Object|	Header area|
-|- resultCode|	Integer|	Result code|
-|- resultMessage|	String| Result message|
-|- isSuccessful|	Boolean| Successful or not|
-|templateModificationsResponse|	Object|	Body area|
-|- templates | List |	Template list |
-|-- plusFriendId | String |	PlusFriend ID |
-|-- senderKey    | String | Sender Key    |
-|-- plusFriendType | String | PlusFriend type(NORMAL, GROUP) |
-|-- templateCode | String |	Template code |
-|-- templateName | String |	Template name |
-|-- templateMessageType| String | Types of template message(BA: Basic, EX: Extra Information, AD: Ad Included, MI: Mixed Purposes) |
-|-- templateEmphasizeType| String| Types of emphasized template(NONE: Basic, TEXT: Emphasized, IMAGE: Image type, default:NONE) |
-|-- templateContent | String |	Template body |
-|-- templateExtra | String | Additional template information |
-|-- templateAd | String | Request for consent of receiving within template or simple ad phrases |
-|-- tempalteTitle| String | Template title |
-|-- templateSubtitle| String | Auxiliary template phrase |
-|- templateHeader| String| Template header(up to 16 characters) |
-|- templateItem | Object | Item |
-|-- list | List | Item list(at least 2, up to 10) |
-|--- title | String | Title(up to 6 characters) |
-|--- description | String | Description(up to 23 characters) |
-|-- summary | Object | Item summary information |
-|--- title | String | Title(up to 6 characters) |
-|--- description | String | Description(Only variables and monetary units, numbers, commas, and periods, up to 14 characters) |
-|- templateItemHighlight | Object | Item highlight |
-|-- title | String | Title(up to 30 characters, 21 characters with a thumbnail image) |
-|-- description | String | Description(up to 19 characters, 13 with a thumbnail image) |
-|-- imageUrl | String | Thumbnail image address |
-|-templateRepresentLink | Object | Main link |
-|-- linkMo| String |	Mobile web link(up to 500 characters)|
-|-- linkPc | String |PC web link(up to 500 characters) |
-|-- schemeIos | String |	iOS app link(up to 500 characters) |
-|-- schemeAndroid | String |	Android app link(up to 500 characters) |
-|-- templateImageName | String | Image name(name of uploaded file) |
-|-- templateImageUrl | String |	Image URL |
-|-- buttons | List |	List of buttons |
-|--- ordering | Integer |	Button sequence(1~5) |
-|--- type| String |	Button type(WL: Web link, AL: App link, DS: Delivery search, BK: Bot keyword, MD: Message delivery, BC: Bot for Consultation, BT: Bot Transfer, AC: Add channel, BF: Business form, P1: Image secure transmission plugin ID, P2: Personal information use plugin ID, P3: One-click payment plugin ID, TN: Call) |
-|--- name | String |	Button name |
-|--- linkMo | String |	Mobile web link(required for the WL type) |
-|--- linkPc | String |	PC web link(optional for the WL type) |
-|--- schemeIos | String |	iOS app link(required for the AL type) |
-|--- schemeAndroid | String |	Android app link(required for the AL type) |
-|-- comments | List | Inspection result |
-|--- id | Integer | Inquiry ID |
-|--- content |  String | Inquiries |
-|--- userName | String | Creator |
-|--- createAt | String | Date of registration |
-|--- attachment | List | Attachment |
-|---- originalFileName | String | Attachment file name |
-|---- filePath | String | Attachment file path |
-|--- status | String | Comment status(INQ: Inquired, APR: Approved, REJ: Rejected, REP: Replied) |
-|-- status| String | Template status |
-|-- statusName | String | Template status name |
-|-- securityFlag| Boolean | Whether it is a security template |
-|-- categoryCode| String | Template category code  |
-|-- activated | Boolean | Activated or not |
-|-- createDate | String | Date of creation |
-|-- updateDate | String | Date of modification |
-|- totalCount | Integer | Total count |
+| Name                          | Type    | Not Null | Description                                                                                                                                                                                                                                      |
+|-------------------------------|---------|:--------:|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| header                        | Object  |    O     | Header area                                                                                                                                                                                                                                      |
+| - resultCode                  | Integer |    O     | Result code                                                                                                                                                                                                                                      |
+| - resultMessage               | String  |    O     | Result message                                                                                                                                                                                                                                   |
+| - isSuccessful                | Boolean |    O     | Success                                                                                                                                                                                                                                          |
+| templateModificationsResponse | Object  |    X     | Body area                                                                                                                                                                                                                                        |
+| - templates                   | List    |    X     | Template list                                                                                                                                                                                                                                    |
+| -- plusFriendId               | String  |    O     | KakaoTalk Channel search ID or Sender Profile group name                                                                                                                                                                                         |
+| -- senderKey                  | String  |    O     | Sender Key                                                                                                                                                                                                                                       |
+| -- plusFriendType             | String  |    O     | PlusFriend type (NORMAL, GROUP)                                                                                                                                                                                                                  |
+| -- templateCode               | String  |    O     | Template Code                                                                                                                                                                                                                                    |
+| -- templateName               | String  |    O     | Template name                                                                                                                                                                                                                                    |
+| -- templateMessageType        | String  |    X     | Types of template message (BA: Basic, EX: Extra Information, AD: Ad Included, MI: Mixed Purposes, default: Basic)                                                                                                                                |
+| -- templateEmphasizeType      | String  |    X     | Template emphasis display type (NONE: Default, TEXT: Emphasis, IMAGE: Image type, )                                                                                                                                                              |
+| -- templateContent            | String  |    O     | Template body                                                                                                                                                                                                                                    |
+| -- templateExtra              | String  |    X     | Template extra information                                                                                                                                                                                                                       |
+| -- templateAd                 | String  |    X     | Consent to receive request or simple advertising copy in the template                                                                                                                                                                            |
+| -- tempalteTitle              | String  |    X     | Template title                                                                                                                                                                                                                                   |
+| -- templateSubtitle           | String  |    X     | Template subtitle                                                                                                                                                                                                                                |
+| - templateHeader              | String  |    X     | Template header (up to 16 characters)                                                                                                                                                                                                            |
+| - templateItem                | Object  |    X     | Item                                                                                                                                                                                                                                             |
+| -- list                       | List    |    X     | Item list (minimum 2, maximum 10)                                                                                                                                                                                                                |
+| --- title                     | String  |    X     | Title (up to 6 characters)                                                                                                                                                                                                                       |
+| --- description               | String  |    X     | Description (up to 23 characters)                                                                                                                                                                                                                |
+| -- summary                    | Object  |    X     | Item summary information                                                                                                                                                                                                                         |
+| --- title                     | String  |    X     | Title (up to 6 characters)                                                                                                                                                                                                                       |
+| --- description               | String  |    X     | Description (Only variables and monetary units, numbers, commas, and periods, up to 14 characters)                                                                                                                                               |
+| - templateItemHighlight       | Object  |    X     | Item highlight                                                                                                                                                                                                                                   |
+| -- title                      | String  |    X     | Title (up to 30 characters; up to 21 characters if a thumbnail image is present)                                                                                                                                                                 |
+| -- description                | String  |    X     | Description (up to 19 characters; up to 13 characters if a thumbnail image is present)                                                                                                                                                           |
+| -- imageUrl                   | String  |    X     | Thumbnail image URL                                                                                                                                                                                                                              |
+| - templateRepresentLink       | Object  |    X     | Representative link                                                                                                                                                                                                                              |
+| -- linkMo                     | String  |    X     | Mobile web link (up to 500 characters)                                                                                                                                                                                                           |
+| -- linkPc                     | String  |    X     | PC web link (up to 500 characters)                                                                                                                                                                                                               |
+| -- schemeIos                  | String  |    X     | iOS app link (up to 500 characters)                                                                                                                                                                                                              |
+| -- schemeAndroid              | String  |    X     | Android app link (up to 500 characters)                                                                                                                                                                                                          |
+| -- templateImageName          | String  |    X     | Image name (uploaded file name)                                                                                                                                                                                                                  |
+| -- templateImageUrl           | String  |    X     | Image URL                                                                                                                                                                                                                                        |
+| -- buttons                    | List    |    X     | Button list                                                                                                                                                                                                                                      |
+| --- ordering                  | Integer |    X     | Button order (1 to 5)                                                                                                                                                                                                                            |
+| --- type                      | String  |    X     | Button type (WL: Web link, AL: App link, DS: Delivery search, BK: Bot keyword, MD: Message delivery, BC: Bot for Consultation, BT: Bot Transfer, AC: Add channel, BF: Business form, P1: Image secure transmission plugin ID, P2: Personal information use plugin ID, P3: One-click payment plugin ID, TN: Call) |
+| --- name                      | String  |    X     | Button name                                                                                                                                                                                                                                      |
+| --- linkMo                    | String  |    X     | Mobile web link (required for the WL type)                                                                                                                                                                                                       |
+| --- linkPc                    | String  |    X     | PC web link (optional for the WL type)                                                                                                                                               |
+| --- schemeIos                 | String  |    X     | iOS app link (required for the AL type)                                                                                                                                              |
+| --- schemeAndroid             | String  |    X     | Android app link (required for the AL type)                                                                                                                                          |
+| --- telNumber                 | 	String  | 	X  | Phone number to send for the TN (Call) type button                                                                                                    |
+| -- quickReplies               | List    |    X     | Quick reply list (up to 5)                                                                                                                                                        |
+| --- ordering                  | Integer |    X     | Quick reply order (required when quick reply exists)                                                                                                                                                |
+| --- type                      | String  |    X     | Quick reply type (WL: Web link, AL: App link, BK: Bot keyword, BC: Bot for Consultation, BT: Bot Transfer, BF: Business form)                                                                                                |
+| --- name                      | String  |    X     | Quick reply name (required when quick reply exists, up to 14 characters)                                                                                                                                        |
+| --- linkMo                    | String  |    X     | Mobile web link (required for the WL type, for up to 500 characters)                                                                                                                                     |
+| --- linkPc                    | String  |    X     | PC web link (required for the WL type, for up to 500 characters)                                                                                                                                      |
+| --- schemeIos                 | String  |    X     | iOS app link (required for the AL type, for up to 500 characters)                                                                                                                                     |
+| --- schemeAndroid             | String  |    X     | Android app link (required for the AL type, for up to 500 characters)                                                                                                                                   |
+| --- bizFormId                 | Integer |    X     | Business form ID (required for the BF type)                                                                                                                                                 |
+| -- comments                   | List    |    X     | Review results                                                                                                                                                                  |
+| --- id                        | Integer |    X     | Inquiry ID                                                                                                                                                                 |
+| --- content                   | String  |    X     | Inquiry content                                                                                                                                                                  |
+| --- userName                  | String  |    X     | Author                                                                                                                                                                    |
+| --- createAt                  | String  |    O     | Registration date                                                                                                                                                                  |
+| --- attachment                | List    |    X     | Attachments                                                                                                                                                                  |
+| ---- originalFileName         | String  |    X     | Attachment file name                                                                                                                                                                 |
+| ---- filePath                 | String  |    X     | Attachment file path                                                                                                                                                               |
+| --- status                    | String  |    X     | Comment status (INQ: Inquired, APR: Approved, REJ: Rejected, REP: Replied, REQ: Under Review)                                                                                                                   |
+| -- status                     | String  |    O     | Template status                                                                                                                                                                 |
+| -- statusName                 | String  |    O     | Template status name                                                                                                                                                                |
+| -- securityFlag               | Boolean |    X     | Whether it is a security template                                                                                                                                              |
+| -- categoryCode               | String  |    X     | Template category code                                                                                                                                                            |
+| -- activated                  | Boolean |    X     | Whether it is activated                                                                                                                                                                 |
+| -- createDate                 | String  |    O     | Creation date                                                                                                                                                                   |
+| -- updateDate                 | String  |    X     | Modification date                                                                                                                                                                   |
+| - totalCount                  | Integer |    X     | Total count                                                                                                                                                                    |
 
 <a id="register-template-image"></a>
 
 ### Register Template Image
+
 <a id="request-21"></a>
 
 #### Request
+
 [URL]
 
 ```
@@ -2941,27 +3078,30 @@ Content-Type: multipart/form-data
 
 [Path parameter]
 
-| Name |	Type|	Description|
-|---|---|---|
-|appkey|	String|	Unique appkey |
+| Name     | 	Type     | 	Description     |
+|--------|---------|---------|
+| appkey | 	String | 	Unique app key |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|X-Secret-Key|	String| O | Can be created on console.   |
+
+| Name           | 	Type     | 	Required | 	Description              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | Can be created in the console. |
 
 [Request parameter]
 
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|file|	File|	O |	Template image file |
+| Name   | 	Type   | 	Required | 	Description     |
+|------|-------|-----|---------|
+| file | 	File | 	O  | 	Image file |
 
 [Example]
+
 ```
 curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/template-image" -F "file=@alimtalk-template-image.jpeg"
 ```
@@ -2969,12 +3109,13 @@ curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}
 <a id="response-22"></a>
 
 #### Response
+
 ```
 {
-  "header" : {
-    "resultCode" :  Integer,
-    "resultMessage" :  String,
-    "isSuccessful" :  boolean
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
   },
   "templateImage" {
     "templateImageName": String,
@@ -2983,22 +3124,24 @@ curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}
 }
 ```
 
-| Name |	Type|	Description|
-|---|---|---|
-|header|	Object|	Header area|
-|- resultCode|	Integer|	Result code|
-|- resultMessage|	String| Result message|
-|- isSuccessful|	Boolean| Successful or not|
-|templateImage|	Object|	Body area|
-|- templateImageName | String |	Image name(name of uploaded file) |
-|- templateImageUrl | String |	Image URL |
+| Name                  | Type      | Not Null | Description             |
+|---------------------|---------|:--------:|----------------|
+| header              | Object  |    O     | Header area          |
+| - resultCode        | Integer |    O     | Result code          |
+| - resultMessage     | String  |    O     | Result message         |
+| - isSuccessful      | Boolean |    O     | Success          |
+| templateImage       | Object  |    X     | Body area          |
+| - templateImageName | String  |    X     | Image name (uploaded file name) |
+| - templateImageUrl  | String  |    X     | Image URL        |
 
 <a id="register-template-item-highlight-images"></a>
 
 ### Register Template Item Highlight Images
+
 <a id="request-22"></a>
 
 #### Request
+
 [URL]
 
 ```
@@ -3008,27 +3151,30 @@ Content-Type: multipart/form-data
 
 [Path parameter]
 
-| Name |	Type|	Description|
-|---|---|---|
-|appkey|	String|	Unique appkey |
+| Name     | 	Type     | 	Description     |
+|--------|---------|---------|
+| appkey | 	String | 	Unique app key |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|X-Secret-Key|	String| O | Can be created on console.   |
+
+| Name           | 	Type     | 	Required | 	Description              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | Can be created in the console. |
 
 [Request parameter]
 
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|file|	File|	O |	Template image file |
+| Name   | 	Type   | 	Required | 	Description     |
+|------|-------|-----|---------|
+| file | 	File | 	O  | 	Image file |
 
 [Example]
+
 ```
 curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/template-image/item-highlight" -F "file=@alimtalk-template-image.jpeg"
 ```
@@ -3036,12 +3182,13 @@ curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}
 <a id="response-23"></a>
 
 #### Response
+
 ```
 {
-  "header" : {
-    "resultCode" :  Integer,
-    "resultMessage" :  String,
-    "isSuccessful" :  boolean
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
   },
   "templateImage" {
     "templateImageName": String,
@@ -3050,22 +3197,24 @@ curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}
 }
 ```
 
-| Name |	Type|	Description|
-|---|---|---|
-|header|	Object|	Header area|
-|- resultCode|	Integer|	Result code|
-|- resultMessage|	String| Result message|
-|- isSuccessful|	Boolean| Successful or not|
-|templateImage|	Object|	Body area|
-|- templateImageName | String |	Image name(name of uploaded file) |
-|- templateImageUrl | String |	Image URL |
+| Name                  | Type      | Not Null | Description             |
+|---------------------|---------|:--------:|----------------|
+| header              | Object  |    O     | Header area          |
+| - resultCode        | Integer |    O     | Result code          |
+| - resultMessage     | String  |    O     | Result message         |
+| - isSuccessful      | Boolean |    O     | Success          |
+| templateImage       | Object  |    X     | Body area          |
+| - templateImageName | String  |    X     | Image name (name of the uploaded file) |
+| - templateImageUrl  | String  |    X     | Image URL        |
 
 <a id="register-template-plugin"></a>
 
 ### Register Template Plugin
+
 <a id="request-23"></a>
 
 #### Request
+
 [URL]
 
 ```
@@ -3075,63 +3224,68 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name |	Type|	Description|
-|---|---|---|
-|appkey|	String|	Unique appkey|
-|senderKey|	String|	Sender Key |
+| Name        | 	Type     | 	Description     |
+|-----------|---------|---------|
+| appkey    | 	String | 	App key |
+| senderKey | 	String | 	Sender Key   |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|X-Secret-Key|	String| O | Can be created on console.   |
+
+| Name           | 	Type     | 	Required | 	Description              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | Can be created in the console. |
 
 [Request Body]
 
 ```
 {
-  "pluginType" : String,
-  "pluginId" : String,
-  "callbackUrl" : String
+  "pluginType": String,
+  "pluginId": String,
+  "callbackUrl": String
 }
 ```
 
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|pluginType|	String |	O | Plugin type(SECURE_IMAGE: secure image transmission, ONE_TIME_PROFILE: personal information use) |
-|pluginId|	String |	O | Plugin ID |
-|callbackUrl|	String |	O | The callback URL to receive when the plugin button is clicked |
+| Name          | 	Type     | 	Required | 	Description                                                        |
+|-------------|---------|-----|------------------------------------------------------------|
+| pluginType  | 	String | 	O  | Plugin type (SECURE_IMAGE: secure image transmission, ONE_TIME_PROFILE: personal information use) |
+| pluginId    | 	String | 	O  | Plugin ID                                                   |
+| callbackUrl | 	String | 	O  | The callback URL to receive when the plugin button is clicked                                  |
 
 <a id="response-24"></a>
 
 #### Response
+
 ```
 {
-  "header" : {
-    "resultCode" :  Integer,
-    "resultMessage" :  String,
-    "isSuccessful" :  boolean
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
   }
 }
 ```
 
-| Name |	Type|	Description|
-|---|---|---|
-|header|	Object|	Header area|
-|- resultCode|	Integer|	Result code|
-|- resultMessage|	String| Result message|
-|- isSuccessful|	Boolean| Successful or not|
+| Name              | Type      | Not Null | Description     |
+|-----------------|---------|:--------:|--------|
+| header          | Object  |    O     | Header area  |
+| - resultCode    | Integer |    O     | Result code  |
+| - resultMessage | String  |    O     | Result message |
+| - isSuccessful  | Boolean |    O     | Success  |
 
 <a id="modify-template-plugin"></a>
 
 ### Modify Template Plugin
+
 <a id="request-24"></a>
 
 #### Request
+
 [URL]
 
 ```
@@ -3141,62 +3295,67 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name |	Type|	Description|
-|---|---|---|
-|appkey|	String|	Unique appkey|
-|senderKey|	String|	Sender Key |
-|pluginId|	String|	Plugin ID |
+| Name      | 	Type   | 	Description |
+|-----------|---------|--------------|
+| appkey    | 	String | 	Unique app key |
+| senderKey | 	String | 	Sender Key   |
+| pluginId  | 	String | 	Plugin ID    |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|X-Secret-Key|	String| O | Can be created on console.   |
+
+| Name         | 	Type   | 	Required | 	Description                       |
+|--------------|---------|-----------|-----------------------------------|
+| X-Secret-Key | 	String | O         | Can be created in the console.    |
 
 [Request Body]
 
 ```
 {
-  "pluginType" : String,
-  "callbackUrl" : String
+  "pluginType": String,
+  "callbackUrl": String
 }
 ```
 
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|pluginType|	String |	O | Plugin type(SECURE_IMAGE: secure image transmission, ONE_TIME_PROFILE: personal information use) |
-|callbackUrl|	String |	O | The callback URL to receive when the plugin button is clicked |
+| Name        | 	Type   | 	Required | 	Description                                                                         |
+|-------------|---------|-----------|--------------------------------------------------------------------------------------|
+| pluginType  | 	String | 	O        | Plugin type (SECURE_IMAGE: secure image transmission, ONE_TIME_PROFILE: personal information use) |
+| callbackUrl | 	String | 	O        | The callback URL to receive when the plugin button is clicked                        |
 
 <a id="response-25"></a>
 
 #### Response
+
 ```
 {
-  "header" : {
-    "resultCode" :  Integer,
-    "resultMessage" :  String,
-    "isSuccessful" :  boolean
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
   }
 }
 ```
 
-| Name |	Type|	Description|
-|---|---|---|
-|header|	Object|	Header area|
-|- resultCode|	Integer|	Result code|
-|- resultMessage|	String| Result message|
-|- isSuccessful|	Boolean| Successful or not|
+| Name            | Type    | Not Null | Description    |
+|-----------------|---------|:--------:|----------------|
+| header          | Object  |    O     | Header area    |
+| - resultCode    | Integer |    O     | Result code    |
+| - resultMessage | String  |    O     | Result message |
+| - isSuccessful  | Boolean |    O     | Success        |
 
 <a id="modify-template-plugin-2"></a>
 
-### Modify Template Plugin
+### Delete Template Plugin
+
 <a id="request-25"></a>
 
 #### Request
+
 [URL]
 
 ```
@@ -3206,48 +3365,53 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name |	Type|	Description|
-|---|---|---|
-|appkey|	String|	Unique appkey|
-|senderKey|	String|	Sender Key |
-|pluginId|	String|	Plugin ID |
+| Name        | 	Type     | 	Description       |
+|-----------|---------|-----------|
+| appkey    | 	String | 	Unique app key   |
+| senderKey | 	String | 	Sender Key     |
+| pluginId  | 	String | 	Plugin ID |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|X-Secret-Key|	String| O | Can be created on console.   |
+
+| Name           | 	Type     | 	Required | 	Description              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | Can be created in the console. |
 
 <a id="response-26"></a>
 
 #### Response
+
 ```
 {
-  "header" : {
-    "resultCode" :  Integer,
-    "resultMessage" :  String,
-    "isSuccessful" :  boolean
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
   }
 }
 ```
 
-| Name |	Type|	Description|
-|---|---|---|
-|header|	Object|	Header area|
-|- resultCode|	Integer|	Result code|
-|- resultMessage|	String| Result message|
-|- isSuccessful|	Boolean| Successful or not|
+| Name              | Type      | Not Null | Description     |
+|-----------------|---------|:--------:|--------|
+| header          | Object  |    O     | Header area  |
+| - resultCode    | Integer |    O     | Result code  |
+| - resultMessage | String  |    O     | Result message |
+| - isSuccessful  | Boolean |    O     | Success  |
 
 <a id="retrieve-template-plugin"></a>
 
-### Retrieve Template Plugin
+### Get Template Plugins
+
 <a id="request-26"></a>
 
 #### Request
+
 [URL]
 
 ```
@@ -3257,32 +3421,35 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name |	Type|	Description|
-|---|---|---|
-|appkey|	String|	Unique appkey|
-|senderKey|	String|	Sender Key |
+| Name      | 	Type     | 	Description  |
+|-----------|---------|---------|
+| appkey    | 	String | 	App key |
+| senderKey | 	String | 	Sender Key   |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|X-Secret-Key|	String| O | Can be created on console.   |
+
+| Name           | 	Type     | 	Required | 	Description              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | Can be created in the console. |
 
 <a id="response-27"></a>
 
 #### Response
+
 ```
 {
-  "header" : {
-    "resultCode" :  Integer,
-    "resultMessage" :  String,
-    "isSuccessful" :  boolean
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
   },
-  "plugins" : [
+  "plugins": [
     {
       "pluginId": String,
       "pluginType": String,
@@ -3296,26 +3463,27 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name |	Type|	Description|
-|---|---|---|
-|header|	Object|	Header area|
-|- resultCode|	Integer|	Result code|
-|- resultMessage|	String| Result message|
-|- isSuccessful|	Boolean| Successful or not|
-|plugins|	List |	Plugin list |
-|- pluginId|	String|	Plugin ID|
-|- pluginType|	String| Plugin type(SECURE_IMAGE: secure image transmission, ONE_TIME_PROFILE: personal information use) |
-|- pluginTypeName|	String| Plugin name |
-|- callbackUrl|	String|	The callback URL to receive when the plugin button is clicked |
-|- modifiable|	Boolean| Modifiable |
-|- deletable|	Boolean| Deletable |
+| Name             | Type      | Not Null | Description                                                                                       |
+|------------------|---------|:--------:|------------------------------------------------------------|
+| header           | Object  |    O     | Header area                                                                                       |
+| - resultCode     | Integer |    O     | Result code                                                                                       |
+| - resultMessage  | String  |    O     | Result message                                                                                    |
+| - isSuccessful   | Boolean |    O     | Success                                                                                           |
+| plugins          | List    |    X     | Plugin list                                                                                       |
+| - pluginId       | String  |    X     | Plugin ID                                                                                         |
+| - pluginType     | String  |    X     | Plugin type (SECURE_IMAGE: secure image transmission, ONE_TIME_PROFILE: personal information use) |
+| - pluginTypeName | String  |    X     | Plugin name                                                                                       |
+| - callbackUrl    | String  |    X     | The callback URL to receive when the plugin button is clicked                                     |
+| - modifiable     | Boolean |    X     | Whether the plugin can be modified                                                                |
+| - deletable      | Boolean |    X     | Whether the plugin can be deleted                                                                 |
 
 <a id="manage-alternative-delivery"></a>
 
 ## Manage Alternative Delivery
+
 <a id="register-an-sms-appkey"></a>
 
-### Register an SMS AppKey
+### Register SMS AppKey
 
 [URL]
 
@@ -3326,20 +3494,21 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name |	Type|	Description|
-|---|---|---|
-|appkey|	String|	Unique appkey|
+| Name     | 	Type     | 	Description     |
+|--------|---------|---------|
+| appkey | 	String | 	Unique app key |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|X-Secret-Key|	String| O | Can be created on console.   |
 
+| Name           | 	Type     | 	Required | 	Description              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | Can be created in the console. |
 
 [Request body]
 
@@ -3349,11 +3518,12 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|resendAppKey|	String|	O | SMS service appkey to set for alternative delivery |
+| Name           | 	Type     | 	Required | 	Description                    |
+|--------------|---------|-----|------------------------|
+| resendAppKey | 	String | 	O  | SMS service app key for alternative delivery |
 
 [Example]
+
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
 ```
@@ -3361,16 +3531,24 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 <a id="response-28"></a>
 
 #### Response
+
 ```
 
 {
-  "header" : {
-      "resultCode" :  Integer,
-      "resultMessage" :  String,
-      "isSuccessful" :  boolean
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
   }
 }
 ```
+
+| Name              | Type      | Not Null | Description     |
+|-----------------|---------|:--------:|--------|
+| header          | Object  |    O     | Header area  |
+| - resultCode    | Integer |    O     | Result code  |
+| - resultMessage | String  |    O     | Result message |
+| - isSuccessful  | Boolean |    O     | Success  |
 
 <a id="register-alternative-delivery-settings"></a>
 
@@ -3385,20 +3563,21 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name |	Type|	Description|
-|---|---|---|
-|appkey|	String|	Unique appkey|
+| Name     | 	Type     | 	Description     |
+|--------|---------|---------|
+| appkey | 	String | 	Unique app key |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|X-Secret-Key|	String| O | Can be created on console. [[Reference](./alimtalk-api-guide/#x-secret-key)  |
 
+| Name           | 	Type     | 	Required | 	Description              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | Can be created in the console. |
 
 [Request body]
 
@@ -3410,13 +3589,14 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name |	Type|	Required|	Description|
-|---|---|---|---|
-|senderKey|	String|	O | Sender Key |
-|isResend|	Boolean|	O | Whether to resend text, if delivery fails<br>Resent by default, if alternative delivery is set on console. |
-|resendSendNo|	String|	O | Sender number for alternative delivery<br><span style="color:red">(Alternative delivery may fail, if the sender number is not registered on the SMS service.)</span> |
+| Name           | 	Type      | 	Required | 	Description                                                                                       |
+|--------------|----------|-----|-------------------------------------------------------------------------------------------|
+| senderKey    | 	String  | 	O  | Sender Key                                                                                      |
+| isResend     | 	Boolean | 	O  | Whether to use SMS alternative delivery if sending fails<br>Resent by default, if fallback is set on console.                          |
+| resendSendNo | 	String  | 	O  | Sender number for alternative delivery<br><span style="color:red">(Alternative delivery may fail, if the sender number is not registered on the SMS service.)</span> |
 
 [Example]
+
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/failback/appkey -d '{"senderKey": "0be23c29de88d6888798aeda57062516354d74ba","isResend": true,"resendSendNo": "01012341234" }
 ```
@@ -3424,13 +3604,21 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 <a id="response-29"></a>
 
 #### Response
+
 ```
 
 {
-  "header" : {
-      "resultCode" :  Integer,
-      "resultMessage" :  String,
-      "isSuccessful" :  boolean
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
   }
 }
 ```
+
+| Name              | Type      | Not Null | Description     |
+|-----------------|---------|:--------:|--------|
+| header          | Object  |    O     | Header area  |
+| - resultCode    | Integer |    O     | Result code  |
+| - resultMessage | String  |    O     | Result message |
+| - isSuccessful  | Boolean |    O     | Success  |

--- a/en/alimtalk-api-guide.md
+++ b/en/alimtalk-api-guide.md
@@ -1,4 +1,4 @@
-## Notification > KakaoTalk Bizmessage > AlimTalk > API v2.3 Guide
+## Notification > KakaoTalk Bizmessage > 알림톡 > API v2.3 Guide
 
 <a id="alimtalk"></a>
 
@@ -36,7 +36,7 @@
 
 <a id="request-of-sending-replaced-messages"></a>
 
-### Send Message with Replacement Variables
+### Send Replacement Message Request
 
 [URL]
 
@@ -47,9 +47,9 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name | Type | Description |
+| Name     | 	Type     | 	Description     |
 |--------|---------|---------|
-| appkey | String | Unique app key |
+| appkey | 	String | 	Unique app key |
 
 [Header]
 
@@ -59,10 +59,10 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name | Type | Required | Description |
-|--------------------------|---------|-----|-----------------------------------------------------------------------------------------------|
-| X-Secret-Key | String | O | Can be created in the console. |
-| X-NC-API-IDEMPOTENCY-KEY | String | X | Key for deduplicating message send requests<br>If a request is made with the same key for 10 minutes, the request will be failed. |
+| Name                       | 	Type     | 	Required | 	Description                                                        |
+|--------------------------|---------|-----|------------------------------------------------------------|
+| X-Secret-Key             | 	String | O   | Can be created in the console.                                           |
+| X-NC-API-IDEMPOTENCY-KEY | 	String | X   | Key used as the basis for duplicate message send requests<br>If a request is made with the same key for 10 minutes, the request will be failed. |
 
 [Request body]
 
@@ -113,55 +113,55 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name | Type | Required | Description |
+| Name                     | 	Type      | 	Required | 	Description                                                                                           |
 |------------------------|----------|-----|-----------------------------------------------------------------------------------------------|
-| senderKey | String | O | Sender Key (40 characters) |
-| templateCode | String | O | Registered delivery template code (up to 20 characters) |
-| requestDate | String | X | Request date/time (yyyy-MM-dd HH:mm)<br>(If not specified, sent immediately)<br>Can be scheduled up to 60 days in advance |
-| senderGroupingKey | String | X | Sender grouping key (up to 100 characters) |
-| createUser | String | X | Creator (stored as user UUID when sent from the console) |
-| recipientList | List | O | Recipient list (up to 1,000) |
-| - recipientNo | String | O | Recipient number (up to 15 characters) |
-| - templateParameter | Object | X | Template parameter<br>(Required if the template contains replacement variables) |
-| -- key | String | X | Replacement key (#{key}) |
-| -- value | String | X | Value mapped to the replacement key |
-| - resendParameter | Object | X | Alternative delivery information |
-| -- isResend | boolean | X | Whether to use SMS fallback on delivery failure<br>If alternative delivery is configured in the console, fallback is used by default. |
-| -- resendType | String | X | Alternative delivery type (SMS, LMS)<br>If no value is specified, the type is determined based on the template body length. |
-| -- resendTitle | String | X | LMS alternative delivery title<br>(If no value is specified, the Plus Friend ID is used instead.) |
-| -- resendContent | String | X | Alternative delivery content<br>(resent with [Message body and web link button name - web link mobile link] if value is unavailable.) |
-| -- resendSendNo | String | X | Alternative delivery sender number<br><span style="color:red">(Fallback may fail, if the sender number is not registered on the SMS service.)</span> |
-| - buttons | List | X | Additional button information |
-| -- ordering | Integer | X | Button order (required if buttons are present) |
-| -- chatExtra | String | X | Metadata to pass for BC (consultation chat switch) / BT (bot switch) type buttons |
-| -- chatEvent | String | X | Bot event name to connect for BT (bot switch) type buttons |
-| -- relayId | String | X | Value passed via the X-Kakao-Plugin-Relay-Id header when the plugin is executed |
-| -- oneClickId | String | X | Payment information used in the one-click payment plugin |
-| -- productId | String | X | Payment information used in the one-click payment plugin |
-| -- target | String | X | For web link buttons, adding "target":"out" attribute sets an outbound link<br>Sent as an in-app link by default |
-| -- telNumber | String | X | Phone number to pass for TN (call) type buttons |
-| - quickReplies | List | X | Quick Reply information |
-| -- ordering | Integer | X | Quick Reply order (required if quick replies are present) |
-| -- chatExtra | String | X | Metadata to pass for BC (consultation chat switch) / BT (bot switch) types |
-| -- chatEvent | String | X | Bot event name to connect for BT (bot switch) types |
-| -- target | String | X | For web link types, adding "target":"out" attribute sets an outbound link<br>Sent as an in-app link by default |
-| - recipientGroupingKey | String | X | Recipient grouping key (up to 100 characters) |
-| messageOption | Object | X | Message option |
-| - price | Integer | X | Price/amount/payment amount included in the message to be delivered to the user (related to moment advertisement) |
-| - currencyType | String | X | Use of international currency codes such as KRW, USD, EUR, which is the currency unit of the price/amount/payment amount included in the message (message to be delivered to the user) (related to moment advertisement) |
-| statsId | String | X | Statistics ID (not included in delivery search conditions, up to 8 characters) |
+| senderKey              | 	String  | 	O  | Sender key (40 characters)                                                                                     |
+| templateCode           | 	String  | 	O  | Registered template code (up to 20 characters)                                                                         |
+| requestDate            | String   | X   | Request date and time (yyyy-MM-dd HH:mm)<br>(If not specified, sent immediately)<br>Schedulable up to 60 days in advance                            |
+| senderGroupingKey      | String   | X   | Sender grouping key (up to 100 characters)                                                                             |
+| createUser             | String   | X   | Registrant (saved as user UUID when sent from the console)                                                                   |
+| recipientList          | 	List    | 	O  | 	Recipient list (up to 1,000)                                                                            |
+| - recipientNo          | 	String  | 	O  | 	Recipient number (up to 15 characters)                                                                                 |
+| - templateParameter    | 	Object  | 	X  | 	Template parameter<br>(Required if the template contains replacement variables)                                                           |
+| -- key                 | 	String  | 	X  | 	Replacement key (#{key})                                                                                 |
+| -- value               | String   | 	X  | 	Value mapped to the replacement key                                                                            |
+| - resendParameter      | 	Object  | 	X  | 	Alternative delivery information                                                                                      |
+| -- isResend            | 	boolean | 	X  | 	Whether to send by SMS as alternative delivery upon send failure<br>If alternative delivery is configured in the console, it is sent as alternative delivery by default.                                      |
+| -- resendType          | 	String  | 	X  | 	Alternative delivery type (SMS, LMS)<br>If no value is specified, the type is determined based on the length of the template body.                                      |
+| -- resendTitle         | 	String  | 	X  | 	LMS alternative delivery title<br>(resent with the Plus Friend ID if value is unavailable.)                                              |
+| -- resendContent       | 	String  | 	X  | 	Alternative delivery content<br>(resent with [Message body and web link button name - web link mobile link] if value is unavailable.)                        |
+| -- resendSendNo        | String   | X   | Sender number for alternative delivery<br><span style="color:red">(Fallback may fail, if the sender number is not registered on the SMS service.)</span> |
+| - buttons              | 	List    | 	X  | Additional button information                                                                                      |
+| -- ordering            | Integer  | X   | 	Button order (required if buttons exist)                                                                          |
+| -- chatExtra           | 	String  | 	X  | 	Meta information to pass for BC (consultation talk switch) / BT (bot switch) type buttons                                                       |
+| -- chatEvent           | 	String  | 	X  | 	Bot event name to connect for BT (bot switch) type buttons                                                                  |
+| -- relayId             | 	String  | 	X  | Value passed via the X-Kakao-Plugin-Relay-Id header when the plugin is executed                                               |
+| -- oneClickId          | 	String  | 	X  | Payment information used in the one-click payment plugin                                                                      |
+| -- productId           | 	String  | 	X  | Payment information used in the one-click payment plugin                                                                      |
+| -- target              | 	String  | 	X  | 	For web link buttons, adding the `"target":"out"` property opens an out-link<br>Sent as an in-app link by default                                    |
+| -- telNumber           | 	String  | 	X  | Phone number to pass for TN (call) type buttons                                                                    |
+| - quickReplies         | 	List    | 	X  | Quick Reply information                                                                                       |
+| -- ordering            | Integer  | X   | 	Quick Reply order (required if Quick Replies exist)                                                                      |
+| -- chatExtra           | 	String  | 	X  | 	Meta information to pass for BC (consultation talk switch) / BT (bot switch) types                                                          |
+| -- chatEvent           | 	String  | 	X  | 	Bot event name to connect for BT (bot switch) types                                                                     |
+| -- target              | 	String  | 	X  | 	For web link types, adding the `"target":"out"` property opens an out-link<br>Sent as an in-app link by default                                    |
+| - recipientGroupingKey | 	String  | 	X  | 	Recipient grouping key (up to 100 characters)                                                                           |
+| messageOption          | Object   | 	X  | Message option                                                                                        |
+| - price                | Integer  | 	X  | Price/amount/payment amount included in the message to be delivered to the user (related to moment advertisement)                                                   |
+| - currencyType         | String   | 	X  | Use of international currency codes such as KRW, USD, EUR, which is the currency unit of the price/amount/payment amount included in the message (message to be delivered to the user) (related to moment advertisement)                |
+| statsId                | String   | 	X  | Statistics ID (not included in send search conditions; up to 8 characters)                                                            |
 
-* <b>The request date/time can be set up to 60 days from the time of the call.</b>
-* <b>Since fallback is made in the SMS service, field values must follow the API specifications for SMS (e.g., Sender number registered at the SMS service, or restriction in the field length).</b>
-* <b>Fallback delivery is available via SMS and LMS. For international fallback, only SMS is supported. For international receiver numbers, the resendType (fallback type) must be changed to SMS to allow sending without fail.</b>
-* <b>A fallback title or content that exceeds the byte limit of the specified fallback type may be truncated. (See [[SMS notes](https://docs.toast.com/ko/Notification/SMS/ko/api-guide/#_1)].)</b>
-* <b>You can apply a strikethrough style by appending a `\s` character to the end of the templateTitle and templateItemHighlight.title fields using a replacement variable and templateParameter.</b>
+* <b>The request date and time can be set from the time of the call to up to 60 days later.</b>
+* <b>Since fallback is made in the SMS service, field values must follow the API specifications for SMS (e.g., Sender number registered at the SMS service, or restriction in the field length). </b>
+* <b>Alternative delivery is available via SMS and LMS. The SMS Service supports international SMS only. For international receiver numbers, the resendType (fallback type) must be changed to SMS to allow sending without fail.</b>
+* <b>Alternative delivery titles or content that exceed the byte limit of the specified alternative delivery type may be truncated. (Refer to [[SMS Precautions](https://docs.toast.com/ko/Notification/SMS/ko/api-guide/#_1)])</b>
+* <b>You can apply a strikethrough style by appending a `\s` character to the end of the `templateTitle` and `templateItemHighlight.title` fields using a replacement variable and `templateParameter`.</b>
     * <b>However, this does not apply if `\s` is added to the field in advance when registering the template.</b>
 
 [Example]
 
 ```
-curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages -d '{"senderKey":"{sender key}","templateCode":"{template code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{recipient number}","templateParameter":{"{replacement variable field}":"{replacement data}"}}]}'
+curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages -d '{"senderKey":"{sender key}","templateCode":"{template code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{recipient number}","templateParameter":{"{replacement field}":"{replacement data}"}}]}'
 ```
 
 <a id="response"></a>
@@ -191,25 +191,25 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 }
 ```
 
-| Name | Type | Not Null | Description |
+| Name                      | Type      | Not Null | Description           |
 |-------------------------|---------|:--------:|--------------|
-| header | Object | O | Header area |
-| - resultCode | Integer | O | Result code |
-| - resultMessage | String | O | Result message |
-| - isSuccessful | Boolean | O | Success |
-| message | Object | X | Body area |
-| - requestId | String | X | Request ID |
-| - senderGroupingKey | String | X | Sender grouping key |
-| - sendResults | Object | O | Delivery request result |
-| -- recipientSeq | Integer | O | Recipient sequence number |
-| -- recipientNo | String | X | Recipient number |
-| -- resultCode | Integer | O | Delivery request result code |
-| -- resultMessage | String | O | Delivery request result message |
-| -- recipientGroupingKey | String | X | Recipient grouping key |
+| header                  | Object  |    O     | Header area        |
+| - resultCode            | Integer |    O     | Result code        |
+| - resultMessage         | String  |    O     | Result message       |
+| - isSuccessful          | Boolean |    O     | Success        |
+| message                 | Object  |    X     | Body area        |
+| - requestId             | String  |    X     | Request ID       |
+| - senderGroupingKey     | String  |    X     | Sender grouping key     |
+| - sendResults           | Object  |    O     | Send request result     |
+| -- recipientSeq         | Integer |    O     | Recipient sequence number   |
+| -- recipientNo          | String  |    X     | Recipient number        |
+| -- resultCode           | Integer |    O     | Send request result code  |
+| -- resultMessage        | String  |    O     | Send request result message |
+| -- recipientGroupingKey | String  |    X     | Recipient grouping key    |
 
 <a id="request-of-sending-full-text"></a>
 
-### Send Raw Message Request
+### Send Full Message Request
 
 [URL]
 
@@ -235,7 +235,7 @@ Content-Type: application/json;charset=UTF-8
 | Name                       | 	Type     | 	Required | 	Description                                                        |
 |--------------------------|---------|-----|------------------------------------------------------------|
 | X-Secret-Key             | 	String | O   | Can be created in the console.                                           |
-| X-NC-API-IDEMPOTENCY-KEY | 	String | X   | Key used as the criterion for duplicate message sending requests<br>If a request is made with the same key for 10 minutes, the request will be failed. |
+| X-NC-API-IDEMPOTENCY-KEY | 	String | X   | Key used as the basis for duplicate message sending requests<br>If a request is made with the same key for 10 minutes, the request will be failed. |
 
 [Request Body]
 
@@ -328,12 +328,12 @@ Content-Type: application/json;charset=UTF-8
 
 | Name                      | 	Type      | 	Required | 	Description                                                                                                                                                                        |
 |-------------------------|----------|-----|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| senderKey               | 	String  | 	O  | Sender Key (40 characters)                                                                                                                                                                  |
-| templateCode            | 	String  | 	O  | Registered template code for sending (up to 20 characters)                                                                                                                                                      |
-| requestDate             | String   | X   | Request date and time (yyyy-MM-dd HH:mm)<br>(If not entered, sent immediately)<br>Can be scheduled up to 60 days in advance                                                                                                         |
+| senderKey               | 	String  | 	O  | Sender key (40 characters)                                                                                                                                                                  |
+| templateCode            | 	String  | 	O  | Registered delivery template code (up to 20 characters)                                                                                                                                                      |
+| requestDate             | String   | X   | Request date and time (yyyy-MM-dd HH:mm)<br>(If not entered, the message is sent immediately)<br>Scheduling is available up to 60 days in advance                                                                                                                                                                         |
 | senderGroupingKey       | String   | X   | Sender grouping key (up to 100 characters)                                                                                                                                                          |
-| createUser              | String   | X   | Registrant (when sending from the console, saved as the user's UUID)                                                                                                                                                |
-| recipientList           | 	List    | 	O  | 	Recipient list (up to 1,000)                                                                                                                                                        |
+| createUser              | String   | X   | Registrant (saved as user UUID when sending from the console)                                                                                                                                                |
+| recipientList           | 	List    | 	O  | 	List of recipients (up to 1,000)                                                                                                                                                        |
 | - recipientNo           | 	String  | 	O  | 	Recipient number (up to 15 characters)                                                                                                                                              |
 | - content               | 	String  | 	O  | 	Content (up to 1,300 characters)                                                                                                                                              |
 | - templateTitle         | String   | X   | Title (up to 50 characters)                                                                                                                                                                 |
@@ -353,11 +353,11 @@ Content-Type: application/json;charset=UTF-8
 | -- linkMo               | String   | 	X  | 	Mobile web link (up to 500 characters)                                                                                                                                                         |
 | -- linkPc               | String   | 	X  | PC web link (up to 500 characters)                                                                                                                                           |
 | -- schemeIos            | String   | X   | 	iOS app link (up to 500 characters)                                                                                                                                                         |
-| -- schemeAndroid        | String   | X   | 	Android app link (up to 500 characters)                                                                                                                                                       |
+| -- schemeAndroid        | String   | X   | 	Android app link (up to 500 characters)                                                                                                                                       |
 | - buttons               | 	List    | 	X  | Button list (up to 5)                                                                                                                                                              |
-| -- ordering             | 	Integer | 	X  | 	Button order (required if there are buttons)                                                                                                                                                       |
+| -- ordering             | 	Integer | 	X  | 	Button order (required if buttons are present)                                                                                                                                                       |
 | -- type                 | String   | 	X  | 	Button type (WL: Web link, AL: App link, DS: Delivery search, BK: Bot keyword, MD: Message delivery, BC: Bot for Consultation, BT: Bot Transfer, AC: Add channel, BF: Business form, P1: Image secure transmission plugin ID, P2: Personal information use plugin ID, P3: One-click payment plugin ID, TN: Call) |
-| -- name                 | String   | 	X  | 	Button name (required if there are buttons, up to 14 characters)                                                                                                                                               |
+| -- name                 | String   | 	X  | 	Button name (required if buttons are present, up to 14 characters)                                                                                                                                               |
 | -- linkMo               | String   | 	X  | 	Mobile web link (required for the WL type, up to 500 characters)                                                                                                                                        |
 | -- linkPc               | String   | 	X  | PC web link (optional for the WL type, up to 500 characters)                                                                                                                                          |
 | -- schemeIos            | String   | X   | 	iOS app link (required for the AL type, up to 500 characters)                                                                                                                                        |
@@ -369,42 +369,42 @@ Content-Type: application/json;charset=UTF-8
 | -- relayId              | 	String  | 	X  | Value passed via the X-Kakao-Plugin-Relay-Id header when the plugin is executed                                                                                                                            |
 | -- oneClickId           | 	String  | 	X  | Payment information used in the one-click payment plugin                                                                                                                                                   |
 | -- productId            | 	String  | 	X  | Payment information used in the one-click payment plugin                                                                                                                                                   |
-| -- target               | 	String  | 	X  | 	For web link buttons, adding the "target":"out" attribute creates an outbound link<br>Sent as an in-app link by default                                                                                                                 |
-| -- telNumber           | 	String  | 	X  | Phone number to send for TN (Call) type buttons                                                                                                                                                   |
-| - quickReplies          | 	List    | 	X  | Quick Reply list (up to 5)                                                                                                                                                            |
-| -- ordering             | 	Integer | 	X  | 	Quick Reply order (required if Quick Reply is included)                                                                                                                                                   |
-| -- type                 | String   | 	X  | 	Quick reply type (WL: Web link, AL: App link, BK: Bot keyword, BC: Bot for Consultation, BT: Bot Transfer, BF: Business form)                                                                                                   |
-| -- name                 | String   | 	X  | 	Quick Reply name (required if Quick Reply is included, up to 14 characters)                                                                                                                           |
+| -- target               | 	String  | 	X  | 	For web link buttons, adding the `"target":"out"` attribute sets an outbound link<br>Sent as an in-app link by default                                                                                                                 |
+| -- telNumber           | 	String  | 	X  | Phone number to send for TN (Call) type buttons                                                                                                                                    |
+| - quickReplies          | 	List    | 	X  | Quick reply list (up to 5)                                                                                                                                                            |
+| -- ordering             | 	Integer | 	X  | 	Quick reply order (required if quick reply is included)                                                                                                                                                   |
+| -- type                 | String   | 	X  | 	Quick reply type (WL: Web Link, AL: App Link, BK: Bot Keyword, BC: Bot for Consultation, BT: Bot Transfer, BF: Business Form)                                                                                                   |
+| -- name                 | String   | 	X  | 	Quick reply name (required if quick reply is included, up to 14 characters)                                                                                                                                           |
 | -- linkMo               | String   | 	X  | 	Mobile web link (required for the WL type, for up to 500 characters)                                                                                                                                        |
-| -- linkPc               | String   | 	X  | PC web link (optional for the WL type, up to 500 characters)                                                                                                                                          |
+| -- linkPc               | String   | 	X  | PC web link (required for the WL type, for up to 500 characters)                                                                                                                                          |
 | -- schemeIos            | String   | X   | 	iOS app link (required for the AL type, for up to 500 characters)                                                                                                                                        |
 | -- schemeAndroid        | String   | X   | 	Android app link (required for the AL type, for up to 500 characters)                                                                                                                                      |
 | -- bizFormId            | 	Integer | 	X  | 	Business form ID (required for the BF type)                                                                                                                                                    |
-| -- target               | 	String  | 	X  | 	For web link types, adding the "target":"out" attribute sets it to an out-link<br>Sent as an in-app link by default                                                                                                                 |
-| - resendParameter       | 	Object  | 	X  | Alternative Delivery information                                                                                                                                                                   |
-| -- isResend             | 	boolean | 	X  | 	Whether to send an alternative SMS when delivery fails<br>If alternative delivery is configured in the console, it is sent as the default.                                                                                                                   |
-| -- resendType           | 	String  | 	X  | 	Alternative delivery type (SMS, LMS)<br>Categorized by the length of template body, if value is unavailable.                                                                                                                   |
-| -- resendTitle          | 	String  | 	X  | 	LMS alternative delivery title<br>(Resent with the Plus Friend ID if value is unavailable.)                                                                                                                           |
-| -- resendContent        | 	String  | 	X  | 	Alternative delivery content<br>(resent with [Message body and web link button name - web link mobile link] if value is unavailable.)                                                                                                     |
-| -- resendSendNo         | String   | X   | Alternative delivery sender number<br><span style="color:red">(Fallback may fail, if the sender number is not registered on the SMS service.)</span>                                                                              |
+| -- target               | 	String  | 	X  | 	For the web link type, add the `"target":"out"` attribute to use an outbound link.<br>Sent as an in-app link by default.                                                                                                                 |
+| - resendParameter       | 	Object  | 	X  | Alternative sending information                                                                                                                                                                   |
+| -- isResend             | 	boolean | 	X  | 	Whether to send a text message as an alternative if delivery fails.<br>If alternative sending is configured in the console, it is sent as an alternative by default.                                                                                                                   |
+| -- resendType           | 	String  | 	X  | 	Alternative sending type (SMS, LMS)<br>Categorized by the length of template body, if value is unavailable.                                                                                                                   |
+| -- resendTitle          | 	String  | 	X  | 	LMS alternative sending title<br>(resent with the Plus Friend ID if value is unavailable.)                                                                                                                           |
+| -- resendContent        | 	String  | 	X  | 	Alternative sending content<br>(resent with [Message body and web link button name - web link mobile link] if value is unavailable.)                                                                                                     |
+| -- resendSendNo         | String   | X   | Sender number for alternative sending<br><span style="color:red">(Fallback may fail, if the sender number is not registered on the SMS service.)</span>                                                                              |
 | - recipientGroupingKey  | 	String  | 	X  | 	Recipient grouping key (up to 100 characters)                                                                                                                                        |
-| messageOption           | Object   | 	X  | Message options                                                                                                                                                                     |
+| messageOption           | Object   | 	X  | Message option                                                                                                                                                                     |
 | - price                 | Integer  | 	X  | Price/amount/payment amount included in the message to be delivered to the user (related to moment advertisement)                                                                                                                                |
-| - currencyType          | String   | 	X  | Use of international currency codes such as KRW, USD, EUR, which is the currency unit of the price/amount/payment amount included in the message (message to be delivered to the user) (related to moment advertisement)                                                                                             |
+| - currencyType          | String   | 	X  | Use of international currency codes such as KRW, USD, EUR, which is the currency unit of the price/amount/payment amount included in the message to be delivered to the user (related to moment advertisement)                                                                                                             |
 | statsId                 | String   | 	X  | Statistics ID (not included in the delivery search conditions, up to 8 characters)                                                                                                                                         |
 
-* <b>Enter data with all replacements completed in the body and buttons.</b>
-* <b>The request date and time can be set up to 60 days from the time of the call.</b>
+* <b>Enter the substitution-completed data in the body and buttons.</b>
+* <b>The request date and time can be set from the time of the call up to 60 days later.</b>
 * <b>Since fallback is made in the SMS service, field values must follow the API specifications for SMS (e.g., Sender number registered at the SMS service, or restriction in the field length).</b>
-* <b>Alternative delivery can be sent via SMS or LMS. International alternative delivery supports SMS only. For international receiver numbers, the resendType (fallback type) must be changed to SMS to allow sending without fail.</b>
-* <b>Alternative delivery titles or content that exceed the byte limit of the specified alternative delivery type may be truncated. (See [[SMS Notes](https://docs.toast.com/ko/Notification/SMS/ko/api-guide/#_1)])</b>
-* <b>Adding the `\s` character at the end of the templateTitle and templateItemHighlight.title fields at the time of sending applies a strikethrough style.</b>
-    * <b>However, this does not apply if `\s` is added to the fields in advance when registering the template.</b>
+* <b>Fallback delivery is available via SMS and LMS. For international fallback delivery, only SMS is supported. For international receiver numbers, the resendType (fallback type) must be changed to SMS to allow sending without fail.</b>
+* <b>Fallback delivery subject or content that exceeds the byte limit of the specified fallback delivery type may be truncated. (See [[SMS Cautions](https://docs.toast.com/ko/Notification/SMS/ko/api-guide/#_1)])</b>
+* <b>At the time of delivery, you can apply a strikethrough style by adding a `\s` character at the end of the templateTitle and templateItemHighlight.title fields.</b>
+    * <b>However, this does not apply if `\s` is added to the fields in advance when registering a template.</b>
 
 [Example]
 
 ```
-curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/raw-messages -d '{"senderKey":"{sender key}","templateCode":"{template code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{recipient number}","content":"{content}","buttons":[{"ordering":"{button order}","type":"{button type}","name":"{button name}","linkMo":"{mobile web link}"}]}]}'
+curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/raw-messages -d '{"senderKey":"{Sender Key}","templateCode":"{Template Code}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{recipient number}","content":"{content}","buttons":[{"ordering":"{button order}","type":"{button type}","name":"{button name}","linkMo":"{mobile web link}"}]}]}'
 ```
 
 <a id="response-2"></a>
@@ -434,21 +434,21 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 }
 ```
 
-| Name                    | Type    | Not Null | Description                          |
-|-------------------------|---------|:--------:|--------------------------------------|
-| header                  | Object  |    O     | Header area                          |
-| - resultCode            | Integer |    O     | Result code                          |
-| - resultMessage         | String  |    O     | Result message                       |
-| - isSuccessful          | Boolean |    O     | Success                              |
-| message                 | Object  |    X     | Body area                            |
-| - requestId             | String  |    X     | Request ID                           |
-| - senderGroupingKey     | String  |    X     | Sender grouping key                  |
-| - sendResults           | Object  |    O     | Delivery request result              |
-| -- recipientSeq         | Integer |    O     | Recipient sequence number            |
-| -- recipientNo          | String  |    X     | Recipient number                     |
-| -- resultCode           | Integer |    O     | Result code of delivery request      |
-| -- resultMessage        | String  |    O     | Result message of delivery request   |
-| -- recipientGroupingKey | String  |    X     | Recipient grouping key               |
+| Name                    | Type    | Not Null | Description                        |
+|-------------------------|---------|:--------:|------------------------------------|
+| header                  | Object  |    O     | Header area                        |
+| - resultCode            | Integer |    O     | Result code                        |
+| - resultMessage         | String  |    O     | Result message                     |
+| - isSuccessful          | Boolean |    O     | Success                            |
+| message                 | Object  |    X     | Body area                          |
+| - requestId             | String  |    X     | Request ID                         |
+| - senderGroupingKey     | String  |    X     | Sender grouping key                |
+| - sendResults           | Object  |    O     | Delivery request result            |
+| -- recipientSeq         | Integer |    O     | Recipient sequence number          |
+| -- recipientNo          | String  |    X     | Recipient number                   |
+| -- resultCode           | Integer |    O     | Result code of delivery request    |
+| -- resultMessage        | String  |    O     | Result message of delivery request |
+| -- recipientGroupingKey | String  |    X     | Recipient grouping key             |
 
 <a id="list-messages"></a>
 
@@ -483,7 +483,7 @@ Content-Type: application/json;charset=UTF-8
 |--------------|---------|-----|------------------|
 | X-Secret-Key | 	String | O   | Can be created in the console. |
 
-[Query parameter] No.1 or (No.2, No.3) is conditionally required
+[Query parameter] No.1 or (2, 3) is conditionally required
 
 | Name                   | 	Type      | 	Required        | 	Description                                                   |
 |----------------------|----------|------------|-------------------------------------------------------|
@@ -501,10 +501,10 @@ Content-Type: application/json;charset=UTF-8
 | resultCode           | String   | 	X         | Delivery result (MRC01 -> successful, MRC02 -> failed)	                     |
 | createUser           | String   | X          | Registrant (saved as user UUID when sending from console)                           |
 | pageNum              | 	Integer | 	X         | 	Page number (Default: 1)                                   |
-| pageSize             | 	Integer | 	X         | 	Number of records to retrieve (Default: 15, Max: 1,000)                        |
+| pageSize             | 	Integer | 	X         | 	Number of queries (Default: 15, Max: 1000)                        |
 
 * Delivery request data before 90 days cannot be queried.
-* The delivery request period range is up to 30 days.
+* The range of delivery request dates is up to 30 days.
 
 <a id="response-3"></a>
 
@@ -555,15 +555,15 @@ Content-Type: application/json;charset=UTF-8
 | - messages                  | List    |    O     | Message list                                                                                                                                                                |
 | -- requestId                | String  |    O     | Request ID                                                                                                                                                                 |
 | -- recipientSeq             | Integer |    O     | Recipient sequence number                                                                                                                                             |
-| -- plusFriendId             | String  |    O     | PlusFriend ID                                                                                                                                               |
+| -- plusFriendId             | String  |    O     | PlusFriend ID                                                                                                                                                               |
 | -- senderKey                | String  |    O     | Sender Key                                                                                                                                                                   |
 | -- templateCode             | String  |    O     | Template Code                                                                                                                                                                 |
 | -- recipientNo              | String  |    O     | Recipient number                                                                                                                                                                  |
 | -- content                  | String  |    X     | Body                                                                                                                                                                     |
-| -- requestDate              | String  |    O     | Request date and time                                                                                                                                                                  |
+| -- requestDate              | String  |    O     | Request date and time                                                                                                                                                  |
 | -- createDate               | String  |    O     | Registration date and time                                                                                                                                                  |
 | -- receiveDate              | String  |    X     | Received date and time                                                                                                                                                  |
-| -- resendStatus             | String  |    O     | Status code of resending (RSC01, RSC02, RSC03, RSC04, RSC05)\<br\>(See the [[resending status table below](http://docs.toast.com/ko/Notification/KakaoTalk%20Bizmessage/ko/alimtalk-api-guide/#smslms)]) |
+| -- resendStatus             | String  |    O     | Status code of resending (RSC01, RSC02, RSC03, RSC04, RSC05)\<br\>([See [Alternative Delivery Status Table](http://docs.toast.com/ko/Notification/KakaoTalk%20Bizmessage/ko/alimtalk-api-guide/#smslms)] below) |
 | -- resendStatusName         | String  |    O     | Status code name of resending                                                                                                                                           |
 | -- messageStatus            | String  |    O     | Request status (COMPLETED -> successful, FAILED -> failed, CANCEL -> canceled)                                                                                                                                |
 | -- createUser               | String  |    X     | Registrant (saved as user UUID when sending from console)                                                                                                                                            |
@@ -596,7 +596,7 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name           | 	Type      | 	Description              |
+| Name           | 	Type      | 	Description         |
 |--------------|----------|-------------|
 | appkey       | 	String  | 	Unique app key     |
 | requestId    | 	String  | 	Request ID     |
@@ -723,84 +723,84 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 
 -----
 
-| Name                    | Type    | Not Null | Description                                                                                                                                                                                   |
-|-------------------------|---------|:--------:|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| header                  | Object  |    O     | Header area                                                                                                                                                                                   |
-| - resultCode            | Integer |    O     | Result code                                                                                                                                                                                   |
-| - resultMessage         | String  |    O     | Result message                                                                                                                                                                                |
-| - isSuccessful          | Boolean |    O     | Success                                                                                                                                                                                       |
-| message                 | Object  |    X     | Message                                                                                                                                                                                       |
-| - requestId             | String  |    O     | Request ID                                                                                                                                                                                    |
-| - recipientSeq          | Integer |    O     | Recipient sequence number                                                                                                                                                                     |
-| - plusFriendId          | String  |    O     | PlusFriend ID                                                                                                                                                                                 |
-| - senderKey             | String  |    O     | Sender Key                                                                                                                                                                                    |
-| - templateCode          | String  |    O     | Template Code                                                                                                                                                                                 |
-| - recipientNo           | String  |    X     | Recipient Number                                                                                                                                                                              |
-| - content               | String  |    X     | Body                                                                                                                                                                                          |
-| - templateTitle         | String  |    X     | Template title                                                                                                                                                                                |
-| - templateSubtitle      | String  |    X     | Template subtitle                                                                                                                                                                             |
-| - templateExtra         | String  |    X     | Template additional content                                                                                                                                                                   |
-| - templateAd            | String  |    X     | Request for consent of receiving within template or simple ad phrases                                                                                                                         |
-| - templateHeader        | String  |    X     | Template header (up to 16 characters)                                                                                                                                                         |
-| - templateItem          | Object  |    X     | Item                                                                                                                                                                                          |
-| -- list                 | List    |    X     | Item list (at least 2, up to 10)                                                                                                                                                              |
-| --- title               | String  |    X     | Title (up to 6 characters)                                                                                                                                                                    |
-| --- description         | String  |    X     | Description (up to 23 characters)                                                                                                                                                             |
-| -- summary              | Object  |    X     | Item summary information                                                                                                                                                                      |
-| --- title               | String  |    X     | Title (up to 6 characters)                                                                                                                                                                    |
-| --- description         | String  |    X     | Description (Only variables and monetary units, numbers, commas, and periods, up to 14 characters)                                                                                            |
-| - templateItemHighlight | Object  |    X     | Item highlight                                                                                                                                                                                |
-| --- title               | String  |    X     | Title (up to 30 characters, 21 characters with a thumbnail image)                                                                                                                             |
-| --- description         | String  |    X     | Description (up to 19 characters, 13 characters with a thumbnail image)                                                                                                                       |
-| --- imageUrl            | String  |    X     | Thumbnail image URL                                                                                                                                                                           |
-| - templateRepresentLink | Object  |    X     | Representative link                                                                                                                                                                           |
-| -- linkMo               | String  |    X     | Mobile web link (up to 500 characters)                                                                                                                                                        |
-| -- linkPc               | String  |    X     | PC web link (up to 500 characters)                                                                                                                                                            |
-| -- schemeIos            | String  |    X     | iOS app link (up to 500 characters)                                                                                                                                                           |
-| -- schemeAndroid        | String  |    X     | Android app link (up to 500 characters)                                                                                                                                                       |
-| - requestDate           | String  |    O     | Request date and time                                                                                                                                                                         |
-| - receiveDate           | String  |    X     | Received date and time                                                                                                                                                                        |
-| - createDate            | String  |    O     | Registration date and time                                                                                                                                                                    |
-| - resendStatus          | String  |    O     | Status code of resending (RSC01, RSC02, RSC03, RSC04, RSC05)\<br\>([[resending status table below](http://docs.toast.com/ko/Notification/KakaoTalk%20Bizmessage/ko/alimtalk-api-guide/#smslms)] See) |
-| - resendStatusName      | String  |    O     | Name of the resending status code                                                                                                                                                             |
-| - resendResultCode      | String  |    X     | Resending result code [SMS result code](https://docs.toast.com/ko/Notification/SMS/ko/error-code/#api)                                                                                        |
-| - resendRequestId       | String  |    X     | Resending SMS request ID                                                                                                                                                                      |
-| - messageStatus         | String  |    O     | Request status (COMPLETED -> successful, FAILED -> failed, CANCEL -> canceled)                                                                                                                |
-| - resultCode            | String  |    X     | Received result code                                                                                                                                                                          |
-| - resultCodeName        | String  |    X     | Received result code name                                                                                                                                                                     |
-| - createUser            | String  |    X     | Creator (saved as user UUID when sent from the console)                                                                                                                                            |
+| Name | Type | Not Null | Description |
+|-------------------------|---------|:--------:|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| header | Object | O | Header area |
+| - resultCode | Integer | O | Result code |
+| - resultMessage | String | O | Result message |
+| - isSuccessful | Boolean | O | Success |
+| message | Object | X | Message |
+| - requestId | String | O | Request ID |
+| - recipientSeq | Integer | O | Recipient sequence number |
+| - plusFriendId | String | O | PlusFriend ID |
+| - senderKey | String | O | Sender Key |
+| - templateCode | String | O | Template Code |
+| - recipientNo | String | X | Recipient number |
+| - content | String | X | Body |
+| - templateTitle | String | X | Template title |
+| - templateSubtitle | String | X | Template subtitle |
+| - templateExtra | String | X | Template additional content |
+| - templateAd | String | X | Request for consent of receiving within template or simple ad phrases |
+| - templateHeader | String | X | Template header (up to 16 characters) |
+| - templateItem | Object | X | Item |
+| -- list | List | X | Item list (at least 2, up to 10) |
+| --- title | String | X | Title (up to 6 characters) |
+| --- description | String | X | Description (up to 23 characters) |
+| -- summary | Object | X | Item summary information |
+| --- title | String | X | Title (up to 6 characters) |
+| --- description | String | X | Description (Only variables and monetary units, numbers, commas, and periods, up to 14 characters) |
+| - templateItemHighlight | Object | X | Item highlight |
+| --- title | String | X | Title (up to 30 characters, 21 characters with a thumbnail image) |
+| --- description | String | X | Description (up to 19 characters, 13 characters with a thumbnail image) |
+| --- imageUrl | String | X | Thumbnail image URL |
+| - templateRepresentLink | Object | X | Representative link |
+| -- linkMo | String | X | Mobile web link (up to 500 characters) |
+| -- linkPc | String | X | PC web link (up to 500 characters) |
+| -- schemeIos | String | X | iOS app link (up to 500 characters) |
+| -- schemeAndroid | String | X | Android app link (up to 500 characters) |
+| - requestDate | String | O | Request date and time |
+| - receiveDate | String | X | Received date and time |
+| - createDate | String | O | Registration date and time |
+| - resendStatus | String | O | Status code of resending (RSC01, RSC02, RSC03, RSC04, RSC05)\<br\>(See [[alternative delivery status table below](http://docs.toast.com/ko/Notification/KakaoTalk%20Bizmessage/ko/alimtalk-api-guide/#smslms)]) |
+| - resendStatusName | String | O | Status code name of resending |
+| - resendResultCode | String | X | Result code of resending [SMS result code](https://docs.toast.com/ko/Notification/SMS/ko/error-code/#api) |
+| - resendRequestId | String | X | Resending SMS request ID |
+| - messageStatus | String | O | Request status (COMPLETED -> successful, FAILED -> failed, CANCEL -> canceled) |
+| - resultCode | String | X | Received result code |
+| - resultCodeName | String | X | Received result code name |
+| - createUser            | String  |    X     | Registrant (saved as user UUID when sending from the console)                                                                                                                                            |
 | - buttons               | List    |    X     | Button list                                                                                                                                                                 |
 | -- ordering             | Integer |    X     | Button order                                                                                                                                                                  |
-| -- type                 | String  |    X     | Button type (WL: Web Link, AL: App Link, DS: Delivery Search, BK: Bot Keyword, MD: Message Delivery, BC: Bot for Consultation, BT: Bot Transfer, AC: Add Channel, BF: Business Form, P1: Image secure transmission plugin ID, P2: Personal information use plugin ID, P3: One-click payment plugin ID, TN: Call) |
+| -- type                 | String  |    X     | Button type (WL: Web link, AL: App link, DS: Delivery search, BK: Bot keyword, MD: Message delivery, BC: Bot for Consultation, BT: Bot Transfer, AC: Add channel, BF: Business form, P1: Image secure transmission plugin ID, P2: Personal information use plugin ID, P3: One-click payment plugin ID, TN: Call) |
 | -- name                 | String  |    X     | Button name                                                                                                                                                                  |
-| -- linkMo               | String  |    X     | Mobile web link (required for the WL type)                                                                                                                                              |
-| -- linkPc               | String  |    X     | PC web link (optional for the WL type)                                                                                                                                               |
-| -- schemeIos            | String  |    X     | iOS app link (required for the AL type)                                                                                                                                              |
-| -- schemeAndroid        | String  |    X     | Android app link (required for the AL type)                                                                                                                                            |
+| -- linkMo               | String  |    X     | Mobile web link (required for the WL type)                                                                                                                              |
+| -- linkPc               | String  |    X     | PC web link (optional for the WL type)                                                                                                                               |
+| -- schemeIos            | String  |    X     | iOS app link (required for the AL type)                                                                                                                              |
+| -- schemeAndroid        | String  |    X     | Android app link (required for the AL type)                                                                                                                            |
 | -- chatExtra            | String  |    X     | Meta information to send for BC (Bot for Consultation) or BT (Bot Transfer) type buttons                                                                                                                                |
 | -- chatEvent            | String  |    X     | Bot event name to connect for BT (Bot Transfer) type buttons                                                                                                                                           |
 | -- bizFormId            | Integer |    X     | Business form ID (required for the BF type)                                                                                                                                                 |
 | -- pluginId             | String  |    X     | Plugin ID (up to 24 characters)                                                                                                                                                        |
 | -- relayId              | String  |    X     | Value passed via the X-Kakao-Plugin-Relay-Id header when the plugin is executed                                                                                                                        |
-| -- oneClickId           | String  |    X     | Payment information used by the one-click payment plugin                                                                                                                               |
-| -- productId            | String  |    X     | Payment information used by the one-click payment plugin                                                                                                                               |
-| -- target               | String  |    X     | For web link buttons, adding the "target":"out" attribute sets it to an out-link\<br\>Sent as an in-app link by default                                                                                                            |
-| - quickReplies          | List    |    X     | Quick Reply list (up to 5)                                                                                                                                                        |
-| -- ordering             | Integer |    X     | Quick Reply order (required if Quick Replies are included)                                                                                                                                                |
-| -- type                 | String  |    X     | Quick Reply type (WL: Web Link, AL: App Link, BK: Bot Keyword, BC: Bot for Consultation, BT: Bot Transfer, BF: Business Form)                                                                                                |
-| -- name                 | String  |    X     | Quick Reply name (required if Quick Replies are included, up to 14 characters)                                                                                                                                        |
+| -- oneClickId           | String  |    X     | Payment information used by the one-click payment plugin                                                                                                                                               |
+| -- productId            | String  |    X     | Payment information used by the one-click payment plugin                                                                                                                                               |
+| -- target               | String  |    X     | For web link buttons, adding the `"target":"out"` attribute sends as an out-link\<br\>Sent as an in-app link by default                                                                                                            |
+| - quickReplies          | List    |    X     | Quick reply list (up to 5)                                                                                                                                                        |
+| -- ordering             | Integer |    X     | Quick reply order (required if quick replies exist)                                                                                                                                                |
+| -- type                 | String  |    X     | Quick reply type (WL: Web link, AL: App link, BK: Bot keyword, BC: Bot for Consultation, BT: Bot Transfer, BF: Business form)                                                                                                |
+| -- name                 | String  |    X     | Quick reply name (required if quick replies exist, up to 14 characters)                                                                                                                                        |
 | -- linkMo               | String  |    X     | Mobile web link (required for the WL type, up to 500 characters)                                                                                                                                     |
 | -- linkPc               | String  |    X     | PC web link (optional for the WL type, up to 500 characters)                                                                                                                                      |
 | -- schemeIos            | String  |    X     | iOS app link (required for the AL type, up to 500 characters)                                                                                                                                     |
 | -- schemeAndroid        | String  |    X     | Android app link (required for the AL type, up to 500 characters)                                                                                                                                   |
-| -- pluginId             | String  |    X     | Plugin ID (up to 24 characters)                                                                                                                                                        |
-| -- target               | String  |    X     | For the web link type, adding the "target":"out" attribute sets it to an out-link\<br\>Sent as an in-app link by default                                                                                                            |
+| -- pluginId             | String  |    X     | Plugin ID (up to 24 characters)                                                                                                                                        |
+| -- target               | String  |    X     | For web link types, adding the `"target":"out"` attribute sends as an out-link\<br\>Sent as an in-app link by default                                                                                                            |
 | -- telNumber           | 	String  | 	X  | Phone number to send for TN (Call) type buttons                                                                                    |
-| - messageOption         | Object  |    X     | Message options                                                                                                                                                                 |
+| - messageOption         | Object  |    X     | Message option                                                                                                                                                                 |
 | -- price                | Integer |    X     | Price/amount/payment amount included in the message to be delivered to the user (related to moment advertisement)                                                                                                                            |
 | -- currencyType         | String  |    X     | Use of international currency codes such as KRW, USD, EUR, which is the currency unit of the price/amount/payment amount included in the message to be delivered to the user (related to moment advertisement)                                                                                         |
 | - senderGroupingKey     | String  |    X     | Sender grouping key                                                                                                                                                               |
-| - recipientGroupingKey  | String  |    X     | Recipient grouping key                                                                                                                                                              |
+| - recipientGroupingKey  | String  |    X     | Recipient grouping key                                                                                                                                              |
 
 <a id="authentication-messages"></a>
 
@@ -819,7 +819,7 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 
 <a id="request-of-sending-replaced-messages-2"></a>
 
-### Send Replacement Message Request
+### Send Replaced Message Request
 
 [URL]
 
@@ -845,7 +845,7 @@ Content-Type: application/json;charset=UTF-8
 | Name                       | 	Type     | 	Required | 	Description                                                        |
 |--------------------------|---------|-----|------------------------------------------------------------|
 | X-Secret-Key             | 	String | O   | Can be created in the console.                                           |
-| X-NC-API-IDEMPOTENCY-KEY | 	String | X   | Key used as the criteria for duplicate message delivery requests<br>If a request is made with the same key for 10 minutes, the request will be failed. |
+| X-NC-API-IDEMPOTENCY-KEY | 	String | X   | Key used as the standard for duplicate message delivery requests<br>If a request is made with the same key for 10 minutes, the request will be failed. |
 
 [Request body]
 [Same as above](./alimtalk-api-guide/#_3)
@@ -878,7 +878,7 @@ Content-Type: application/json;charset=UTF-8
 | Name                       | 	Type     | 	Required | 	Description                                                        |
 |--------------------------|---------|-----|------------------------------------------------------------|
 | X-Secret-Key             | 	String | O   | Can be created in the console.                                           |
-| X-NC-API-IDEMPOTENCY-KEY | 	String | X   | Key used as the criteria for duplicate message delivery requests<br>If a request is made with the same key for 10 minutes, the request will be failed. |
+| X-NC-API-IDEMPOTENCY-KEY | 	String | X   | Key used as the standard for duplicate message delivery requests<br>If a request is made with the same key for 10 minutes, the request will be failed. |
 
 [Request Body]
 [Same as above](./alimtalk-api-guide/#_5)
@@ -972,7 +972,7 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 
 <a id="cancel-sending-messages"></a>
 
-### Cancel Message Delivery
+### Cancel Sending Messages
 
 <a id="request-5"></a>
 
@@ -987,10 +987,10 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name | Type | Description |
-|-----------|---------|---------|
-| appkey | String | Unique app key |
-| requestId | String | Request ID |
+| Name      | 	Type   | 	Description    |
+|-----------|---------|-----------------|
+| appkey    | 	String | 	Unique app key |
+| requestId | String  | Request ID      |
 
 [Header]
 
@@ -1000,15 +1000,15 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name | Type | Required | Description |
-|--------------|---------|-----|------------------|
-| X-Secret-Key | String | O | Can be created in the console. |
+| Name         | 	Type   | 	Required | 	Description                          |
+|--------------|---------|-----------|---------------------------------------|
+| X-Secret-Key | 	String | O         | Can be created in the console. |
 
 [Query parameter]
 
-| Name | Type | Required | Description |
-|--------------|---------|-----|---------------------------------------------|
-| recipientSeq | String | X | Recipient sequence number<br>(to cancel all deliveries of request ID, if the value is left blank) |
+| Name         | 	Type   | 	Required | 	Description                                                                           |
+|--------------|---------|-----------|----------------------------------------------------------------------------------------|
+| recipientSeq | 	String | 	X        | Recipient sequence number<br>(to cancel all deliveries of request ID, if the value is left blank) |
 
 * Both general and authentication messages can be canceled by the same API.
 
@@ -1026,12 +1026,12 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name | Type | Not Null | Description |
-|-----------------|---------|:--------:|--------|
-| header | Object | O | Header area |
-| - resultCode | Integer | O | Result code |
-| - resultMessage | String | O | Result message |
-| - isSuccessful | Boolean | O | Success |
+| Name            | Type    | Not Null | Description    |
+|-----------------|---------|:--------:|----------------|
+| header          | Object  |    O     | Header area    |
+| - resultCode    | Integer |    O     | Result code    |
+| - resultMessage | String  |    O     | Result message |
+| - isSuccessful  | Boolean |    O     | Success        |
 
 [Example]
 
@@ -1041,7 +1041,7 @@ curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Ke
 
 <a id="query-updates-of-message-result"></a>
 
-### Query Message Result Updates
+### Query Updates of Message Result
 
 <a id="request-6"></a>
 
@@ -1056,9 +1056,9 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name | Type | Description |
-|--------|---------|---------|
-| appkey | String | Unique app key |
+| Name   | 	Type   | 	Description    |
+|--------|---------|-----------------|
+| appkey | 	String | 	Unique app key |
 
 [Header]
 
@@ -1068,19 +1068,19 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name | Type | Required | Description |
-|--------------|---------|-----|------------------|
-| X-Secret-Key | String | O | Can be created in the console. |
+| Name         | 	Type   | 	Required | 	Description                   |
+|--------------|---------|-----------|--------------------------------|
+| X-Secret-Key | 	String | O         | Can be created in the console. |
 
 [Query parameter]
 
-| Name | Type | Required | Description |
-|---------------------|----------|-----|-------------------------------------|
-| startUpdateDate | String | O | Start time of querying result updates (yyyy-MM-dd HH:mm) |
-| endUpdateDate | String | O | End time of querying result updates (yyyy-MM-dd HH:mm) |
-| alimtalkMessageType | String | X | AlimTalk message type (NORMAL, AUTH) |
-| pageNum | Integer | X | Page number (default: 1) |
-| pageSize | Integer | X | Number of results (Default: 15, Max: 1,000) |
+| Name                | 	Type    | 	Required | 	Description                                              |
+|---------------------|----------|-----------|-----------------------------------------------------------|
+| startUpdateDate     | 	String  | 	O        | Start time of querying result updates (yyyy-MM-dd HH:mm)  |
+| endUpdateDate       | 	String  | O         | End time of querying result updates (yyyy-MM-dd HH:mm)    |
+| alimtalkMessageType | 	String  | X         | AlimTalk message type (NORMAL, AUTH)                      |
+| pageNum             | 	Integer | 	X        | Page number (default: 1)                                  |
+| pageSize            | 	Integer | 	X        | Number of queries (default: 15, max: 1000)                |
 
 <a id="response-7"></a>
 
@@ -1112,25 +1112,25 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name | Type | Not Null | Description |
-|--------------------|---------|:--------:|--------------------------------------------------------------------------------------------------------|
-| header | Object | O | Header area |
-| - resultCode | Integer | O | Result code |
-| - resultMessage | String | O | Result message |
-| - isSuccessful | Boolean | O | Success |
-| messages | List | X | Message list |
-| - requestId | String | O | Request ID |
-| - recipientSeq | Integer | O | Recipient sequence number |
-| - requestDate | String | O | Request date and time |
-| - createDate | String | O | Created date and time |
-| - receiveDate | String | X | Received date and time |
-| - resendStatus | String | O | Status code of resending (RSC01, RSC02, RSC03, RSC04, RSC05)\<br\>(See [[SMS/LMS Resending Status Table below](http://docs.toast.com/ko/Notification/KakaoTalk%20Bizmessage/ko/alimtalk-api-guide/#smslms)]) |
-| - resendStatusName | String | O | Resending status code name |
-| - resendResultCode | String | X | Resending result code [SMS Result Code](https://docs.toast.com/ko/Notification/SMS/ko/error-code/#api) |
-| - resendRequestId | String | X | SMS request ID for resending |
-| - messageStatus | String | O | Request status (COMPLETED -> successful, FAILED -> failed, CANCEL -> canceled) |
-| - resultCode | String | X | Received result code |
-| - resultCodeName | String | X | Received result code name |
+| Name               | Type    | Not Null | Description                                                                                                                                                                        |
+|--------------------|---------|:--------:|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| header             | Object  |    O     | Header area                                                                                                                                                                        |
+| - resultCode       | Integer |    O     | Result code                                                                                                                                                                        |
+| - resultMessage    | String  |    O     | Result message                                                                                                                                                                     |
+| - isSuccessful     | Boolean |    O     | Success                                                                                                                                                                            |
+| messages           | List    |    X     | Message list                                                                                                                                                                       |
+| - requestId        | String  |    O     | Request ID                                                                                                                                                                         |
+| - recipientSeq     | Integer |    O     | Recipient sequence number                                                                                                                                                          |
+| - requestDate      | String  |    O     | Request date and time                                                                                                                                                              |
+| - createDate       | String  |    O     | Creation date and time                                                                                                                                                             |
+| - receiveDate      | String  |    X     | Receipt date and time                                                                                                                                                              |
+| - resendStatus     | String  |    O     | Status code of resending (RSC01, RSC02, RSC03, RSC04, RSC05)\<br\>(See [[SMS/LMS resending status table](http://docs.toast.com/en/Notification/KakaoTalk%20Bizmessage/ko/alimtalk-api-guide/#smslms)] below) |
+| - resendStatusName | String  |    O     | Status code name of resending                                                                                                                                                      |
+| - resendResultCode | String  |    X     | Result code of resending [SMS result code](https://docs.toast.com/en/Notification/SMS/ko/error-code/#api)                                                                          |
+| - resendRequestId  | String  |    X     | Request ID of resending SMS                                                                                                                                                        |
+| - messageStatus    | String  |    O     | Request status (COMPLETED -> successful, FAILED -> failed, CANCEL -> canceled)                                                                                                     |
+| - resultCode       | String  |    X     | Receipt result code                                                                                                                                                                |
+| - resultCodeName   | String  |    X     | Receipt result code name                                                                                                                                                           |
 
 [Example]
 
@@ -1155,9 +1155,9 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name | Type | Description |
-|--------|---------|---------|
-| appkey | String | Unique app key |
+| Name   | 	Type   | 	Description    |
+|--------|---------|-----------------|
+| appkey | 	String | 	Unique app key |
 
 [Header]
 
@@ -1167,17 +1167,17 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name | Type | Required | Description |
-|--------------|---------|-----|------------------|
-| X-Secret-Key | String | O | Can be created in the console. |
+| Name         | 	Type   | 	Required | 	Description                   |
+|--------------|---------|-----------|--------------------------------|
+| X-Secret-Key | 	String | O         | Can be created in the console. |
 
 [Query parameter]
 
-| Name | Type | Required | Description |
-|---------------------|----------|-----|-------------------------------------|
-| startUpdateDate | String | O | Start time of querying result updates (yyyy-MM-dd HH:mm) |
-| endUpdateDate | String | O | End time of querying result updates (yyyy-MM-dd HH:mm) |
-| alimtalkMessageType | String | X | AlimTalk message type (NORMAL, AUTH) |
+| Name                | 	Type   | 	Required | 	Description                                             |
+|---------------------|---------|-----------|----------------------------------------------------------|
+| startUpdateDate     | 	String | 	O        | Start time of querying result updates (yyyy-MM-dd HH:mm) |
+| endUpdateDate       | 	String | O         | End time of querying result updates (yyyy-MM-dd HH:mm)   |
+| alimtalkMessageType | 	String | X         | AlimTalk message type (NORMAL, AUTH)                     |
 
 <a id="response-8"></a>
 
@@ -1194,13 +1194,13 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name | Type | Not Null | Description |
-|-----------------|---------|:--------:|--------|
-| header | Object | O | Header area |
-| - resultCode | Integer | O | Result code |
-| - resultMessage | String | O | Result message |
-| - isSuccessful | Boolean | O | Success |
-| totalCount | Integer | O | Total count |
+| Name            | Type    | Not Null | Description    |
+|-----------------|---------|:--------:|----------------|
+| header          | Object  |    O     | Header area    |
+| - resultCode    | Integer |    O     | Result code    |
+| - resultMessage | String  |    O     | Result message |
+| - isSuccessful  | Boolean |    O     | Success        |
+| totalCount      | Integer |    O     | Total count    |
 
 [Example]
 
@@ -1210,15 +1210,15 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 
 <a id="status-code-of-smslms-resending"></a>
 
-### Status Codes for SMS/LMS Resending
+### SMS/LMS Resending Status Code
 
-| Name | Description |
-|-------|--------------------------------------|
-| RSC01 | Not applicable for resending |
-| RSC02 | Target of resending (If sending fails, resending is performed.) |
-| RSC03 | Resending in progress |
-| RSC04 | Resending successful |
-| RSC05 | Resending failed |
+| Name  | 	Description                                                             |
+|-------|--------------------------------------------------------------------------|
+| RSC01 | 	Not a target of resending                                               |
+| RSC02 | 	Target of resending (If sending fails, resending is performed.)         |
+| RSC03 | 	Resending in progress                                                   |
+| RSC04 | 	Resending successful                                                    |
+| RSC05 | 	Resending failed                                                        |
 
 <a id="mass-delivery"></a>
 
@@ -1239,7 +1239,7 @@ GET /alimtalk/v2.3/appkeys/{appKey}/mass-messages
 Content-Type: application/json;charset=UTF-8
 ```
 
-[Path Parameter]
+[Path parameter]
 
 | Name     | 	Type     | 	Description     |
 |--------|---------|---------|
@@ -1257,17 +1257,17 @@ Content-Type: application/json;charset=UTF-8
 |--------------|---------|-----------|
 | X-Secret-Key | 	String | 	Unique secret key |
 
-[Query Parameter]
+[Query parameter]
 
 * One of the following is required: requestId, startRequestDate + endRequestDate, or startCreateDate + endCreateDate.
 
 | Name               | 	Type               | Max Length | 	Required | 	Description       |
 |------------------|-------------------|-------|-----|-----------|
 | requestId        | String            | -     | O   | Request ID     |
-| startRequestDate | String            | -     | O   | Start delivery date  |
-| endRequestDate   | String            | -     | O   | End delivery date  |
-| startCreateDate  | 	String           | -     | 	O  | 	Start registration date |
-| endCreateDate    | 	String           | -     | 	O  | 	End registration date |
+| startRequestDate | String            | -     | O   | Delivery start date  |
+| endRequestDate   | String            | -     | O   | Delivery end date  |
+| startCreateDate  | 	String           | -     | 	O  | 	Registration start date |
+| endCreateDate    | 	String           | -     | 	O  | 	Registration end date |
 | pageNum          | optional, Integer | -     | X   | Page number    |
 | pageSize         | optional, Integer | 1000  | X   | Number of results      |
 
@@ -1325,13 +1325,13 @@ curl -X GET \
 | - messages          | Object  |    X     | Message list                                                                        |
 | -- requestId        | String  |    O     | Request ID                                                                          |
 | -- requestDate      | String  |    O     | Request date                                                                          |
-| -- plusFriendId     | String  |    O     | Plus Friend ID                                                                      |
-| -- senderKey        | String  |    O     | Sender Key (40 characters)                                                                      |
+| -- plusFriendId     | String  |    O     | PlusFriend ID                                                                      |
+| -- senderKey        | String  |    O     | Sender key (40 characters)                                                                      |
 | -- masterStatusCode | String  |    O     | Mass delivery status code (WAIT, READY, SENDREADY, SENDWAIT, SENDING, COMPLETE, CANCEL, FAIL) |
 | -- content          | String  |    X     | Content                                                                             |
-| -- fileId           | String  |    X     | Attachment ID                                                                       |
+| -- fileId           | String  |    X     | Attachment file ID                                                                       |
 | -- templateCode     | String  |    O     | Template Code (up to 20 characters)                                                                 |
-| -- autoSendYn       | String  |    X     | Whether auto-delivery is enabled                                                                       |
+| -- autoSendYn       | String  |    X     | Auto-send enabled                                                                       |
 | -- statsId          | String  |    X     | Statistics ID                                                                          |
 | -- createDate       | String  |    O     | Creation date                                                                          |
 | -- createUser       | String  |    X     | User who created the request (saved as user UUID when sending from console)                                                 |
@@ -1354,10 +1354,10 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name        | 	Type     | 	Description     |
-|-----------|---------|---------|
+| Name      | 	Type   | 	Description  |
+|-----------|---------|---------------|
 | appKey    | 	String | 	Unique app key |
-| requestId | 	String | 	Request ID  |
+| requestId | 	String | 	Request ID    |
 
 [Header]
 
@@ -1367,19 +1367,19 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name           | 	Type     | 	Description       |
-|--------------|---------|-----------|
-| X-Secret-Key | 	String | 	Unique secret key |
+| Name         | 	Type   | 	Description        |
+|--------------|---------|---------------------|
+| X-Secret-Key | 	String | 	Unique secret key   |
 
-| Name               | 	Type               | Max Length | 	Required | 	Description       |
-|------------------|-------------------|-------|-----|-----------|
-| requestId        | String            | -     | O   | Request ID     |
-| startRequestDate | String            | -     | X   | Start date for delivery  |
-| endRequestDate   | String            | -     | X   | End date for delivery  |
-| startCreateDate  | 	String           | -     | 	X  | 	Start date for registration |
-| endCreateDate    | 	String           | -     | 	X  | 	End date for registration |
-| pageNum          | optional, Integer | -     | X   | Page number    |
-| pageSize         | optional, Integer | 1000  | X   | Number of results      |
+| Name             | 	Type             | Max Length | 	Required | 	Description          |
+|------------------|-------------------|------------|-----------|------------------------|
+| requestId        | String            | -          | O         | Request ID             |
+| startRequestDate | String            | -          | X         | Delivery start date    |
+| endRequestDate   | String            | -          | X         | Delivery end date      |
+| startCreateDate  | 	String           | -          | 	X        | 	Registration start date |
+| endCreateDate    | 	String           | -          | 	X        | 	Registration end date |
+| pageNum          | optional, Integer | -          | X         | Page number            |
+| pageSize         | optional, Integer | 1000       | X         | Number of results      |
 
 <a id="curl-2"></a>
 
@@ -1421,23 +1421,23 @@ curl -X GET \
 }
 ```
 
-| Name                | Type      | Not Null | Description         |
-|-------------------|---------|:--------:|------------|
-| header            | Object  |    O     | Header area      |
-| - resultCode      | Integer |    O     | Result code      |
-| - resultMessage   | String  |    O     | Result message     |
-| - isSuccessful    | Boolean |    O     | Success      |
-| body              | Object  |    X     | Body area      |
-| - messages        | Object  |    X     | Message list    |
-| -- requestId      | String  |    O     | Request ID      |
+| Name              | Type    | Not Null |Description             |
+|-------------------|---------|:--------:|------------------------|
+| header            | Object  |    O     | Header area            |
+| - resultCode      | Integer |    O     | Result code            |
+| - resultMessage   | String  |    O     | Result message         |
+| - isSuccessful    | Boolean |    O     | Success                |
+| body              | Object  |    X     | Body area              |
+| - messages        | Object  |    X     | Message list           |
+| -- requestId      | String  |    O     | Request ID             |
 | -- recipientSeq   | String  |    O     | Recipient sequence number |
-| -- recipientNo    | String  |    X     | Recipient number      |
-| -- requestDate    | String  |    O     | Request date      |
-| -- receiveDate    | String  |    X     | Receipt date      |
-| -- messageStatus  | String  |    O     | Message status     |
-| -- resultCode     | String  |    X     | Result code      |
-| -- resultCodeName | String  |    X     | Result code description   |
-| - totalCount      | Integer |    X     | Total count        |
+| -- recipientNo    | String  |    X     | Recipient number       |
+| -- requestDate    | String  |    O     | Request date           |
+| -- receiveDate    | String  |    X     | Received date          |
+| -- messageStatus  | String  |    O     | Message status         |
+| -- resultCode     | String  |    X     | Result code            |
+| -- resultCodeName | String  |    X     | Result code description |
+| - totalCount      | Integer |    X     | Total count            |
 
 <a id="get-a-mass-delivery-recipient"></a>
 
@@ -1456,11 +1456,11 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name           | 	Type     | 	Description    |
-|--------------|---------|--------|
-| appKey       | 	String | Unique app key |
-| requestId    | 	String | Request ID  |
-| recipientSeq | String  | Recipient sequence number |
+| Name         | 	Type   | 	Description       |
+|--------------|---------|--------------------|
+| appKey       | 	String | Unique app key     |
+| requestId    | 	String | Request ID         |
+| recipientSeq | String  | Recipient sequence |
 
 [Header]
 
@@ -1470,19 +1470,19 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name           | 	Type     | 	Description       |
-|--------------|---------|-----------|
-| X-Secret-Key | 	String | 	Unique secret key |
+| Name         | 	Type   | 	Description        |
+|--------------|---------|---------------------|
+| X-Secret-Key | 	String | 	Unique secret key  |
 
-| Name               | 	Type               | Max Length | 	Required | 	Description       |
-|------------------|-------------------|-------|-----|-----------|
-| requestId        | String            | -     | O   | Request ID     |
-| startRequestDate | String            | -     | X   | Start delivery date  |
-| endRequestDate   | String            | -     | X   | End delivery date  |
-| startCreateDate  | 	String           | -     | 	X  | 	Start registration date |
-| endCreateDate    | 	String           | -     | 	X  | 	End registration date |
-| pageNum          | optional, Integer | -     | X   | Page number    |
-| pageSize         | optional, Integer | 1000  | X   | Search count      |
+| Name             | 	Type             | Max Length | 	Required | 	Description           |
+|------------------|-------------------|------------|-----------|------------------------|
+| requestId        | String            | -          | O         | Request ID             |
+| startRequestDate | String            | -          | X         | Delivery start date    |
+| endRequestDate   | String            | -          | X         | Delivery end date      |
+| startCreateDate  | 	String           | -          | 	X        | 	Registration start date |
+| endCreateDate    | 	String           | -          | 	X        | 	Registration end date |
+| pageNum          | optional, Integer | -          | X         | Page number            |
+| pageSize         | optional, Integer | 1000       | X         | Search count           |
 
 <a id="curl-3"></a>
 
@@ -1590,79 +1590,79 @@ curl -X GET \
 }
 ```
 
-| Name                    | Type    | Not Null | Description                                                                                                                                                                                                                                  |
-|-------------------------|---------|:--------:|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| header                  | Object  |    O     | Header area                                                                                                                                                                                                                                  |
-| - resultCode            | Integer |    O     | Result code                                                                                                                                                                                                                                  |
-| - resultMessage         | String  |    O     | Result message                                                                                                                                                                                                                               |
-| - isSuccessful          | Boolean |    O     | Success                                                                                                                                                                                                                                      |
-| body                    | Object  |    X     | Body area                                                                                                                                                                                                                                    |
-| - requestId             | String  |    O     | Request ID                                                                                                                                                                                                                                   |
-| - recipientSeq          | String  |    O     | Recipient sequence number                                                                                                                                                                                                                    |
-| - plusFriendId          | String  |    O     | PlusFriend ID                                                                                                                                                                                                                                |
-| - senderKey             | String  |    O     | Sender ID                                                                                                                                                                                                                                    |
-| - templateCode          | String  |    O     | Template Code (up to 20 characters)                                                                                                                                                                                                          |
-| - recipientNo           | String  |    X     | Recipient Number                                                                                                                                                                                                                             |
-| - content               | String  |    X     | Content                                                                                                                                                                                                                                      |
-| - tempalteTitle         | String  |    X     | Template title (No more than 50 characters, Android: To be abbreviated if it exceeds 2 lines with more than 23 characters, iOS: To be abbreviated if it exceeds 2 lines with more than 27 characters)                                        |
-| - templateSubtitle      | String  |    X     | Auxiliary template phrase (No more than 50 characters, Android: To be abbreviated if it exceeds 18 characters, iOS: To be abbreviated if it exceeds 21 characters)                                                                           |
-| - templateExtra         | String  |    X     | Additional template information (Required, if template message type is [Ad Included/Mixed Purposes])                                                                                                                                         |
-| - templateAd            | String  |    X     | Request for consent of receiving within template or simple ad phrases                                                                                                                                                                        |
-| - templateHeader        | String  |    X     | Template header (up to 16 characters)                                                                                                                                                                                                        |
-| - templateItem          | Object  |    X     | Item                                                                                                                                                                                                                                         |
-| -- list                 | List    |    X     | Item list (minimum 2, maximum 10)                                                                                                                                                                                                            |
-| --- title               | String  |    X     | Title (up to 6 characters)                                                                                                                                                                                                                   |
-| --- description         | String  |    X     | Description (up to 23 characters)                                                                                                                                                                                                            |
-| -- summary              | Object  |    X     | Item summary information                                                                                                                                                                                                                     |
-| --- title               | String  |    X     | Title (up to 6 characters)                                                                                                                                                                                                                   |
-| --- description         | String  |    X     | Description (Only variables and monetary units, numbers, commas, and periods, up to 14 characters)                                                                                                                                           |
-| - templateItemHighlight | Object  |    X     | Item highlight                                                                                                                                                                                                                               |
-| --- title               | String  |    X     | Title (up to 30 characters, 21 characters with a thumbnail image)                                                                                                                                                                            |
-| --- description         | String  |    X     | Description (up to 19 characters, 13 characters with a thumbnail image)                                                                                                                                                                      |
-| --- imageUrl            | String  |    X     | Thumbnail image URL                                                                                                                                                                                                                          |
-| - templateRepresentLink | Object  |    X     | Representative link                                                                                                                                                                                                                          |
-| -- linkMo               | String  |    X     | Mobile web link (up to 500 characters)                                                                                                                                                                                                       |
-| -- linkPc               | String  |    X     | PC web link (up to 500 characters)                                                                                                                                                                                                           |
-| -- schemeIos            | String  |    X     | iOS app link (up to 500 characters)                                                                                                                                                                                                          |
-| -- schemeAndroid        | String  |    X     | Android app link (up to 500 characters)                                                                                                                                                                                                      |
-| - requestDate           | String  |    O     | Request date                                                                                                                                                                                                                                 |
-| - receiveDate           | String  |    X     | Received date                                                                                                                                                                                                                                |
-| - createDate            | String  |    O     | Creation date                                                                                                                                                                                                                                |
-| - resendStatus          | String  |    O     | Status code of resending (RSC01, RSC02, RSC03, RSC04, RSC05)\<br\>([[Resending status table below](http://docs.toast.com/ko/Notification/KakaoTalk%20Bizmessage/ko/alimtalk-api-guide/#smslms)] reference)                                   |
-| - resendStatusName      | String  |    O     | Resending status name                                                                                                                                                                                                                        |
-| - resendResultCode      | String  |    O     | Resending result code [SMS result code](https://docs.toast.com/ko/Notification/SMS/ko/error-code/#api)                                                                                                                                       |
-| - resendRequestId       | String  |    X     | Resending request ID                                                                                                                                                                                                                         |
-| - messageStatus         | String  |    O     | Mass recipient delivery status code (READY, COMPLETED, FAILED, CANCEL)                                                                                                                                                                       |
-| - resultCode            | String  |    X     | Result status code                                                                                                                                                                                                                           |
-| - resultCodeName        | String  |    X     | Result status name                                                                                                                                                                                                                           |
-| - createUser            | String  |    X     | User who created the message (stored as user UUID when sent from the console)                                                                                                                                         |
+| Name | Type | Not Null | Description |
+|-------------------------|---------|:--------:|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| header | Object | O | Header area |
+| - resultCode | Integer | O | Result code |
+| - resultMessage | String | O | Result message |
+| - isSuccessful | Boolean | O | Success |
+| body | Object | X | Body area |
+| - requestId | String | O | Request ID |
+| - recipientSeq | String | O | Recipient sequence number |
+| - plusFriendId | String | O | PlusFriend ID |
+| - senderKey | String | O | Sender ID |
+| - templateCode | String | O | Template Code (up to 20 characters) |
+| - recipientNo | String | X | Recipient number |
+| - content | String | X | Content |
+| - tempalteTitle | String | X | Template title (No more than 50 characters, Android: To be abbreviated if it exceeds 2 lines with more than 23 characters, iOS: To be abbreviated if it exceeds 2 lines with more than 27 characters) |
+| - templateSubtitle | String | X | Auxiliary template phrase (No more than 50 characters, Android: To be abbreviated if it exceeds 18 characters, iOS: To be abbreviated if it exceeds 21 characters) |
+| - templateExtra | String | X | Additional template information (Required, if template message type is [Ad Included/Mixed Purposes]) |
+| - templateAd | String | X | Request for consent of receiving within template or simple ad phrases |
+| - templateHeader | String | X | Template header (up to 16 characters) |
+| - templateItem | Object | X | Item |
+| -- list | List | X | Item list (minimum 2, maximum 10) |
+| --- title | String | X | Title (up to 6 characters) |
+| --- description | String | X | Description (up to 23 characters) |
+| -- summary | Object | X | Item summary information |
+| --- title | String | X | Title (up to 6 characters) |
+| --- description | String | X | Description (Only variables and monetary units, numbers, commas, and periods, up to 14 characters) |
+| - templateItemHighlight | Object | X | Item highlight |
+| --- title | String | X | Title (up to 30 characters, 21 characters with a thumbnail image) |
+| --- description | String | X | Description (up to 19 characters, 13 characters with a thumbnail image) |
+| --- imageUrl | String | X | Thumbnail image URL |
+| - templateRepresentLink | Object | X | Representative link |
+| -- linkMo | String | X | Mobile web link (up to 500 characters) |
+| -- linkPc | String | X | PC web link (up to 500 characters) |
+| -- schemeIos | String | X | iOS app link (up to 500 characters) |
+| -- schemeAndroid | String | X | Android app link (up to 500 characters) |
+| - requestDate | String | O | Request date |
+| - receiveDate | String | X | Received date |
+| - createDate | String | O | Created date |
+| - resendStatus | String | O | Status code of resending (RSC01, RSC02, RSC03, RSC04, RSC05)\<br\>([[See the alternative delivery status table below](http://docs.toast.com/ko/Notification/KakaoTalk%20Bizmessage/ko/alimtalk-api-guide/#smslms)]) |
+| - resendStatusName | String | O | Status name of resending |
+| - resendResultCode | String | O | Result code of resending [SMS result code](https://docs.toast.com/ko/Notification/SMS/ko/error-code/#api) |
+| - resendRequestId | String | X | Request ID of resending |
+| - messageStatus | String | O | Mass recipient delivery status code (READY, COMPLETED, FAILED, CANCEL) |
+| - resultCode | String | X | Result status code |
+| - resultCodeName | String | X | Result status name |
+| - createUser            | String  |    X     | Created user (saved as user UUID when sent from the console)                                                                                                                                         |
 | - buttons               | List    |    X     | Button list                                                                                                                                                                 |
 | -- ordering             | Integer |    X     | Button order                                                                                                                                                                  |
 | -- type                 | String  |    X     | Button type (WL: Web link, AL: App link, DS: Delivery search, BK: Bot keyword, MD: Message delivery, BC: Bot for Consultation, BT: Bot Transfer, AC: Add channel, BF: Business form, P1: Image secure transmission plugin ID, P2: Personal information use plugin ID, P3: One-click payment plugin ID, TN: Call) |
 | -- name                 | String  |    X     | Button name                                                                                                                                                                  |
-| -- linkMo               | String  |    X     | Mobile web link (required for the WL type)                                                                                                                              |
-| -- linkPc               | String  |    X     | PC web link (optional for the WL type)                                                                                                                               |
-| -- schemeIos            | String  |    X     | iOS app link (required for the AL type)                                                                                                                              |
-| -- schemeAndroid        | String  |    X     | Android app link (required for the AL type)                                                                                                                            |
+| -- linkMo               | String  |    X     | Mobile web link (required for the WL type)                                                                                                                                              |
+| -- linkPc               | String  |    X     | PC web link (optional for the WL type)                                                                                                                                               |
+| -- schemeIos            | String  |    X     | iOS app link (required for the AL type)                                                                                                                                              |
+| -- schemeAndroid        | String  |    X     | Android app link (required for the AL type)                                                                                                                                            |
 | -- chatExtra            | String  |    X     | Meta information to send for BC (Bot for Consultation) or BT (Bot Transfer) type buttons                                                                                                                                |
-| -- chatEvent            | String  |    X     | Bot event name to connect for BT (Bot Transfer) type buttons                                                                                                                                           |
+| -- chatEvent            | String  |    X     | Bot event name to connect for BT (Bot Transfer) type buttons                                                                                                                           |
 | -- bizFormId            | Integer |    X     | Business form ID (required for the BF type)                                                                                                                                                 |
-| -- pluginId             | String  |    X     | Plugin ID (up to 24 characters)                                                                                                                                        |
+| -- pluginId             | String  |    X     | Plugin ID (up to 24 characters)                                                                                                                                                        |
 | -- relayId              | String  |    X     | Value passed via the X-Kakao-Plugin-Relay-Id header when the plugin is executed                                                                                                                        |
-| -- oneClickId           | String  |    X     | Payment information used in the one-click payment plugin                                                                                                                               |
-| -- productId            | String  |    X     | Payment information used in the one-click payment plugin                                                                                                                               |
-| -- target               | String  |    X     | For web link buttons, adding the "target":"out" attribute sets an outbound link\<br\>Sent as an in-app link by default                                                                                                            |
-| -- telNumber            | String  |    X     | Phone number to send for TN (Call) type buttons                                                                    |
+| -- oneClickId           | String  |    X     | Payment information used by the one-click payment plugin                                                                                                                                               |
+| -- productId            | String  |    X     | Payment information used by the one-click payment plugin                                                                                                                                               |
+| -- target               | String  |    X     | For web link buttons, adding the `"target":"out"` attribute sends an out-link\<br\>Sent as an in-app link by default                                                                                                            |
+| -- telNumber           | 	String  | 	X  | Phone number to send for TN (Call) type buttons                                                                                                                                    |
 | - quickReplies          | List    |    X     | Quick reply list (up to 5)                                                                                                                                                        |
-| -- ordering             | Integer |    X     | Quick reply order (required if quick replies are included)                                                                                                                                                |
+| -- ordering             | Integer |    X     | Quick reply order (required if quick replies are present)                                                                                                                                                |
 | -- type                 | String  |    X     | Quick reply type (WL: Web link, AL: App link, BK: Bot keyword, BC: Bot for Consultation, BT: Bot Transfer, BF: Business form)                                                                                                |
-| -- name                 | String  |    X     | Quick reply name (required if quick replies are included, up to 14 characters)                                                                                                                                        |
+| -- name                 | String  |    X     | Quick reply name (required if quick replies are present, up to 14 characters)                                                                                                                                        |
 | -- linkMo               | String  |    X     | Mobile web link (required for the WL type, up to 500 characters)                                                                                                                                     |
 | -- linkPc               | String  |    X     | PC web link (optional for the WL type, up to 500 characters)                                                                                                                                      |
 | -- schemeIos            | String  |    X     | iOS app link (required for the AL type, up to 500 characters)                                                                                                                                     |
 | -- schemeAndroid        | String  |    X     | Android app link (required for the AL type, up to 500 characters)                                                                                                                                   |
-| -- pluginId             | String  |    X     | Plugin ID (up to 24 characters)                                                                                                                                        |
-| -- target               | String  |    X     | For the web link type, adding the "target":"out" attribute sets an outbound link\<br\>Sent as an in-app link by default                                                                                                            |
+| -- pluginId             | String  |    X     | Plugin ID (up to 24 characters)                                                                                                                                                        |
+| -- target               | String  |    X     | For web link types, adding the `"target":"out"` attribute sends an out-link\<br\>Sent as an in-app link by default                                                                                                            |
 
 <a id="templates"></a>
 
@@ -1670,7 +1670,7 @@ curl -X GET \
 
 <a id="list-template-categories"></a>
 
-### List Template Categories
+### Query Template Categories
 
 <a id="request-11"></a>
 
@@ -1738,7 +1738,7 @@ Content-Type: application/json;charset=UTF-8
 | - isSuccessful  | Boolean |    O     | Success                    |
 | categories      | List    |    X     | Category list                 |
 | - name          | String  |    X     | Category name                  |
-| - subCategories | List    |    X     | Subcategory list              |
+| - subCategories | List    |    X     | Sub-category list              |
 | -- code         | String  |    X     | Category code (Used when registering/modifying templates) |
 | -- name         | String  |    X     | Category name                  |
 | -- groupName    | String  |    X     | Category group name                 |
@@ -1747,7 +1747,7 @@ Content-Type: application/json;charset=UTF-8
 
 <a id="register-templates"></a>
 
-### Register Template
+### Register Templates
 
 <a id="request-12"></a>
 
@@ -1760,7 +1760,7 @@ POST  /alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates
 Content-Type: application/json;charset=UTF-8
 ```
 
-[Path Parameter]
+[Path parameter]
 
 | Name        | 	Type     | 	Description     |
 |-----------|---------|---------|
@@ -1846,49 +1846,49 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name                  | 	Type     | 	Required | 	Description                                                                                                                                                                                                                                                                                              |
-|-----------------------|----------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| templateCode          | 	String  | 	O        | Template Code (up to 20 characters)                                                                                                                                                                                                                                                                       |
-| templateName          | 	String  | 	O        | Template name (up to 150 characters)                                                                                                                                                                                                                                                                      |
-| templateContent       | 	String  | 	O        | Template body (up to 1,300 characters)                                                                                                                                                                                                                                                                    |
-| templateMessageType   | String   | X         | Types of template message (BA: Basic, EX: Extra Information, AD: Ad Included, MI: Mixed Purposes, default: BA)                                                                                                                                                                                            |
-| templateEmphasizeType | String   | X         | Template emphasis display type (NONE: Default, TEXT: Emphasis, IMAGE: Image type, ITEM_LIST: Item List Type, default: NONE)<br>- TEXT: templateTitle, templateSubtitle fields required<br>- IMAGE: templateImageName, templateImageUrl fields required<br>ITEM_LIST: At least one of image, header, item highlight, and item list is required |
-| templateExtra         | String   | X         | Template supplementary information (required if the template message type is [Extra Information/Mixed Purposes])                                                                                                                                                                                           |
-| tempalteTitle         | String   | X         | Template title (No more than 50 characters, Android: To be abbreviated if it exceeds 2 lines with more than 23 characters, iOS: To be abbreviated if it exceeds 2 lines with more than 27 characters)                                                                                                     |
-| templateSubtitle      | String   | X         | Auxiliary template phrase (No more than 50 characters, Android: To be abbreviated if it exceeds 18 characters, iOS: To be abbreviated if it exceeds 21 characters)                                                                                                                                        |
-| templateHeader        | String   | X         | Template header (up to 16 characters)                                                                                                                                                                                                                                                                     |
-| templateItem          | Object   | X         | Item                                                                                                                                                                                                                                                                                                      |
-| - list                | List     | X         | Item list (minimum 2, maximum 10)                                                                                                                                                                                                                                                                         |
-| -- title              | String   | X         | Title (up to 6 characters)                                                                                                                                                                                                                                                                                |
-| -- description        | String   | X         | Description (up to 23 characters)                                                                                                                                                                                                                                                                         |
-| - summary             | Object   | X         | Item summary information                                                                                                                                                                                                                                                                                   |
-| -- title              | String   | X         | Title (up to 6 characters)                                                                                                                                                                                                                                                                                |
-| -- description        | String   | X         | Description (Only variables and monetary units, numbers, commas, and periods, up to 14 characters)                                                                                                                                                                                                        |
-| templateItemHighlight | Object   | X         | Item highlight                                                                                                                                                                                                                                                                                            |
-| - title               | String   | X         | Title (up to 30 characters, 21 characters if a thumbnail image is present)                                                                                                                                                                                                                                |
-| - description         | String   | X         | Description (up to 19 characters, 13 characters if a thumbnail image is present)                                                                                                                                                                                                                          |
-| - imageUrl            | String   | X         | Thumbnail image URL                                                                                                                                                                                                                                                                                       |
-| templateRepresentLink | Object   | X         | Representative link                                                                                                                                                                                                                                                                                       |
-| - linkMo              | String   | 	X        | 	Mobile web link (up to 500 characters)                                                                                                                                                                                                                                                                   |
-| - linkPc              | String   | 	X        | PC web link (up to 500 characters)                                                                                                                                                                                                                                                                        |
-| - schemeIos           | String   | X         | 	iOS app link (up to 500 characters)                                                                                                                                                                                                                                                                      |
-| - schemeAndroid       | String   | X         | 	Android app link (up to 500 characters)                                                                                                                                                                                                                                                                  |
-| templateImageName     | String   | 	X        | Image name (uploaded file name)                                                                                                                                                                                                                                                                           |
-| templateImageUrl      | String   | 	X        | Image URL                                                                                                                                                                                                                                                                                                 |
-| securityFlag          | Boolean  | X         | Whether it is a security template<br>Set for security messages such as OTP<br>If set, message text is unexposed to all devices except for the main device at the time of sending (default: false)                                                                                                          |
-| categoryCode          | String   | X         | Template category code (refer to the Template Category Query API, default: 999999)<br>If the category is "Other," it will be reviewed with the lowest priority                                                                                                                                             |
-| buttons               | 	List    | 	X        | Button list (maximum 5)                                                                                                                                                                                                                                                                                   |
-| - ordering            | 	Integer | 	X        | Button order (1 to 5)                                                                                                                                                                                                                                                                                     |
-| - type                | String   | 	X        | 	Button type (WL: Web link, AL: App link, DS: Delivery search, BK: Bot keyword, MD: Message delivery, BC: Bot for Consultation, BT: Bot Transfer, AC: Add channel, BF: Business form, P1: Image secure transmission plugin ID, P2: Personal information use plugin ID, P3: One-click payment plugin ID, TN: Call) |
-| - name                | String   | 	X        | 	Button name (required if there is a button, up to 14 characters)                                                                                                                                                                                                                                         |
+| Name                  | Type     | Required | Description                                                                                                                                                                                                                                                                                               |
+|-----------------------|----------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| templateCode          | String   | O        | Template code (up to 20 characters)                                                                                                                                                                                                                                                                       |
+| templateName          | String   | O        | Template name (up to 150 characters)                                                                                                                                                                                                                                                                      |
+| templateContent       | String   | O        | Template body (up to 1,300 characters)                                                                                                                                                                                                                                                                    |
+| templateMessageType   | String   | X        | Types of template message (BA: Basic, EX: Extra Information, AD: Ad Included, MI: Mixed Purposes, default: BA)                                                                                                                                                                                            |
+| templateEmphasizeType | String   | X        | Template emphasis display type (NONE: Default, TEXT: Emphasis, IMAGE: Image type, ITEM_LIST: Item list type, default: NONE)<br>- TEXT: templateTitle and templateSubtitle fields are required<br>- IMAGE: templateImageName and templateImageUrl fields are required<br>- ITEM_LIST: At least one of image, header, item highlight, or item list is required |
+| templateExtra         | String   | X        | Template extra information (required if the template message type is [Extra Information/Mixed Purposes])                                                                                                                                                                                                  |
+| tempalteTitle         | String   | X        | Template title (No more than 50 characters, Android: To be abbreviated if it exceeds 2 lines with more than 23 characters, iOS: To be abbreviated if it exceeds 2 lines with more than 27 characters)                                                                                                     |
+| templateSubtitle      | String   | X        | Auxiliary template phrase (No more than 50 characters, Android: To be abbreviated if it exceeds 18 characters, iOS: To be abbreviated if it exceeds 21 characters)                                                                                                                                        |
+| templateHeader        | String   | X        | Template header (up to 16 characters)                                                                                                                                                                                                                                                                     |
+| templateItem          | Object   | X        | Item                                                                                                                                                                                                                                                                                                      |
+| - list                | List     | X        | Item list (minimum 2, maximum 10)                                                                                                                                                                                                                                                                         |
+| -- title              | String   | X        | Title (up to 6 characters)                                                                                                                                                                                                                                                                                |
+| -- description        | String   | X        | Description (up to 23 characters)                                                                                                                                                                                                                                                                         |
+| - summary             | Object   | X        | Item summary information                                                                                                                                                                                                                                                                                  |
+| -- title              | String   | X        | Title (up to 6 characters)                                                                                                                                                                                                                                                                                |
+| -- description        | String   | X        | Description (Only variables and monetary units, numbers, commas, and periods, up to 14 characters)                                                                                                                                                                                                        |
+| templateItemHighlight | Object   | X        | Item highlight                                                                                                                                                                                                                                                                                            |
+| - title               | String   | X        | Title (up to 30 characters; up to 21 characters if a thumbnail image is present)                                                                                                                                                                                                                          |
+| - description         | String   | X        | Description (up to 19 characters; up to 13 characters if a thumbnail image is present)                                                                                                                                                                                                                    |
+| - imageUrl            | String   | X        | Thumbnail image URL                                                                                                                                                                                                                                                                                       |
+| templateRepresentLink | Object   | X        | Representative link                                                                                                                                                                                                                                                                                       |
+| - linkMo              | String   | X        | Mobile web link (up to 500 characters)                                                                                                                                                                                                                                                                    |
+| - linkPc              | String   | X        | PC web link (up to 500 characters)                                                                                                                                                                                                                                                                        |
+| - schemeIos           | String   | X        | iOS app link (up to 500 characters)                                                                                                                                                                                                                                                                       |
+| - schemeAndroid       | String   | X        | Android app link (up to 500 characters)                                                                                                                                                                                                                                                                   |
+| templateImageName     | String   | X        | Image name (name of the uploaded file)                                                                                                                                                                                                                                                                    |
+| templateImageUrl      | String   | X        | Image URL                                                                                                                                                                                                                                                                                                 |
+| securityFlag          | Boolean  | X        | Whether it is a security template<br>Set this for security messages such as OTP<br>If set, message text is unexposed to all devices except for the main device at the time of sending (default: false)                                                                                                    |
+| categoryCode          | String   | X        | Template category code (refer to the Get Template Categories API, default: 999999)<br>If the category is "Other", the template is reviewed with the lowest priority                                                                                                                                       |
+| buttons               | List     | X        | Button list (up to 5)                                                                                                                                                                                                                                                                                     |
+| - ordering            | Integer  | X        | Button order (1–5)                                                                                                                                                                                                                                                                                        |
+| - type                | String   | X        | Button type (WL: Web link, AL: App link, DS: Delivery search, BK: Bot keyword, MD: Message delivery, BC: Bot for Consultation, BT: Bot Transfer, AC: Add channel, BF: Business form, P1: Image secure transmission plugin ID, P2: Personal information use plugin ID, P3: One-click payment plugin ID, TN: Call) |
+| - name                | String   | X        | Button name (required if a button is present; up to 14 characters)                                                                                                                                                                                                                                        |
 | - linkMo              | String   | 	X  | 	Mobile web link (required for the WL type, for up to 500 characters)                                                                                                                                                                                                             |
 | - linkPc              | String   | 	X  | PC web link (optional for the WL type, for up to 500 characters)                                                                                                                                                                                                               |
 | - schemeIos           | String   | X   | 	iOS app link (required for the AL type, for up to 500 characters)                                                                                                                                                                                                             |
 | - schemeAndroid       | String   | X   | 	Android app link (required for the AL type, for up to 500 characters)                                                                                                                                                                                                           |
 | - bizFormId           | 	Integer | 	X  | 	Business form ID (required for the BF type)                                                                                                                                                                                                                         |
 | - pluginId            | 	String  | 	X  | 	Plugin ID (up to 24 characters)                                                                                                                                                                                                                                |
-| -- telNumber           | 	String  | 	X  | Phone number to send for a TN (Call) type button                                                                    |
-| quickReplies          | 	List    | 	X  | Quick reply list (up to 5 items)                                                                                                                                                                                                                                 |
+| -- telNumber           | 	String  | 	X  | Phone number to send for TN (Call) type buttons                                                    |
+| quickReplies          | 	List    | 	X  | Quick reply list (up to 5)                                                                                                                                                                                                                                 |
 | - ordering            | 	Integer | 	X  | 	Quick reply order (required when quick reply exists)                                                                                                                                                                                                                        |
 | - type                | String   | 	X  | 	Quick reply type (WL: Web link, AL: App link, BK: Bot keyword, BC: Bot for Consultation, BT: Bot Transfer, BF: Business form)                                                                                                                                                                        |
 | - name                | String   | 	X  | 	Quick reply name (required when quick reply exists, up to 14 characters)                                                                                                                                                                                                                |
@@ -1899,10 +1899,10 @@ Content-Type: application/json;charset=UTF-8
 | - bizFormId           | 	Integer | 	X  | 	Business form ID (required for the BF type)                                                                                                                                                                                                                         |
 
 * The templateAd value is fixed when registering the AD included (AD) or Mixed Purposes (MI) message type template.
-* The Add Channel button must be in the first position when registering the AD included (AD) or Mixed Purposes (MI) message type template.
-* The Add Channel (AC) button name must be fixed as 'Add channel' when registering.
+* The Add Channel (AC) button must be in the first position when registering the AD included (AD) or Mixed Purposes (MI) message type template.
+* The Add Channel (AC) button name must be registered as "Add channel".
 
-Refer to the following table for the availability of replacement variables (#{variable}) for each field.
+Refer to the table below for whether replacement variables (#{variable}) can be used for each field.
 
 | Category | Field | Replaceable |
 |------|------|---------|
@@ -1916,14 +1916,14 @@ Refer to the following table for the availability of replacement variables (#{va
 | Button | linkMo, linkPc, schemeIos, schemeAndroid | O |
 | Quick Reply | name | X |
 | Quick Reply | linkMo, linkPc, schemeIos, schemeAndroid | O |
-| Template Item | title | X |
-| Template Item | description | O |
-| Template Item summary | title | X |
-| Template Item summary | description | O |
-| Template Item Highlight | title | O |
-| Template Item Highlight | description | O |
-| Template Item Highlight | imageUrl | X |
-| Representative Link | linkMo, linkPc, schemeIos, schemeAndroid | O |
+| Template item | title | X |
+| Template item | description | O |
+| Template item summary | title | X |
+| Template item summary | description | O |
+| Template item highlight | title | O |
+| Template item highlight | description | O |
+| Template item highlight | imageUrl | X |
+| Representative link | linkMo, linkPc, schemeIos, schemeAndroid | O |
 
 <a id="response-13"></a>
 
@@ -1961,13 +1961,13 @@ PUT  /alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode
 Content-Type: application/json;charset=UTF-8
 ```
 
-[Path parameter]
+[Path Parameter]
 
 | Name           | 	Type     | 	Description     |
 |--------------|---------|---------|
 | appkey       | 	String | 	Unique app key |
-| senderKey    | 	String | 	Sender Key   |
-| templateCode | 	String | 	Template Code |
+| senderKey    | 	String | 	Sender key   |
+| templateCode | 	String | 	Template code |
 
 [Header]
 
@@ -2047,60 +2047,60 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name                    | 	Type      | 	Required | 	Description                                                                                                                                                                        |
-|-----------------------|----------|-----|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| templateName          | 	String  | 	O  | Template name (up to 150 characters)                                                                                                                                                              |
-| templateContent       | 	String  | 	O  | Template body (up to 1,300 characters)                                                                                                                                                           |
-| templateMessageType   | String   | X   | Types of template message (BA: Basic, EX: Extra Information, AD: Ad Included, MI: Mixed Purposes)                                                                                                                                       |
-| templateEmphasizeType | String   | X   | Template emphasis type (NONE: Default, TEXT: Emphasized, IMAGE: Image type, default: NONE)<br>- TEXT: templateTitle, templateSubtitle fields required<br>- IMAGE: templateImageName, templateImageUrl fields required     |
-| templateExtra         | String   | X   | Additional template information (required if the template message type is [Extra Information/Mixed Purposes])                                                                                                                                 |
-| tempalteTitle         | String   | X   | Template title (No more than 50 characters, Android: To be abbreviated if it exceeds 2 lines with more than 23 characters, iOS: To be abbreviated if it exceeds 2 lines with more than 27 characters)                                                                                                                                         |
-| templateSubtitle      | String   | X   | Auxiliary template phrase (No more than 50 characters, Android: To be abbreviated if it exceeds 18 characters, iOS: To be abbreviated if it exceeds 21 characters)                                                                                                                              |
-| templateHeader        | String   | X   | Template header (up to 16 characters)                                                                                                                                                             |
-| templateItem          | Object   | X   | Item                                                                                                                                                                        |
-| - list                | List     | X   | Item list (minimum 2, maximum 10)                                                                                                                                                     |
-| -- title              | String   | X   | Title (up to 6 characters)                                                                                                                                                                 |
-| -- description        | String   | X   | Description (up to 23 characters)                                                                                                                                                              |
-| - summary             | Object   | X   | Item summary information                                                                                                                                                                  |
-| -- title              | String   | X   | Title (up to 6 characters)                                                                                                                                                                 |
-| -- description        | String   | X   | Description (Only variables and monetary units, numbers, commas, and periods, up to 14 characters)                                                                                                                              |
-| templateItemHighlight | Object   | X   | Item highlight                                                                                                                                                                  |
-| - title               | String   | X   | Title (up to 30 characters; up to 21 characters if a thumbnail image is included)                                                                                                                                            |
-| - description         | String   | X   | Description (up to 19 characters; up to 13 characters if a thumbnail image is included)                                                                                                                                          |
-| - imageUrl            | String   | X   | Thumbnail image URL                                                                                                                                                                 |
-| templateRepresentLink | Object   | X   | Representative link                                                                                                                                                                      |
-| - linkMo              | String   | 	X  | 	Mobile web link (up to 500 characters)                                                                                                                                                         |
-| - linkPc              | String   | 	X  | PC web link (up to 500 characters)                                                                                                                                                           |
-| - schemeIos           | String   | X   | 	iOS app link (up to 500 characters)                                                                                                                                                         |
-| - schemeAndroid       | String   | X   | 	Android app link (up to 500 characters)                                                                                                                                                       |
-| templateImageName     | String   | 	X  | Image name (name of the uploaded file)                                                                                                                                                             |
-| templateImageUrl      | String   | 	X  | Image URL                                                                                                                                                                    |
-| securityFlag          | Boolean  | X   | Whether the template is a security template<br>Set for security messages such as OTP<br>If set, message text is unexposed to all devices except for the main device at the time of sending (default: false)                                                                               |
-| categoryCode          | String   | X   | Template category code (see the Template Category Query API, default: 999999)<br>If the category is "Others," it is reviewed with the lowest priority                                                                                                              |
-| buttons               | 	List    | 	X  | Button list (maximum 5)                                                                                                                                                              |
-| - ordering            | 	Integer | 	X  | Button order (1 to 5)                                                                                                                                                                 |
-| - type                | String   | 	X  | 	Button type (WL: Web link, AL: App link, DS: Delivery search, BK: Bot keyword, MD: Message delivery, BC: Bot for Consultation, BT: Bot Transfer, AC: Add channel, BF: Business form, P1: Image secure transmission plugin ID, P2: Personal information use plugin ID, P3: One-click payment plugin ID, TN: Call) |
-| - name                | String   | 	X  | 	Button name (required if a button exists, up to 14 characters)                                                                                                                               |
-| - linkMo              | String   | 	X  | 	Mobile web link (required field if type is WL, up to 500 characters)                                                                                                                                        |
-| - linkPc              | String   | 	X  | PC web link (optional field if type is WL, up to 500 characters)                                                                                                                                          |
-| - schemeIos           | String   | X   | 	iOS app link (required field if type is AL, up to 500 characters)                                                                                                                                        |
-| - schemeAndroid       | String   | X   | 	Android app link (required field if type is AL, up to 500 characters)                                                                                                                                      |
-| - bizFormId           | 	Integer | 	X  | 	Business form ID (required if type is BF)                                                                                                                                                    |
-| - pluginId            | 	String  | 	X  | 	Plugin ID (up to 24 characters)                                                                                                                                                           |
-| -- telNumber           | 	String  | 	X  | Phone number to forward when using a TN (Call) type button                                                                    |
-| quickReplies          | 	List    | 	X  | Quick Reply list (maximum 5)                                                                                                                                                            |
-| - ordering            | 	Integer | 	X  | 	Quick Reply order (required if Quick Reply exists)                                                                                                                                                   |
-| - type                | String   | 	X  | 	Quick Reply type (WL: Web Link, AL: App Link, BK: Bot Keyword, BC: Bot for Consultation, BT: Bot Transfer, BF: Business Form)                                                                                                                   |
-| - name                | String   | 	X  | 	Quick Reply name (required if Quick Reply exists, up to 14 characters)                                                                                                                           |
-| - linkMo              | String   | 	X  | 	Mobile web link (required field if type is WL, up to 500 characters)                                                                                                                                        |
+| Name                  | 	Type     | 	Required | 	Description                                                                                                                                                                                                                                                        |
+|-----------------------|----------|-----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| templateName          | 	String  | 	O        | Template name (up to 150 characters)                                                                                                                                                                                                                                |
+| templateContent       | 	String  | 	O        | Template body (up to 1,300 characters)                                                                                                                                                                                                                              |
+| templateMessageType   | String   | X         | Types of template message (BA: Basic, EX: Extra Information, AD: Ad Included, MI: Mixed Purposes, default: Basic)                                                                                                                                                   |
+| templateEmphasizeType | String   | X         | Template emphasis display type (NONE: Default, TEXT: Emphasis, IMAGE: Image type, default: NONE)<br>- TEXT: templateTitle and templateSubtitle fields are required<br>- IMAGE: templateImageName and templateImageUrl fields are required                            |
+| templateExtra         | String   | X         | Template extra information (required if the template message type is [Extra Information/Mixed Purposes])                                                                                                                                                            |
+| tempalteTitle         | String   | X         | Template title (No more than 50 characters, Android: To be abbreviated if it exceeds 2 lines with more than 23 characters, iOS: To be abbreviated if it exceeds 2 lines with more than 27 characters)                                                               |
+| templateSubtitle      | String   | X         | Auxiliary template phrase (No more than 50 characters, Android: To be abbreviated if it exceeds 18 characters, iOS: To be abbreviated if it exceeds 21 characters)                                                                                                  |
+| templateHeader        | String   | X         | Template header (up to 16 characters)                                                                                                                                                                                                                               |
+| templateItem          | Object   | X         | Item                                                                                                                                                                                                                                                                |
+| - list                | List     | X         | Item list (minimum 2, maximum 10)                                                                                                                                                                                                                                   |
+| -- title              | String   | X         | Title (up to 6 characters)                                                                                                                                                                                                                                          |
+| -- description        | String   | X         | Description (up to 23 characters)                                                                                                                                                                                                                                   |
+| - summary             | Object   | X         | Item summary information                                                                                                                                                                                                                                             |
+| -- title              | String   | X         | Title (up to 6 characters)                                                                                                                                                                                                                                          |
+| -- description        | String   | X         | Description (Only variables and monetary units, numbers, commas, and periods, up to 14 characters)                                                                                                                                                                  |
+| templateItemHighlight | Object   | X         | Item highlight                                                                                                                                                                                                                                                      |
+| - title               | String   | X         | Title (up to 30 characters; up to 21 characters if a thumbnail image is present)                                                                                                                                                                                    |
+| - description         | String   | X         | Description (up to 19 characters; up to 13 characters if a thumbnail image is present)                                                                                                                                                                              |
+| - imageUrl            | String   | X         | Thumbnail image URL                                                                                                                                                                                                                                                 |
+| templateRepresentLink | Object   | X         | Representative link                                                                                                                                                                                                                                                 |
+| - linkMo              | String   | 	X        | 	Mobile web link (up to 500 characters)                                                                                                                                                                                                                             |
+| - linkPc              | String   | 	X        | PC web link (up to 500 characters)                                                                                                                                                                                                                                  |
+| - schemeIos           | String   | X         | 	iOS app link (up to 500 characters)                                                                                                                                                                                                                                |
+| - schemeAndroid       | String   | X         | 	Android app link (up to 500 characters)                                                                                                                                                                                                                            |
+| templateImageName     | String   | 	X        | Image name (name of the uploaded file)                                                                                                                                                                                                                              |
+| templateImageUrl      | String   | 	X        | Image URL                                                                                                                                                                                                                                                           |
+| securityFlag          | Boolean  | X         | Whether it is a security template<br>Set this if the message contains security content such as OTPs<br>If set, message text is unexposed to all devices except for the main device at the time of sending (default: false)                                          |
+| categoryCode          | String   | X         | Template category code (refer to the Query Template Categories API, default: 999999)<br>If the category is "Other," the template is reviewed at the lowest priority                                                                                                 |
+| buttons               | 	List    | 	X        | Button list (up to 5)                                                                                                                                                                                                                                               |
+| - ordering            | 	Integer | 	X        | Button order (1–5)                                                                                                                                                                                                                                                  |
+| - type                | String   | 	X        | 	Button type (WL: Web link, AL: App link, DS: Delivery search, BK: Bot keyword, MD: Message delivery, BC: Bot for Consultation, BT: Bot Transfer, AC: Add channel, BF: Business form, P1: Image secure transmission plugin ID, P2: Personal information use plugin ID, P3: One-click payment plugin ID, TN: Call) |
+| - name                | String   | 	X        | 	Button name (required if a button exists, up to 14 characters)                                                                                                                                                                                                     |
+| - linkMo              | String   | 	X        | 	Mobile web link (required field for WL type, up to 500 characters)                                                                                                                                                                                                 |
+| - linkPc              | String   | 	X        | PC web link (optional field for WL type, up to 500 characters)                                                                                                                                                                                                      |
+| - schemeIos           | String   | X         | 	iOS app link (required field for AL type, up to 500 characters)                                                                                                                                                                                                    |
+| - schemeAndroid       | String   | X         | 	Android app link (required field for AL type, up to 500 characters)                                                                                                                                                                                                |
+| - bizFormId           | 	Integer | 	X        | 	Business form ID (required for BF type)                                                                                                                                                                                                                            |
+| - pluginId            | 	String  | 	X        | 	Plugin ID (up to 24 characters)                                                                                                                                                                                                                                    |
+| -- telNumber          | 	String  | 	X        | Phone number to be delivered for TN (Call) type buttons                                                                                                                                                                                                             |
+| quickReplies          | 	List    | 	X        | Quick Reply list (up to 5)                                                                                                                                                                                                                                          |
+| - ordering            | 	Integer | 	X        | 	Quick Reply order (required if a Quick Reply exists)                                                                                                                                                                                                               |
+| - type                | String   | 	X        | 	Quick Reply type (WL: Web link, AL: App link, BK: Bot keyword, BC: Bot for Consultation, BT: Bot Transfer, BF: Business form)                                                                                                                                      |
+| - name                | String   | 	X        | 	Quick Reply name (required if a Quick Reply exists, up to 14 characters)                                                                                                                                                                                           |
+| - linkMo              | String   | 	X        | 	Mobile web link (required field for WL type, up to 500 characters)                                                                                                                                                                                                 |
 | - linkPc              | String   | 	X  | PC web link (optional for the WL type, for up to 500 characters)                                                                                                                          |
 | - schemeIos           | String   | X   | 	iOS app link (required for the AL type, for up to 500 characters)                                                                                                                        |
 | - schemeAndroid       | String   | X   | 	Android app link (required for the AL type, for up to 500 characters)                                                                                                                      |
 | - bizFormId           | 	Integer | 	X  | 	Business form ID (required for the BF type)                                                                                                                                                    |
 
 * The templateAd value is fixed when modifying the AD included (AD) or Mixed Purposes (MI) message type template.
-* The Add Channel button must be in the first when modifying the AD included (AD) or Mixed Purposes (MI) message type template.
-* The button name of the Add Channel (AC) button must be fixed as "Add Channel" when modifying.
+* The Add Chanel button must be in the first when modifying the AD included (AD) or Mixed Purposes (MI) message type template.
+* The button name of the Add Channel (AC) button must be fixed to "Add Channel" and modified accordingly.
 
 <a id="response-14"></a>
 
@@ -2118,10 +2118,10 @@ Content-Type: application/json;charset=UTF-8
 
 | Name              | Type      | Not Null | Description     |
 |-----------------|---------|:--------:|--------|
-| header          | Object  |    O     | Header     |
+| header          | Object  |    O     | Header area  |
 | - resultCode    | Integer |    O     | Result code  |
 | - resultMessage | String  |    O     | Result message |
-| - isSuccessful  | Boolean |    O     | Success  |
+| - isSuccessful  | Boolean |    O     | Success |
 
 <a id="delete-templates"></a>
 
@@ -2140,11 +2140,11 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name         | 	Type   | 	Description    |
-|--------------|---------|-----------------|
-| appkey       | 	String | 	Unique app key |
-| senderKey    | 	String | 	Sender Key     |
-| templateCode | 	String | 	Template Code  |
+| Name         | 	Type   | 	Description      |
+|--------------|---------|-------------------|
+| appkey       | 	String | 	App Key           |
+| senderKey    | 	String | 	Sender Key        |
+| templateCode | 	String | 	Template Code     |
 
 [Header]
 
@@ -2172,16 +2172,16 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name            | Type    | Not Null | Description  |
-|-----------------|---------|:--------:|--------------|
-| header          | Object  |    O     | Header area  |
-| - resultCode    | Integer |    O     | Result code  |
+| Name            | Type    | Not Null | Description    |
+|-----------------|---------|:--------:|----------------|
+| header          | Object  |    O     | Header area    |
+| - resultCode    | Integer |    O     | Result code    |
 | - resultMessage | String  |    O     | Result message |
-| - isSuccessful  | Boolean |    O     | Success      |
+| - isSuccessful  | Boolean |    O     | Success        |
 
 <a id="inquire-of-templates"></a>
 
-### Comment on a Template
+### Inquire About a Template
 
 <a id="request-15"></a>
 
@@ -2198,8 +2198,8 @@ Content-Type: application/json;charset=UTF-8
 
 | Name         | 	Type   | 	Description  |
 |--------------|---------|---------------|
-| appkey       | 	String | 	App Key      |
-| senderKey    | 	String | 	Sender Key   |
+| appkey       | 	String | 	Appkey        |
+| senderKey    | 	String | 	Sender Key    |
 | templateCode | 	String | 	Template Code |
 
 [Header]
@@ -2210,8 +2210,8 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name         | 	Type   | 	Required | 	Description                       |
-|--------------|---------|-----------|-----------------------------------|
+| Name         | 	Type   | 	Required | 	Description                    |
+|--------------|---------|-----------|----------------------------------|
 | X-Secret-Key | 	String | O         | Can be created in the console. |
 
 [Request Body]
@@ -2223,7 +2223,7 @@ Content-Type: application/json;charset=UTF-8
 ```
 
 | Name    | 	Type   | 	Required | 	Description    |
-|---------|---------|-----------|----------------|
+|---------|---------|-----------|-----------------|
 | comment | 	String | 	O        | Inquiry content |
 
 * When commenting a template in the REJ status, it will be changed to the REQ status.
@@ -2251,7 +2251,7 @@ Content-Type: application/json;charset=UTF-8
 
 <a id="send-inquiry-on-templates-with-file-attachment"></a>
 
-### Submit a Template Inquiry with File Attachments
+### Add a Comment with File Attachment to a Template
 
 <a id="request-16"></a>
 
@@ -2266,11 +2266,11 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name           | 	Type     | 	Description     |
-|--------------|---------|---------|
-| appkey       | 	String | 	Unique App Key |
-| senderKey    | 	String | 	Sender Key   |
-| templateCode | 	String | 	Template Code |
+| Name         | 	Type   | 	Description     |
+|--------------|---------|-----------------|
+| appkey       | 	String | 	App Key         |
+| senderKey    | 	String | 	Sender Key      |
+| templateCode | 	String | 	Template Code   |
 
 [Header]
 
@@ -2280,9 +2280,9 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name           | 	Type     | 	Required | 	Description              |
-|--------------|---------|-----|------------------|
-| X-Secret-Key | 	String | O   | Can be created in the console. |
+| Name         | 	Type   | 	Required | 	Description                          |
+|--------------|---------|-----------|---------------------------------------|
+| X-Secret-Key | 	String | O         | Can be created in the console. |
 
 [Request Body]
 
@@ -2293,10 +2293,10 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name          | 	Type        | 	Required | 	Description                                                                                                                                        |
-|-------------|------------|-----|--------------------------------------------------------------------------------------------------------------------------------------------|
-| comment     | 	String    | 	O  | Inquiry content                                                                                                                                      |
-| attachments | List<File> | X   | List of attachments (up to 10)<br>- Supported file extensions: .png, .jpg, .jpeg, .gif, .pdf, .hwp, .doc, .docx<br>- Maximum size per individual file: 50 MB<br>- Maximum total upload size: 100 MB |
+| Name        | 	Type      | 	Required | 	Description                                                                                                                                                                        |
+|-------------|------------|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| comment     | 	String    | 	O        | Comment content                                                                                                                                                                     |
+| attachments | List<File> | X         | List of attachments (up to 10)<br>- Supported extensions: .png, .jpg, .jpeg, .gif, .pdf, .hwp, .doc, .docx<br>- Maximum size per file: 50 MB<br>- Maximum total upload size: 100 MB |
 
 * When commenting a template in the REJ status, it will be changed to the REQ status.
 
@@ -2314,12 +2314,12 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name              | Type      | Not Null | Description     |
-|-----------------|---------|:--------:|--------|
-| header          | Object  |    O     | Header area  |
-| - resultCode    | Integer |    O     | Result code  |
+| Name            | Type    | Not Null | Description    |
+|-----------------|---------|:--------:|----------------|
+| header          | Object  |    O     | Header area    |
+| - resultCode    | Integer |    O     | Result code    |
 | - resultMessage | String  |    O     | Result message |
-| - isSuccessful  | Boolean |    O     | Success  |
+| - isSuccessful  | Boolean |    O     | Success        |
 
 <a id="change-template-to-channel-add-type"></a>
 
@@ -2338,11 +2338,11 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name         | 	Type   | 	Description       |
-|--------------|---------|---------------------|
-| appkey       | 	String | 	Unique app key     |
-| senderKey    | 	String | 	Sender Key         |
-| templateCode | 	String | 	Template Code      |
+| Name         | 	Type   | 	Description    |
+|--------------|---------|-----------------|
+| appkey       | 	String | 	Unique app key |
+| senderKey    | 	String | 	Sender key     |
+| templateCode | 	String | 	Template code  |
 
 [Header]
 
@@ -2356,7 +2356,7 @@ Content-Type: application/json;charset=UTF-8
 |--------------|---------|-----------|-------------------------------------|
 | X-Secret-Key | 	String | O         | Can be created in the console. |
 
-* Templates registered under a group Sender Profile cannot be converted to the Add Channel type.
+* Templates registered to a group Sender Profile cannot be converted to the Add Channel type.
 
 <a id="response-18"></a>
 
@@ -2396,10 +2396,10 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name         | 	Type    | 	Description   |
-|--------------|---------|----------------|
+| Name         | 	Type   | 	Description  |
+|--------------|---------|---------------|
 | appkey       | 	String | 	Unique app key |
-| senderKey    | 	String | 	Sender Key     |
+| senderKey    | 	String | 	Sender Key    |
 | templateCode | String  | Template Code  |
 
 [Header]
@@ -2410,16 +2410,16 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name         | 	Type    | 	Required | 	Description                        |
-|--------------|---------|-----------|-------------------------------------|
+| Name         | 	Type   | 	Required | 	Description                    |
+|--------------|---------|-----------|----------------------------------|
 | X-Secret-Key | 	String | O         | Can be created in the console. |
 
 | Template Status Code | Description |
-|-----------|------|
-| TSC01     | Requested   |
-| TSC02     | Reviewing   |
-| TSC03     | Approved    |
-| TSC04     | Rejected    |
+|----------------------|-------------|
+| TSC01                | Requested   |
+| TSC02                | Reviewing   |
+| TSC03                | Approved    |
+| TSC04                | Rejected    |
 
 [Example]
 
@@ -2528,82 +2528,82 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 }
 ```
 
-| Name                    | Type    | Not Null | Description                                                                                                                                                                                                                                                                         |
-|-------------------------|---------|:--------:|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| header                  | Object  |    O     | Header area                                                                                                                                                                                                                                                                         |
-| - resultCode            | Integer |    O     | Result code                                                                                                                                                                                                                                                                         |
-| - resultMessage         | String  |    O     | Result message                                                                                                                                                                                                                                                                      |
-| - isSuccessful          | Boolean |    O     | Success                                                                                                                                                                                                                                                                             |
-| templates               | Object  |    X     | Template list                                                                                                                                                                                                                                                                       |
-| - plusFriendId          | String  |    O     | KakaoTalk Channel search ID or Sender Profile group name                                                                                                                                                                                                                            |
-| - senderKey             | String  |    O     | Sender Key                                                                                                                                                                                                                                                                          |
-| - plusFriendType        | String  |    O     | PlusFriend type (NORMAL, GROUP)                                                                                                                                                                                                                                                     |
-| - templateCode          | String  |    O     | Template Code                                                                                                                                                                                                                                                                       |
-| - kakaoTemplateCode     | String  |    O     | Original template code                                                                                                                                                                                                                                                              |
-| - templateName          | String  |    O     | Template name                                                                                                                                                                                                                                                                       |
-| - templateMessageType   | String  |    X     | Types of template message (BA: Basic, EX: Extra Information, AD: Ad Included, MI: Mixed Purposes, default: Basic)                                                                                                                                                                   |
-| - templateEmphasizeType | String  |    X     | Types of emphasized template (NONE: Basic, TEXT: Emphasized, IMAGE: Image type, ITEM_LIST: Item List type, default: NONE)                                                                                                                                                           |
-| - templateContent       | String  |    X     | Template body                                                                                                                                                                                                                                                                       |
-| - templateExtra         | String  |    X     | Template additional information                                                                                                                                                                                                                                                     |
-| - templateAd            | String  |    X     | Request for consent of receiving within template or simple ad phrases                                                                                                                                                                                                               |
-| - tempalteTitle         | String  |    X     | Template title                                                                                                                                                                                                                                                                      |
-| - templateSubtitle      | String  |    X     | Template subtitle                                                                                                                                                                                                                                                                   |
-| - templateHeader        | String  |    X     | Template header (up to 16 characters)                                                                                                                                                                                                                                               |
-| - templateItem          | Object  |    X     | Item                                                                                                                                                                                                                                                                                |
-| -- list                 | List    |    X     | Item list (minimum 2, maximum 10)                                                                                                                                                                                                                                                   |
-| --- title               | String  |    X     | Title (up to 6 characters)                                                                                                                                                                                                                                                          |
-| --- description         | String  |    X     | Description (up to 23 characters)                                                                                                                                                                                                                                                   |
-| -- summary              | Object  |    X     | Item summary information                                                                                                                                                                                                                                                            |
-| --- title               | String  |    X     | Title (up to 6 characters)                                                                                                                                                                                                                                                          |
-| --- description         | String  |    X     | Description (only variables and monetary units, numbers, commas, and periods, up to 14 characters)                                                                                                                                                                                  |
-| - templateItemHighlight | Object  |    X     | Item highlight                                                                                                                                                                                                                                                                      |
-| -- title                | String  |    X     | Title (up to 30 characters; up to 21 characters if a thumbnail image is present)                                                                                                                                                                                                    |
-| -- description          | String  |    X     | Description (up to 19 characters; up to 13 characters if a thumbnail image is present)                                                                                                                                                                                              |
-| -- imageUrl             | String  |    X     | Thumbnail image URL                                                                                                                                                                                                                                                                 |
-| - templateRepresentLink | Object  |    X     | Representative link                                                                                                                                                                                                                                                                 |
-| -- linkMo               | String  |    X     | Mobile web link (up to 500 characters)                                                                                                                                                                                                                                              |
-| -- linkPc               | String  |    X     | PC web link (up to 500 characters)                                                                                                                                                                                                                                                  |
-| -- schemeIos            | String  |    X     | iOS app link (up to 500 characters)                                                                                                                                                                                                                                                 |
-| -- schemeAndroid        | String  |    X     | Android app link (up to 500 characters)                                                                                                                                                                                                                                             |
-| - templateImageName     | String  |    X     | Image name (uploaded file name)                                                                                                                                                                                                                                                     |
-| - templateImageUrl      | String  |    X     | Image URL                                                                                                                                                                                                                                                                           |
-| - buttons               | List    |    X     | Button list                                                                                                                                                                                                                                                                         |
-| -- ordering             | Integer |    X     | Button order (1 to 5)                                                                                                                                                                                                                                                               |
+| Name                    | Type    | Not Null | Description                                                                                                                                                                                                                  |
+|-------------------------|---------|:--------:|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| header                  | Object  |    O     | Header area                                                                                                                                                                                                                  |
+| - resultCode            | Integer |    O     | Result code                                                                                                                                                                                                                  |
+| - resultMessage         | String  |    O     | Result message                                                                                                                                                                                                               |
+| - isSuccessful          | Boolean |    O     | Success                                                                                                                                                                                                                      |
+| templates               | Object  |    X     | Template list                                                                                                                                                                                                                |
+| - plusFriendId          | String  |    O     | KakaoTalk Channel search ID or Sender Profile group name                                                                                                                                                                     |
+| - senderKey             | String  |    O     | Sender Key                                                                                                                                                                                                                   |
+| - plusFriendType        | String  |    O     | PlusFriend type (NORMAL, GROUP)                                                                                                                                                                                              |
+| - templateCode          | String  |    O     | Template Code                                                                                                                                                                                                                |
+| - kakaoTemplateCode     | String  |    O     | Original template code                                                                                                                                                                                                       |
+| - templateName          | String  |    O     | Template name                                                                                                                                                                                                                |
+| - templateMessageType   | String  |    X     | Types of template message (BA: Basic, EX: Extra Information, AD: Ad Included, MI: Mixed Purposes)                                                                                                                            |
+| - templateEmphasizeType | String  |    X     | Types of emphasized template (NONE: Basic, TEXT: Emphasized, IMAGE: Image type, ITEM_LIST: Item List type)                                                                                                                   |
+| - templateContent       | String  |    X     | Template body                                                                                                                                                                                                                |
+| - templateExtra         | String  |    X     | Template extra information                                                                                                                                                                                                   |
+| - templateAd            | String  |    X     | Request for consent of receiving within template or simple ad phrases                                                                                                                                                        |
+| - tempalteTitle         | String  |    X     | Template title                                                                                                                                                                                                               |
+| - templateSubtitle      | String  |    X     | Template subtitle                                                                                                                                                                                                            |
+| - templateHeader        | String  |    X     | Template header (up to 16 characters)                                                                                                                                                                                        |
+| - templateItem          | Object  |    X     | Item                                                                                                                                                                                                                         |
+| -- list                 | List    |    X     | Item list (minimum 2, maximum 10)                                                                                                                                                                                            |
+| --- title               | String  |    X     | Title (up to 6 characters)                                                                                                                                                                                                   |
+| --- description         | String  |    X     | Description (up to 23 characters)                                                                                                                                                                                            |
+| -- summary              | Object  |    X     | Item summary information                                                                                                                                                                                                     |
+| --- title               | String  |    X     | Title (up to 6 characters)                                                                                                                                                                                                   |
+| --- description         | String  |    X     | Description (Only variables and monetary units, numbers, commas, and periods, up to 14 characters)                                                                                                                           |
+| - templateItemHighlight | Object  |    X     | Item highlight                                                                                                                                                                                                               |
+| -- title                | String  |    X     | Title (up to 30 characters, up to 21 characters if a thumbnail image is present)                                                                                                                                             |
+| -- description          | String  |    X     | Description (up to 19 characters, up to 13 characters if a thumbnail image is present)                                                                                                                                       |
+| -- imageUrl             | String  |    X     | Thumbnail image URL                                                                                                                                                                                                          |
+| - templateRepresentLink | Object  |    X     | Representative link                                                                                                                                                                                                          |
+| -- linkMo               | String  |    X     | Mobile web link (up to 500 characters)                                                                                                                                                                                       |
+| -- linkPc               | String  |    X     | PC web link (up to 500 characters)                                                                                                                                                                                           |
+| -- schemeIos            | String  |    X     | iOS app link (up to 500 characters)                                                                                                                                                                                          |
+| -- schemeAndroid        | String  |    X     | Android app link (up to 500 characters)                                                                                                                                                                                      |
+| - templateImageName     | String  |    X     | Image name (uploaded file name)                                                                                                                                                                                              |
+| - templateImageUrl      | String  |    X     | Image URL                                                                                                                                                                                                                    |
+| - buttons               | List    |    X     | Button list                                                                                                                                                                                                                  |
+| -- ordering             | Integer |    X     | Button order (1–5)                                                                                                                                                                                                           |
 | -- type                 | String  |    X     | Button type (WL: Web link, AL: App link, DS: Delivery search, BK: Bot keyword, MD: Message delivery, BC: Bot for Consultation, BT: Bot Transfer, AC: Add channel, BF: Business form, P1: Image secure transmission plugin ID, P2: Personal information use plugin ID, P3: One-click payment plugin ID, TN: Call) |
-| -- name                 | String  |    X     | Button name                                                                                                                                                                                                                                                                         |
-| -- linkMo               | String  |    X     | Mobile web link (required for the WL type)                                                                                                                                                        |
-| -- linkPc               | String  |    X     | PC web link (optional for the WL type)                                                                                                                                                         |
-| -- schemeIos            | String  |    X     | iOS app link (required for the AL type)                                                                                                                                                        |
-| -- schemeAndroid        | String  |    X     | Android app link (required for the AL type)                                                                                                                                                      |
-| -- bizFormId            | Integer |    X     | Business form ID (required for the BF type)                                                                                                                                                           |
-| -- pluginId             | String  |    X     | Plugin ID (up to 24 characters)                                                                                                                                                                  |
-| -- telNumber            | 	String  | 	X  | Phone number to send for TN (Call) type buttons                                                                                                                                                       |
-| - quickReplies          | List    |    X     | Quick reply list (up to 5 items)                                                                                                                                                                  |
-| -- ordering             | Integer |    X     | Quick reply order (required when quick reply exists)                                                                                                                                                          |
-| -- type                 | String  |    X     | Quick reply type (WL: Web link, AL: App link, BK: Bot keyword, BC: Bot for Consultation, BT: Bot Transfer, BF: Business form)                                                                                                          |
-| -- name                 | String  |    X     | Quick reply name (required when quick reply exists, up to 14 characters)                                                                                                                                                  |
-| -- linkMo               | String  |    X     | Mobile web link (required for the WL type, for up to 500 characters)                                                                                                                                               |
-| -- linkPc               | String  |    X     | PC web link (optional for the WL type, for up to 500 characters)                                                                                                                                                |
-| -- schemeIos            | String  |    X     | iOS app link (required for the AL type, for up to 500 characters)                                                                                                                                               |
-| -- schemeAndroid        | String  |    X     | Android app link (required for the AL type, for up to 500 characters)                                                                                                                                             |
-| -- bizFormId            | Integer |    X     | Business form ID (required for the BF type)                                                                                                                                                           |
-| - comments              | List    |    X     | Review result                                                                                                                                                                            |
-| -- id                   | Integer |    X     | Inquiry ID                                                                                                                                                                           |
-| -- content              | String  |    X     | Inquiry content                                                                                                                                                                            |
-| -- userName             | String  |    X     | Author                                                                                                                                                                              |
-| -- createAt             | String  |    O     | Registration date                                                                                                                                                                            |
-| -- attachment           | List    |    X     | Attachment                                                                                                                                                                    |
-| --- originalFileName    | String  |    X     | Attachment file name                                                                                                                                                                           |
-| --- filePath            | String  |    X     | Attachment file path                                                                                                                                                                         |
-| -- status               | String  |    X     | Comment status (INQ: Inquired, APR: Approved, REJ: Rejected, REP: Replied, REQ: Under Review)                                                                                                                             |
-| - status                | String  |    O     | Template Status                                                                                                                                                                           |
-| - statusName            | String  |    X     | Template status name                                                                                                                                                                          |
-| - securityFlag          | Boolean |    X     | Whether the template is a security template                                                                                                                                                        |
-| - categoryCode          | String  |    X     | Template category code                                                                                                                                                                      |
-| - block                 | Boolean |    X     | Whether blocked                                                                                                                                                                            |
-| - dormant               | Boolean |    X     | Whether dormant                                                                                                                                                                            |
-| - createDate            | String  |    O     | Creation date                                                                                                                                                                             |
-| - updateDate            | String  |    X     | Modification date                                                                                                                                                                             |
+| -- name                 | String  |    X     | Button name                                                                                                                                                                                                                  |
+| -- linkMo               | String  |    X     | Mobile web link (required for the WL type)                                                                                                                                      |
+| -- linkPc               | String  |    X     | PC web link (optional for the WL type)                                                                                                                                          |
+| -- schemeIos            | String  |    X     | iOS app link (required for the AL type)                                                                                                                                         |
+| -- schemeAndroid        | String  |    X     | Android app link (required for the AL type)                                                                                                                                     |
+| -- bizFormId            | Integer |    X     | Business form ID (required for the BF type)                                                                                                                                     |
+| -- pluginId             | String  |    X     | Plugin ID (up to 24 characters)                                                                                                                                                 |
+| -- telNumber            | 	String  | 	X  | Phone number to send for TN (Call) type buttons                                                                                                                                 |
+| - quickReplies          | List    |    X     | Quick reply list (up to 5)                                                                                                                                                      |
+| -- ordering             | Integer |    X     | Quick reply order (required when quick reply exists)                                                                                                                            |
+| -- type                 | String  |    X     | Quick reply type (WL: Web link, AL: App link, BK: Bot keyword, BC: Bot for Consultation, BT: Bot Transfer, BF: Business form)                                                   |
+| -- name                 | String  |    X     | Quick reply name (required when quick reply exists, up to 14 characters)                                                                                                        |
+| -- linkMo               | String  |    X     | Mobile web link (required for the WL type, for up to 500 characters)                                                                                                           |
+| -- linkPc               | String  |    X     | PC web link (required for the WL type, for up to 500 characters)                                                                                                               |
+| -- schemeIos            | String  |    X     | iOS app link (required for the AL type, for up to 500 characters)                                                                                                              |
+| -- schemeAndroid        | String  |    X     | Android app link (required for the AL type, for up to 500 characters)                                                                                                          |
+| -- bizFormId            | Integer |    X     | Business form ID (required for the BF type)                                                                                                                                     |
+| - comments              | List    |    X     | Inspection results                                                                                                                                                              |
+| -- id                   | Integer |    X     | Inquiry ID                                                                                                                                                                      |
+| -- content              | String  |    X     | Inquiry content                                                                                                                                                                 |
+| -- userName             | String  |    X     | Author                                                                                                                                                                          |
+| -- createAt             | String  |    O     | Registration date                                                                                                                                                               |
+| -- attachment           | List    |    X     | Attached files                                                                                                                                                                  |
+| --- originalFileName    | String  |    X     | Attachment file name                                                                                                                                                            |
+| --- filePath            | String  |    X     | Attachment file path                                                                                                                                                            |
+| -- status               | String  |    X     | Comment status (INQ: Inquired, APR: Approved, REJ: Rejected, REP: Replied, REQ: Under Review)                                                                                   |
+| - status                | String  |    O     | Template status                                                                                                                                                                 |
+| - statusName            | String  |    X     | Template status name                                                                                                                                                            |
+| - securityFlag          | Boolean |    X     | Whether it is a security template                                                                                                                                               |
+| - categoryCode          | String  |    X     | Template category code                                                                                                                                                          |
+| - block                 | Boolean |    X     | Whether blocked                                                                                                                                                                 |
+| - dormant               | Boolean |    X     | Whether dormant                                                                                                                                                                 |
+| - createDate            | String  |    O     | Creation date                                                                                                                                                                   |
+| - updateDate            | String  |    X     | Modification date                                                                                                                                                               |
 
 <a id="list-templates"></a>
 
@@ -2622,10 +2622,10 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name        | 	Type     | 	Description     |
-|-----------|---------|---------|
-| appkey    | 	String | 	Unique appkey |
-| senderKey | 	String | 	Sender Key   |
+| Name      | 	Type   | 	Description  |
+|-----------|---------|---------------|
+| appkey    | 	String | 	Unique app key |
+| senderKey | 	String | 	Sender key    |
 
 [Header]
 
@@ -2635,26 +2635,26 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name           | 	Type     | 	Required | 	Description              |
-|--------------|---------|-----|------------------|
-| X-Secret-Key | 	String | O   | Can be created in the console. |
+| Name         | 	Type   | 	Required | 	Description                       |
+|--------------|---------|-----------|-------------------------------------|
+| X-Secret-Key | 	String | O         | Can be created in the console. |
 
 [Query parameter]
 
-| Name             | 	Type      | 	Required | 	Description                            |
-|----------------|----------|-----|--------------------------------|
-| templateCode   | 	String  | 	X  | 	Template Code                        |
-| templateName   | 	String  | 	X  | 	Template name                        |
-| templateStatus | String   | 	X  | Template status code                      |
-| pageNum        | 	Integer | 	X  | 	Page number (Default: 1)            |
-| pageSize       | 	Integer | 	X  | 	Number of records to retrieve (Default: 15, Max: 1,000) |
+| Name           | 	Type    | 	Required | 	Description                            |
+|----------------|----------|-----------|------------------------------------------|
+| templateCode   | 	String  | 	X        | 	Template Code                          |
+| templateName   | 	String  | 	X        | 	Template name                          |
+| templateStatus | String   | 	X        | Template status code                    |
+| pageNum        | 	Integer | 	X        | 	Page number (Default: 1)               |
+| pageSize       | 	Integer | 	X        | 	Number of records to retrieve (Default: 15, Max: 1,000) |
 
-| Template status code | Description   |
-|-----------|------|
-| TSC01     | Requested   |
-| TSC02     | Reviewing |
-| TSC03     | Approved   |
-| TSC04     | Rejected   |
+| Template Status Code | Description  |
+|----------------------|--------------|
+| TSC01                | Requested    |
+| TSC02                | Reviewing    |
+| TSC03                | Approved     |
+| TSC04                | Rejected     |
 
 [Example]
 
@@ -2766,82 +2766,82 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 }
 ```
 
-| Name                     | Type    | Not Null | Description                                                                                                                                                                                                                                       |
-|--------------------------|---------|:--------:|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| header                   | Object  |    O     | Header area                                                                                                                                                                                                                                       |
-| - resultCode             | Integer |    O     | Result code                                                                                                                                                                                                                                       |
-| - resultMessage          | String  |    O     | Result message                                                                                                                                                                                                                                    |
-| - isSuccessful           | Boolean |    O     | Success                                                                                                                                                                                                                                           |
-| templateListResponse     | Object  |    X     | Body area                                                                                                                                                                                                                                         |
-| - templates              | List    |    X     | Template list                                                                                                                                                                                                                                     |
-| -- plusFriendId          | String  |    O     | KakaoTalk Channel search ID or Sender Profile group name                                                                                                                                                                                          |
-| -- senderKey             | String  |    O     | Sender Key                                                                                                                                                                                                                                        |
-| -- plusFriendType        | String  |    O     | PlusFriend type (NORMAL, GROUP)                                                                                                                                                                                                                   |
-| -- templateCode          | String  |    O     | Template Code                                                                                                                                                                                                                                     |
-| -- kakaoTemplateCode     | String  |    O     | Original template code                                                                                                                                                                                                                            |
-| -- templateName          | String  |    O     | Template name                                                                                                                                                                                                                                     |
-| -- templateMessageType   | String  |    X     | Types of template message (BA: Basic, EX: Extra Information, AD: Ad Included, MI: Mixed Purposes, default: Basic)                                                                                                                                 |
-| -- templateEmphasizeType | String  |    X     | Template emphasis display type (NONE: Default, TEXT: Emphasis, IMAGE: Image type, ITEM_LIST: Item List type)                                                                                                                                      |
-| -- templateContent       | String  |    X     | Template body                                                                                                                                                                                                                                     |
-| -- templateExtra         | String  |    X     | Template additional information                                                                                                                                                                                                                   |
-| -- templateAd            | String  |    X     | Consent to receive request or simple advertisement text within the template                                                                                                                                                                       |
-| -- tempalteTitle         | String  |    X     | Template title                                                                                                                                                                                                                                    |
-| -- templateSubtitle      | String  |    X     | Template subtitle                                                                                                                                                                                                                                 |
-| - templateHeader         | String  |    X     | Template header (up to 16 characters)                                                                                                                                                                                                             |
-| - templateItem           | Object  |    X     | Item                                                                                                                                                                                                                                              |
-| -- list                  | List    |    X     | Item list (minimum 2, maximum 10)                                                                                                                                                                                                                 |
-| --- title                | String  |    X     | Title (up to 6 characters)                                                                                                                                                                                                                        |
-| --- description          | String  |    X     | Description (up to 23 characters)                                                                                                                                                                                                                 |
-| -- summary               | Object  |    X     | Item summary information                                                                                                                                                                                                                          |
-| --- title                | String  |    X     | Title (up to 6 characters)                                                                                                                                                                                                                        |
-| --- description          | String  |    X     | Description (Only variables and monetary units, numbers, commas, and periods, up to 14 characters)                                                                                                                                                |
-| - templateItemHighlight  | Object  |    X     | Item highlight                                                                                                                                                                                                                                    |
-| -- title                 | String  |    X     | Title (up to 30 characters; up to 21 characters if a thumbnail image is present)                                                                                                                                                                  |
-| -- description           | String  |    X     | Description (up to 19 characters; up to 13 characters if a thumbnail image is present)                                                                                                                                                            |
-| -- imageUrl              | String  |    X     | Thumbnail image URL                                                                                                                                                                                                                               |
-| - templateRepresentLink  | Object  |    X     | Representative link                                                                                                                                                                                                                               |
-| -- linkMo                | String  |    X     | Mobile web link (up to 500 characters)                                                                                                                                                                                                            |
-| -- linkPc                | String  |    X     | PC web link (up to 500 characters)                                                                                                                                                                                                                |
-| -- schemeIos             | String  |    X     | iOS app link (up to 500 characters)                                                                                                                                                                                                               |
-| -- schemeAndroid         | String  |    X     | Android app link (up to 500 characters)                                                                                                                                                                                                           |
-| -- templateImageName     | String  |    X     | Image name (uploaded file name)                                                                                                                                                                                                                   |
-| -- templateImageUrl      | String  |    X     | Image URL                                                                                                                                                                                                                                         |
-| -- buttons               | List    |    X     | Button list                                                                                                                                                                                                                                       |
-| --- ordering             | Integer |    X     | Button order (1 to 5)                                                                                                                                                                                                                             |
+| Name                     | Type    | Not Null | Description                                                                                                                                                                     |
+|--------------------------|---------|:--------:|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| header                   | Object  |    O     | Header area                                                                                                                                                                  |
+| - resultCode             | Integer |    O     | Result code                                                                                                                                                                  |
+| - resultMessage          | String  |    O     | Result message                                                                                                                                                                 |
+| - isSuccessful           | Boolean |    O     | Success                                                                                                                                                                  |
+| templateListResponse     | Object  |    X     | Body area                                                                                                                                                                  |
+| - templates              | List    |    X     | Template list                                                                                                                                                                |
+| -- plusFriendId          | String  |    O     | KakaoTalk Channel search ID or Sender Profile group name                                                                                                                                           |
+| -- senderKey             | String  |    O     | Sender Key                                                                                                                                                                   |
+| -- plusFriendType        | String  |    O     | Sender Profile type (NORMAL, GROUP)                                                                                                                                                |
+| -- templateCode          | String  |    O     | Template Code                                                                                                                                                                 |
+| -- kakaoTemplateCode     | String  |    O     | Original template code                                                                                                                                                              |
+| -- templateName          | String  |    O     | Template name                                                                                                                                                                   |
+| -- templateMessageType   | String  |    X     | Types of template message (BA: Basic, EX: Extra Information, AD: Ad Included, MI: Mixed Purposes)                                                                                                                   |
+| -- templateEmphasizeType | String  |    X     | Template emphasis type (NONE: Default, TEXT: Emphasis, IMAGE: Image Type, ITEM_LIST: Item List Type)                                                                                                   |
+| -- templateContent       | String  |    X     | Template body                                                                                                                                                                 |
+| -- templateExtra         | String  |    X     | Template extra information                                                                                                                                                              |
+| -- templateAd            | String  |    X     | Request for consent to receive messages or simple ad phrases within the template                                                                                                                                            |
+| -- tempalteTitle         | String  |    X     | Template title                                                                                                                                                                 |
+| -- templateSubtitle      | String  |    X     | Template subtitle                                                                                                                                                              |
+| - templateHeader         | String  |    X     | Template header (up to 16 characters)                                                                                                                                                         |
+| - templateItem           | Object  |    X     | Item                                                                                                                                                                    |
+| -- list                  | List    |    X     | Item list (minimum 2, maximum 10)                                                                                                                                                 |
+| --- title                | String  |    X     | Title (up to 6 characters)                                                                                                                                                             |
+| --- description          | String  |    X     | Description (up to 23 characters)                                                                                                                                                          |
+| -- summary               | Object  |    X     | Item summary information                                                                                                                                                              |
+| --- title                | String  |    X     | Title (up to 6 characters)                                                                                                                                                             |
+| --- description          | String  |    X     | Description (only variables and monetary units, numbers, commas, and periods, up to 14 characters)                                                                                                                          |
+| - templateItemHighlight  | Object  |    X     | Item highlight                                                                                                                                                              |
+| -- title                 | String  |    X     | Title (up to 30 characters, up to 21 characters if a thumbnail image is present)                                                                                                                                        |
+| -- description           | String  |    X     | Description (up to 19 characters, up to 13 characters if a thumbnail image is present)                                                                                                                                      |
+| -- imageUrl              | String  |    X     | Thumbnail image URL                                                                                                                                                             |
+| - templateRepresentLink  | Object  |    X     | Representative link                                                                                                                                                                  |
+| -- linkMo                | String  |    X     | Mobile web link (up to 500 characters)                                                                                                                                                      |
+| -- linkPc                | String  |    X     | PC web link (up to 500 characters)                                                                                                                                                       |
+| -- schemeIos             | String  |    X     | iOS app link (up to 500 characters)                                                                                                                                                      |
+| -- schemeAndroid         | String  |    X     | Android app link (up to 500 characters)                                                                                                                                                    |
+| -- templateImageName     | String  |    X     | Image name (uploaded file name)                                                                                                                                                         |
+| -- templateImageUrl      | String  |    X     | Image URL                                                                                                                                                                |
+| -- buttons               | List    |    X     | Button list                                                                                                                                                                 |
+| --- ordering             | Integer |    X     | Button order (1–5)                                                                                                                                                             |
 | --- type                 | String  |    X     | Button type (WL: Web link, AL: App link, DS: Delivery search, BK: Bot keyword, MD: Message delivery, BC: Bot for Consultation, BT: Bot Transfer, AC: Add channel, BF: Business form, P1: Image secure transmission plugin ID, P2: Personal information use plugin ID, P3: One-click payment plugin ID, TN: Call) |
-| --- name                 | String  |    X     | Button name                                                                                                                                                                                                                                       |
-| --- linkMo               | String  |    X     | Mobile web link (required for the WL type)                                                                                                                                                                                                        |
-| --- linkPc               | String  |    X     | PC web link (optional for the WL type)                                                                                                                                               |
-| --- schemeIos            | String  |    X     | iOS app link (required for the AL type)                                                                                                                                              |
-| --- schemeAndroid        | String  |    X     | Android app link (required for the AL type)                                                                                                                                            |
-| --- bizFormId            | Integer |    X     | Business form ID (required for the BF type)                                                                                                                                                 |
-| --- pluginId             | String  |    X     | Plugin ID (up to 24 characters)                                                                                                                                                        |
-| --- telNumber            | 	String  | 	X  | Phone number to send for TN (call) type buttons                                                                                                    |
-| -- quickReplies          | List    |    X     | Quick reply list (up to 5)                                                                                                                                                        |
-| --- ordering             | Integer |    X     | Quick reply order (required when quick reply exists)                                                                                                                                                |
-| --- type                 | String  |    X     | Quick reply type (WL: Web link, AL: App link, BK: Bot keyword, BC: Bot for Consultation, BT: Bot Transfer, BF: Business form)                                                                                                |
-| --- name                 | String  |    X     | Quick reply name (required when quick reply exists, up to 14 characters)                                                                                                                                        |
-| --- linkMo               | String  |    X     | Mobile web link (required for the WL type, for up to 500 characters)                                                                                                                                     |
-| --- linkPc               | String  |    X     | PC web link (required for the WL type, for up to 500 characters)                                                                                                                                      |
-| --- schemeIos            | String  |    X     | iOS app link (required for the AL type, for up to 500 characters)                                                                                                                                     |
-| --- schemeAndroid        | String  |    X     | Android app link (required for the AL type, for up to 500 characters)                                                                                                                                   |
-| --- bizFormId            | Integer |    X     | Business form ID (required for the BF type)                                                                                                                                                 |
-| -- comments              | List    |    X     | Inspection results                                                                                                                                                                  |
+| --- name                 | String  |    X     | Button name                                                                                                                                                                  |
+| --- linkMo               | String  |    X     | Mobile web link (required for the WL type)                                                                                                                                              |
+| --- linkPc               | String  |    X     | PC web link (optional field for the WL type)                                                                                                                               |
+| --- schemeIos            | String  |    X     | iOS app link (required for the AL type)                                                                                                                                    |
+| --- schemeAndroid        | String  |    X     | Android app link (required for the AL type)                                                                                                                                |
+| --- bizFormId            | Integer |    X     | Business form ID (required for the BF type)                                                                                                                                |
+| --- pluginId             | String  |    X     | Plugin ID (up to 24 characters)                                                                                                                                            |
+| --- telNumber            | 	String  | 	X  | Phone number to send for TN (Call) type buttons                                                                                                                            |
+| -- quickReplies          | List    |    X     | Quick reply list (up to 5)                                                                                                                                                 |
+| --- ordering             | Integer |    X     | Quick reply order (required when quick reply exists)                                                                                                                       |
+| --- type                 | String  |    X     | Quick reply type (WL: Web link, AL: App link, BK: Bot keyword, BC: Bot for Consultation, BT: Bot Transfer, BF: Business form)                                              |
+| --- name                 | String  |    X     | Quick reply name (required when quick reply exists, up to 14 characters)                                                                                                   |
+| --- linkMo               | String  |    X     | Mobile web link (required for the WL type, for up to 500 characters)                                                                                                      |
+| --- linkPc               | String  |    X     | PC web link (required for the WL type, for up to 500 characters)                                                                                                          |
+| --- schemeIos            | String  |    X     | iOS app link (required for the AL type, for up to 500 characters)                                                                                                         |
+| --- schemeAndroid        | String  |    X     | Android app link (required for the AL type, for up to 500 characters)                                                                                                     |
+| --- bizFormId            | Integer |    X     | Business form ID (required for the BF type)                                                                                                                                |
+| -- comments              | List    |    X     | Review results                                                                                                                                                             |
 | --- id                   | Integer |    X     | Inquiry ID                                                                                                                                                                 |
-| --- content              | String  |    X     | Inquiry content                                                                                                                                                                  |
-| --- userName             | String  |    X     | Author                                                                                                                                                                    |
-| --- createAt             | String  |    O     | Registration date                                                                                                                                                                  |
-| --- attachment           | List    |    X     | Attachments                                                                                                                                                                  |
-| ---- originalFileName    | String  |    X     | Attachment file name                                                                                                                                                                 |
-| ---- filePath            | String  |    X     | Attachment file path                                                                                                                                                               |
-| --- status               | String  |    X     | Comment status (INQ: Inquired, APR: Approved, REJ: Rejected, REP: Replied, REQ: Under Review)                                                                                                                   |
-| -- status                | String  |    O     | Template status                                                                                                                                                                 |
-| -- statusName            | String  |    X     | Template status name                                                                                                                                                                |
-| -- securityFlag          | Boolean |    X     | Whether the template is a security template                                                                                                                                              |
-| -- categoryCode          | String  |    X     | Template category code                                                                                                                                                            |
-| -- createDate            | String  |    O     | Creation date                                                                                                                                                                   |
-| -- updateDate            | String  |    X     | Modification date                                                                                                                                                                   |
-| - totalCount             | Integer |    X     | Total count                                                                                                                                                                    |
+| --- content              | String  |    X     | Inquiry content                                                                                                                                                            |
+| --- userName             | String  |    X     | Author                                                                                                                                                                     |
+| --- createAt             | String  |    O     | Registration date                                                                                                                                                          |
+| --- attachment           | List    |    X     | Attachments                                                                                                                                                                |
+| ---- originalFileName    | String  |    X     | Attachment file name                                                                                                                                                       |
+| ---- filePath            | String  |    X     | Attachment file path                                                                                                                                                       |
+| --- status               | String  |    X     | Comment status (INQ: Inquired, APR: Approved, REJ: Rejected, REP: Replied, REQ: Under Review)                                                                              |
+| -- status                | String  |    O     | Template status                                                                                                                                                            |
+| -- statusName            | String  |    X     | Template status name                                                                                                                                                       |
+| -- securityFlag          | Boolean |    X     | Whether it is a security template                                                                                                                                          |
+| -- categoryCode          | String  |    X     | Template category code                                                                                                                                                     |
+| -- createDate            | String  |    O     | Created date                                                                                                                                                               |
+| -- updateDate            | String  |    X     | Modified date                                                                                                                                                              |
+| - totalCount             | Integer |    X     | Total count                                                                                                                                                                |
 
 <a id="list-template-modifications"></a>
 
@@ -2860,11 +2860,11 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name         | 	Type   | 	Description      |
-|--------------|---------|-------------------|
-| appkey       | 	String | 	Unique app key   |
-| senderKey    | 	String | 	Sender Key       |
-| templateCode | 	String | 	Template Code    |
+| Name         | 	Type   | 	Description    |
+|--------------|---------|-----------------|
+| appkey       | 	String | 	Unique app key |
+| senderKey    | 	String | 	Sender Key     |
+| templateCode | 	String | 	Template Code  |
 
 [Header]
 
@@ -2874,8 +2874,8 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name         | 	Type   | 	Required | 	Description                          |
-|--------------|---------|-----------|---------------------------------------|
+| Name         | 	Type   | 	Required | 	Description                         |
+|--------------|---------|-----------|--------------------------------------|
 | X-Secret-Key | 	String | O         | Can be created in the console. |
 
 [Example]
@@ -2986,54 +2986,54 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 }
 ```
 
-| Name                          | Type    | Not Null | Description                                                                                                                                                                                                                                      |
-|-------------------------------|---------|:--------:|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| header                        | Object  |    O     | Header area                                                                                                                                                                                                                                      |
-| - resultCode                  | Integer |    O     | Result code                                                                                                                                                                                                                                      |
-| - resultMessage               | String  |    O     | Result message                                                                                                                                                                                                                                   |
-| - isSuccessful                | Boolean |    O     | Success                                                                                                                                                                                                                                          |
-| templateModificationsResponse | Object  |    X     | Body area                                                                                                                                                                                                                                        |
-| - templates                   | List    |    X     | Template list                                                                                                                                                                                                                                    |
-| -- plusFriendId               | String  |    O     | KakaoTalk Channel search ID or Sender Profile group name                                                                                                                                                                                         |
-| -- senderKey                  | String  |    O     | Sender Key                                                                                                                                                                                                                                       |
-| -- plusFriendType             | String  |    O     | PlusFriend type (NORMAL, GROUP)                                                                                                                                                                                                                  |
-| -- templateCode               | String  |    O     | Template Code                                                                                                                                                                                                                                    |
-| -- templateName               | String  |    O     | Template name                                                                                                                                                                                                                                    |
-| -- templateMessageType        | String  |    X     | Types of template message (BA: Basic, EX: Extra Information, AD: Ad Included, MI: Mixed Purposes, default: Basic)                                                                                                                                |
-| -- templateEmphasizeType      | String  |    X     | Template emphasis display type (NONE: Default, TEXT: Emphasis, IMAGE: Image type, )                                                                                                                                                              |
-| -- templateContent            | String  |    O     | Template body                                                                                                                                                                                                                                    |
-| -- templateExtra              | String  |    X     | Template extra information                                                                                                                                                                                                                       |
-| -- templateAd                 | String  |    X     | Consent to receive request or simple advertising copy in the template                                                                                                                                                                            |
-| -- tempalteTitle              | String  |    X     | Template title                                                                                                                                                                                                                                   |
-| -- templateSubtitle           | String  |    X     | Template subtitle                                                                                                                                                                                                                                |
-| - templateHeader              | String  |    X     | Template header (up to 16 characters)                                                                                                                                                                                                            |
-| - templateItem                | Object  |    X     | Item                                                                                                                                                                                                                                             |
-| -- list                       | List    |    X     | Item list (minimum 2, maximum 10)                                                                                                                                                                                                                |
-| --- title                     | String  |    X     | Title (up to 6 characters)                                                                                                                                                                                                                       |
-| --- description               | String  |    X     | Description (up to 23 characters)                                                                                                                                                                                                                |
-| -- summary                    | Object  |    X     | Item summary information                                                                                                                                                                                                                         |
-| --- title                     | String  |    X     | Title (up to 6 characters)                                                                                                                                                                                                                       |
-| --- description               | String  |    X     | Description (Only variables and monetary units, numbers, commas, and periods, up to 14 characters)                                                                                                                                               |
-| - templateItemHighlight       | Object  |    X     | Item highlight                                                                                                                                                                                                                                   |
-| -- title                      | String  |    X     | Title (up to 30 characters; up to 21 characters if a thumbnail image is present)                                                                                                                                                                 |
-| -- description                | String  |    X     | Description (up to 19 characters; up to 13 characters if a thumbnail image is present)                                                                                                                                                           |
-| -- imageUrl                   | String  |    X     | Thumbnail image URL                                                                                                                                                                                                                              |
-| - templateRepresentLink       | Object  |    X     | Representative link                                                                                                                                                                                                                              |
-| -- linkMo                     | String  |    X     | Mobile web link (up to 500 characters)                                                                                                                                                                                                           |
-| -- linkPc                     | String  |    X     | PC web link (up to 500 characters)                                                                                                                                                                                                               |
-| -- schemeIos                  | String  |    X     | iOS app link (up to 500 characters)                                                                                                                                                                                                              |
-| -- schemeAndroid              | String  |    X     | Android app link (up to 500 characters)                                                                                                                                                                                                          |
-| -- templateImageName          | String  |    X     | Image name (uploaded file name)                                                                                                                                                                                                                  |
-| -- templateImageUrl           | String  |    X     | Image URL                                                                                                                                                                                                                                        |
-| -- buttons                    | List    |    X     | Button list                                                                                                                                                                                                                                      |
-| --- ordering                  | Integer |    X     | Button order (1 to 5)                                                                                                                                                                                                                            |
+| Name                          | Type    | Not Null | Description                                                                                                                                                                                                                                  |
+|-------------------------------|---------|:--------:|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| header                        | Object  |    O     | Header area                                                                                                                                                                                                                                  |
+| - resultCode                  | Integer |    O     | Result code                                                                                                                                                                                                                                  |
+| - resultMessage               | String  |    O     | Result message                                                                                                                                                                                                                               |
+| - isSuccessful                | Boolean |    O     | Success                                                                                                                                                                                                                                      |
+| templateModificationsResponse | Object  |    X     | Body area                                                                                                                                                                                                                                    |
+| - templates                   | List    |    X     | Template list                                                                                                                                                                                                                                |
+| -- plusFriendId               | String  |    O     | KakaoTalk Channel search ID or Sender Profile group name                                                                                                                                                                                     |
+| -- senderKey                  | String  |    O     | Sender Key                                                                                                                                                                                                                                   |
+| -- plusFriendType             | String  |    O     | Sender Profile type (NORMAL, GROUP)                                                                                                                                                                                                          |
+| -- templateCode               | String  |    O     | Template Code                                                                                                                                                                                                                                |
+| -- templateName               | String  |    O     | Template name                                                                                                                                                                                                                                |
+| -- templateMessageType        | String  |    X     | Types of template message (BA: Basic, EX: Extra Information, AD: Ad Included, MI: Mixed Purposes, default: Basic)                                                                                                                            |
+| -- templateEmphasizeType      | String  |    X     | Template emphasis type (NONE: Default, TEXT: Emphasis Type, IMAGE: Image Type)                                                                                                                                                               |
+| -- templateContent            | String  |    O     | Template body                                                                                                                                                                                                                                |
+| -- templateExtra              | String  |    X     | Template additional information                                                                                                                                                                                                              |
+| -- templateAd                 | String  |    X     | Request for consent to receive messages or simple ad phrases within the template                                                                                                                                                             |
+| -- tempalteTitle              | String  |    X     | Template title                                                                                                                                                                                                                               |
+| -- templateSubtitle           | String  |    X     | Template auxiliary phrase                                                                                                                                                                                                                    |
+| - templateHeader              | String  |    X     | Template header (up to 16 characters)                                                                                                                                                                                                        |
+| - templateItem                | Object  |    X     | Item                                                                                                                                                                                                                                         |
+| -- list                       | List    |    X     | Item list (minimum 2, maximum 10)                                                                                                                                                                                                            |
+| --- title                     | String  |    X     | Title (up to 6 characters)                                                                                                                                                                                                                   |
+| --- description               | String  |    X     | Description (up to 23 characters)                                                                                                                                                                                                            |
+| -- summary                    | Object  |    X     | Item summary information                                                                                                                                                                                                                     |
+| --- title                     | String  |    X     | Title (up to 6 characters)                                                                                                                                                                                                                   |
+| --- description               | String  |    X     | Description (Only variables and monetary units, numbers, commas, and periods, up to 14 characters)                                                                                                                                           |
+| - templateItemHighlight       | Object  |    X     | Item highlight                                                                                                                                                                                                                               |
+| -- title                      | String  |    X     | Title (up to 30 characters; up to 21 characters if a thumbnail image is present)                                                                                                                                                             |
+| -- description                | String  |    X     | Description (up to 19 characters; up to 13 characters if a thumbnail image is present)                                                                                                                                                       |
+| -- imageUrl                   | String  |    X     | Thumbnail image URL                                                                                                                                                                                                                          |
+| - templateRepresentLink       | Object  |    X     | Representative link                                                                                                                                                                                                                          |
+| -- linkMo                     | String  |    X     | Mobile web link (up to 500 characters)                                                                                                                                                                                                       |
+| -- linkPc                     | String  |    X     | PC web link (up to 500 characters)                                                                                                                                                                                                           |
+| -- schemeIos                  | String  |    X     | iOS app link (up to 500 characters)                                                                                                                                                                                                          |
+| -- schemeAndroid              | String  |    X     | Android app link (up to 500 characters)                                                                                                                                                                                                      |
+| -- templateImageName          | String  |    X     | Image name (uploaded file name)                                                                                                                                                                                                              |
+| -- templateImageUrl           | String  |    X     | Image URL                                                                                                                                                                                                                                    |
+| -- buttons                    | List    |    X     | Button list                                                                                                                                                                                                                                  |
+| --- ordering                  | Integer |    X     | Button order (1–5)                                                                                                                                                                                                                           |
 | --- type                      | String  |    X     | Button type (WL: Web link, AL: App link, DS: Delivery search, BK: Bot keyword, MD: Message delivery, BC: Bot for Consultation, BT: Bot Transfer, AC: Add channel, BF: Business form, P1: Image secure transmission plugin ID, P2: Personal information use plugin ID, P3: One-click payment plugin ID, TN: Call) |
-| --- name                      | String  |    X     | Button name                                                                                                                                                                                                                                      |
-| --- linkMo                    | String  |    X     | Mobile web link (required for the WL type)                                                                                                                                                                                                       |
+| --- name                      | String  |    X     | Button name                                                                                                                                                                                                                                  |
+| --- linkMo                    | String  |    X     | Mobile web link (required for the WL type)                                                                                                                                                                                                   |
 | --- linkPc                    | String  |    X     | PC web link (optional for the WL type)                                                                                                                                               |
 | --- schemeIos                 | String  |    X     | iOS app link (required for the AL type)                                                                                                                                              |
-| --- schemeAndroid             | String  |    X     | Android app link (required for the AL type)                                                                                                                                          |
-| --- telNumber                 | 	String  | 	X  | Phone number to send for the TN (Call) type button                                                                                                    |
+| --- schemeAndroid             | String  |    X     | Android app link (required for the AL type)                                                                                                                                            |
+| --- telNumber                 | 	String  | 	X  | Phone number to send for TN (call) type buttons                                                                    |
 | -- quickReplies               | List    |    X     | Quick reply list (up to 5)                                                                                                                                                        |
 | --- ordering                  | Integer |    X     | Quick reply order (required when quick reply exists)                                                                                                                                                |
 | --- type                      | String  |    X     | Quick reply type (WL: Web link, AL: App link, BK: Bot keyword, BC: Bot for Consultation, BT: Bot Transfer, BF: Business form)                                                                                                |
@@ -3048,7 +3048,7 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | --- content                   | String  |    X     | Inquiry content                                                                                                                                                                  |
 | --- userName                  | String  |    X     | Author                                                                                                                                                                    |
 | --- createAt                  | String  |    O     | Registration date                                                                                                                                                                  |
-| --- attachment                | List    |    X     | Attachments                                                                                                                                                                  |
+| --- attachment                | List    |    X     | Attachments                                                                                                                                                                 |
 | ---- originalFileName         | String  |    X     | Attachment file name                                                                                                                                                                 |
 | ---- filePath                 | String  |    X     | Attachment file path                                                                                                                                                               |
 | --- status                    | String  |    X     | Comment status (INQ: Inquired, APR: Approved, REJ: Rejected, REP: Replied, REQ: Under Review)                                                                                                                   |
@@ -3056,7 +3056,7 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- statusName                 | String  |    O     | Template status name                                                                                                                                                                |
 | -- securityFlag               | Boolean |    X     | Whether it is a security template                                                                                                                                              |
 | -- categoryCode               | String  |    X     | Template category code                                                                                                                                                            |
-| -- activated                  | Boolean |    X     | Whether it is activated                                                                                                                                                                 |
+| -- activated                  | Boolean |    X     | Whether it is activated                                                                                                                                                 |
 | -- createDate                 | String  |    O     | Creation date                                                                                                                                                                   |
 | -- updateDate                 | String  |    X     | Modification date                                                                                                                                                                   |
 | - totalCount                  | Integer |    X     | Total count                                                                                                                                                                    |
@@ -3204,7 +3204,7 @@ curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}
 | - resultMessage     | String  |    O     | Result message         |
 | - isSuccessful      | Boolean |    O     | Success          |
 | templateImage       | Object  |    X     | Body area          |
-| - templateImageName | String  |    X     | Image name (name of the uploaded file) |
+| - templateImageName | String  |    X     | Image name (uploaded file name) |
 | - templateImageUrl  | String  |    X     | Image URL        |
 
 <a id="register-template-plugin"></a>
@@ -3224,10 +3224,10 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name        | 	Type     | 	Description     |
-|-----------|---------|---------|
-| appkey    | 	String | 	App key |
-| senderKey | 	String | 	Sender Key   |
+| Name      | Type   | Description    |
+|-----------|--------|----------------|
+| appkey    | String | Unique app key |
+| senderKey | String | Sender Key     |
 
 [Header]
 
@@ -3237,9 +3237,9 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name           | 	Type     | 	Required | 	Description              |
-|--------------|---------|-----|------------------|
-| X-Secret-Key | 	String | O   | Can be created in the console. |
+| Name         | Type   | Required | Description                          |
+|--------------|--------|----------|--------------------------------------|
+| X-Secret-Key | String | O        | Can be created in the console. |
 
 [Request Body]
 
@@ -3251,83 +3251,13 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name          | 	Type     | 	Required | 	Description                                                        |
-|-------------|---------|-----|------------------------------------------------------------|
-| pluginType  | 	String | 	O  | Plugin type (SECURE_IMAGE: secure image transmission, ONE_TIME_PROFILE: personal information use) |
-| pluginId    | 	String | 	O  | Plugin ID                                                   |
-| callbackUrl | 	String | 	O  | The callback URL to receive when the plugin button is clicked                                  |
+| Name        | Type   | Required | Description                                                                                         |
+|-------------|--------|----------|-----------------------------------------------------------------------------------------------------|
+| pluginType  | String | O        | Plugin type (SECURE_IMAGE: secure image transmission, ONE_TIME_PROFILE: personal information use) |
+| pluginId    | String | O        | Plugin ID                                                                                           |
+| callbackUrl | String | O        | The callback URL to receive when the plugin button is clicked                                       |
 
 <a id="response-24"></a>
-
-#### Response
-
-```
-{
-  "header": {
-    "resultCode": Integer,
-    "resultMessage": String,
-    "isSuccessful": boolean
-  }
-}
-```
-
-| Name              | Type      | Not Null | Description     |
-|-----------------|---------|:--------:|--------|
-| header          | Object  |    O     | Header area  |
-| - resultCode    | Integer |    O     | Result code  |
-| - resultMessage | String  |    O     | Result message |
-| - isSuccessful  | Boolean |    O     | Success  |
-
-<a id="modify-template-plugin"></a>
-
-### Modify Template Plugin
-
-<a id="request-24"></a>
-
-#### Request
-
-[URL]
-
-```
-PUT  /alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/plugins/{pluginId}
-Content-Type: application/json;charset=UTF-8
-```
-
-[Path parameter]
-
-| Name      | 	Type   | 	Description |
-|-----------|---------|--------------|
-| appkey    | 	String | 	Unique app key |
-| senderKey | 	String | 	Sender Key   |
-| pluginId  | 	String | 	Plugin ID    |
-
-[Header]
-
-```
-{
-  "X-Secret-Key": String
-}
-```
-
-| Name         | 	Type   | 	Required | 	Description                       |
-|--------------|---------|-----------|-----------------------------------|
-| X-Secret-Key | 	String | O         | Can be created in the console.    |
-
-[Request Body]
-
-```
-{
-  "pluginType": String,
-  "callbackUrl": String
-}
-```
-
-| Name        | 	Type   | 	Required | 	Description                                                                         |
-|-------------|---------|-----------|--------------------------------------------------------------------------------------|
-| pluginType  | 	String | 	O        | Plugin type (SECURE_IMAGE: secure image transmission, ONE_TIME_PROFILE: personal information use) |
-| callbackUrl | 	String | 	O        | The callback URL to receive when the plugin button is clicked                        |
-
-<a id="response-25"></a>
 
 #### Response
 
@@ -3347,6 +3277,76 @@ Content-Type: application/json;charset=UTF-8
 | - resultCode    | Integer |    O     | Result code    |
 | - resultMessage | String  |    O     | Result message |
 | - isSuccessful  | Boolean |    O     | Success        |
+
+<a id="modify-template-plugin"></a>
+
+### Modify Template Plugin
+
+<a id="request-24"></a>
+
+#### Request
+
+[URL]
+
+```
+PUT  /alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/plugins/{pluginId}
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| Name        | 	Type     | 	Description       |
+|-----------|---------|-----------|
+| appkey    | 	String | 	Unique app key   |
+| senderKey | 	String | 	Sender Key     |
+| pluginId  | 	String | 	Plugin ID |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| Name           | 	Type     | 	Required | 	Description              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | Can be created in the console. |
+
+[Request Body]
+
+```
+{
+  "pluginType": String,
+  "callbackUrl": String
+}
+```
+
+| Name          | 	Type     | 	Required | 	Description                                                        |
+|-------------|---------|-----|------------------------------------------------------------|
+| pluginType  | 	String | 	O  | Plugin type (SECURE_IMAGE: secure image transmission, ONE_TIME_PROFILE: personal information use) |
+| callbackUrl | 	String | 	O  | The callback URL to receive when the plugin button is clicked                                  |
+
+<a id="response-25"></a>
+
+#### Response
+
+```
+{
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
+  }
+}
+```
+
+| Name              | Type      | Not Null | Description     |
+|-----------------|---------|:--------:|--------|
+| header          | Object  |    O     | Header area  |
+| - resultCode    | Integer |    O     | Result code  |
+| - resultMessage | String  |    O     | Result message |
+| - isSuccessful  | Boolean |    O     | Success  |
 
 <a id="modify-template-plugin-2"></a>
 
@@ -3402,11 +3402,11 @@ Content-Type: application/json;charset=UTF-8
 | header          | Object  |    O     | Header area  |
 | - resultCode    | Integer |    O     | Result code  |
 | - resultMessage | String  |    O     | Result message |
-| - isSuccessful  | Boolean |    O     | Success  |
+| - isSuccessful  | Boolean |    O     | Success |
 
 <a id="retrieve-template-plugin"></a>
 
-### Get Template Plugins
+### Get Template Plugin
 
 <a id="request-26"></a>
 
@@ -3421,10 +3421,10 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name      | 	Type     | 	Description  |
+| Name | Type | Description |
 |-----------|---------|---------|
-| appkey    | 	String | 	App key |
-| senderKey | 	String | 	Sender Key   |
+| appkey | String | Unique app key |
+| senderKey | String | Sender Key |
 
 [Header]
 
@@ -3434,9 +3434,9 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name           | 	Type     | 	Required | 	Description              |
+| Name | Type | Required | Description |
 |--------------|---------|-----|------------------|
-| X-Secret-Key | 	String | O   | Can be created in the console. |
+| X-Secret-Key | String | O | Can be created in the console. |
 
 <a id="response-27"></a>
 
@@ -3463,27 +3463,27 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name             | Type      | Not Null | Description                                                                                       |
+| Name | Type | Not Null | Description |
 |------------------|---------|:--------:|------------------------------------------------------------|
-| header           | Object  |    O     | Header area                                                                                       |
-| - resultCode     | Integer |    O     | Result code                                                                                       |
-| - resultMessage  | String  |    O     | Result message                                                                                    |
-| - isSuccessful   | Boolean |    O     | Success                                                                                           |
-| plugins          | List    |    X     | Plugin list                                                                                       |
-| - pluginId       | String  |    X     | Plugin ID                                                                                         |
-| - pluginType     | String  |    X     | Plugin type (SECURE_IMAGE: secure image transmission, ONE_TIME_PROFILE: personal information use) |
-| - pluginTypeName | String  |    X     | Plugin name                                                                                       |
-| - callbackUrl    | String  |    X     | The callback URL to receive when the plugin button is clicked                                     |
-| - modifiable     | Boolean |    X     | Whether the plugin can be modified                                                                |
-| - deletable      | Boolean |    X     | Whether the plugin can be deleted                                                                 |
+| header | Object | O | Header area |
+| - resultCode | Integer | O | Result code |
+| - resultMessage | String | O | Result message |
+| - isSuccessful | Boolean | O | Success |
+| plugins | List | X | Plugin list |
+| - pluginId | String | X | Plugin ID |
+| - pluginType | String | X | Plugin type (SECURE_IMAGE: secure image transmission, ONE_TIME_PROFILE: personal information use) |
+| - pluginTypeName | String | X | Plugin name |
+| - callbackUrl | String | X | The callback URL to receive when the plugin button is clicked |
+| - modifiable | Boolean | X | Whether modification is possible |
+| - deletable | Boolean | X | Whether deletion is possible |
 
 <a id="manage-alternative-delivery"></a>
 
-## Manage Alternative Delivery
+## Alternative Delivery Management
 
 <a id="register-an-sms-appkey"></a>
 
-### Register SMS AppKey
+### Register an SMS AppKey
 
 [URL]
 
@@ -3520,7 +3520,7 @@ Content-Type: application/json;charset=UTF-8
 
 | Name           | 	Type     | 	Required | 	Description                    |
 |--------------|---------|-----|------------------------|
-| resendAppKey | 	String | 	O  | SMS service app key for alternative delivery |
+| resendAppKey | 	String | 	O  | App key of the SMS service to set for alternative delivery |
 
 [Example]
 
@@ -3591,8 +3591,8 @@ Content-Type: application/json;charset=UTF-8
 
 | Name           | 	Type      | 	Required | 	Description                                                                                       |
 |--------------|----------|-----|-------------------------------------------------------------------------------------------|
-| senderKey    | 	String  | 	O  | Sender Key                                                                                      |
-| isResend     | 	Boolean | 	O  | Whether to use SMS alternative delivery if sending fails<br>Resent by default, if fallback is set on console.                          |
+| senderKey    | 	String  | 	O  | Sender key                                                                                      |
+| isResend     | 	Boolean | 	O  | Whether to send an SMS as an alternative if delivery fails<br>Resent by default, if fallback is set on console.                          |
 | resendSendNo | 	String  | 	O  | Sender number for alternative delivery<br><span style="color:red">(Alternative delivery may fail, if the sender number is not registered on the SMS service.)</span> |
 
 [Example]

--- a/en/alimtalk-api-guide.md
+++ b/en/alimtalk-api-guide.md
@@ -1,4 +1,4 @@
-## Notification > KakaoTalk Bizmessage > 알림톡 > API v2.3 Guide
+## Notification > KakaoTalk Bizmessage > AlimTalk > API v2.3 Guide
 
 <a id="alimtalk"></a>
 

--- a/en/friendtalkupgrade-api-guide.md
+++ b/en/friendtalkupgrade-api-guide.md
@@ -6,51 +6,51 @@
 
 <a id="api-domain"></a>
 
-#### \[API Domain]
+#### [API Domain]
 
-| Domain|
-|----------|
-| [https://kakaotalk-bizmessage.api.nhncloudservice.com](https://kakaotalk-bizmessage.api.nhncloudservice.com)|
+| Domain |
+|------------------------------------------------------------------------------|
+| [https://kakaotalk-bizmessage.api.nhncloudservice.com](https://kakaotalk-bizmessage.api.nhncloudservice.com) |
 
 <a id="introduce-v10-api"></a>
 
-## Introduce v1.0 API
+## Introduction to v1.0 API
 
 <a id="manage-non-friend-message-sending-targeting-m-n"></a>
 
-## Manage non-friend message sending (targeting M, N)
+## Manage Non-Friend Message Sending (Targeting M, N)
 
-Non-friend message sending (targeting M, N) can be sent if all the conditions below are met:
+Non-friend message sending (Targeting M, N) can be used when all of the following conditions are met:
 
-- Business verification channel
-- Register a business registration number
-- Register a channel customer service center phone number
-- 50,000 or more channel friends
-- Successfully send notification messages within the past three months
+- Business authentication channel
+- Business registration number registered
+- Channel customer center phone number registered
+- At least 50,000 channel friends
+- History of successful AlimTalk deliveries within the last 3 months
 
 <a id="upload-marketing-consent-records"></a>
 
-### Upload marketing consent records
+### Upload Marketing Consent Records
 
 <a id="requested"></a>
 
-#### Requested
+#### Request
 
-\[URL]
+[URL]
 
 ```
 POST  /brand-message/v1.0/appkeys/{appKey}/senders/{senderKey}/upload-marketing-agreement
 Content-Type: multipart/form-data
 ```
 
-\[Path parameter]
+[Path parameter]
 
-| Name| Type| Description|
-|----------|----------|----------|
-| appkey| String| Unique appkey|
-| senderKey| String| Outgoing Key|
+| Name      | Type   | Description        |
+|-----------|--------|--------------------|
+| appkey    | String | Unique app key     |
+| senderKey | String | Sender Key         |
 
-\[Header]
+[Header]
 
 ```
 {
@@ -58,15 +58,15 @@ Content-Type: multipart/form-data
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| X-Secret-Key| String| O| Available to create from the console.|
+| Name         | Type   | Required | Description                          |
+|--------------|--------|----------|--------------------------------------|
+| X-Secret-Key | String | O        | Can be created in the console.       |
 
-\[Request parameter]
+[Request parameter]
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| file| File| O| Marketing consent records|
+| Name | Type | Required | Description                      |
+|------|------|----------|----------------------------------|
+| file | File | O        | Marketing consent records        |
 
 <a id="response"></a>
 
@@ -82,36 +82,36 @@ Content-Type: multipart/form-data
 }
 ```
 
-| Name| Type| Not Null| Description|
-|:----------|:----------|:----------|:----------|
-| header| Object| O| Header zone|
-| \- resultCode| Integer| O| Result code|
-| \- resultMessage| String| O| Result message|
-| \- isSuccessful| boolean| O| Success status|
+| Name            | Type    | Not Null | Description     |
+|:----------------|:--------|:---------|:----------------|
+| header          | Object  | O        | Header area     |
+| - resultCode    | Integer | O        | Result code     |
+| - resultMessage | String  | O        | Result message  |
+| - isSuccessful  | boolean | O        | Success         |
 
 <a id="apply-for-using-non-friend-message-sending-targeting-m-n"></a>
 
-### Apply for using non-friend message sending (targeting M, N)
+### Apply for Non-Friend Message Sending (Targeting M, N)
 
 <a id="requested-2"></a>
 
-#### Requested
+#### Request
 
-\[URL]
+[URL]
 
 ```
 POST  /brand-message/v1.0/appkeys/{appKey}/senders/{senderKey}/marketing-agreement
 Content-Type: application/json;charset=UTF-8
 ```
 
-\[Path parameter]
+[Path parameter]
 
-| Name| Type| Description|
-|----------|----------|----------|
-| appkey| String| Unique appkey|
-| senderKey| String| Outgoing Key|
+| Name      | Type   | Description        |
+|-----------|--------|--------------------|
+| appkey    | String | Unique app key     |
+| senderKey | String | Sender Key         |
 
-\[Header]
+[Header]
 
 ```
 {
@@ -119,9 +119,9 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| X-Secret-Key| String| O| Available to create from the console.|
+| Name         | Type   | Required | Description                          |
+|--------------|--------|----------|--------------------------------------|
+| X-Secret-Key | String | O        | Can be created in the console.       |
 
 <a id="response-2"></a>
 
@@ -137,55 +137,55 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Not Null| Description|
-|:----------|:----------|:----------|:----------|
-| header| Object| O| Header zone|
-| \- resultCode| Integer| O| Result code|
-| \- resultMessage| String| O| Result message|
-| \- isSuccessful| boolean| O| Success status|
+| Name            | Type    | Not Null | Description     |
+|:----------------|:--------|:---------|:----------------|
+| header          | Object  | O        | Header area     |
+| - resultCode    | Integer | O        | Result code     |
+| - resultMessage | String  | O        | Result message  |
+| - isSuccessful  | boolean | O        | Success         |
 
 <a id="request-to-send-a-free-form-message"></a>
 
-## Request to send a free-form message
+## Send Freestyle Messages
 
 * Marketing consent-based sending can be used.
-   * You can specify the type of message target by specifying the targeting field.
-       * M: Users who agree to receive advertising information from the client company (KakaoTalk message consent)
-       * N: Users who agree to receive advertising information from the client company - Channel friend
-       * I: Target of customer sending request ∩ Channel friend
-* You can use all 8 message types of the existing FriendTalk.
-* You can use BT, AC button types.
-* Note the following constraints when using the AC (Add Channel) button:
-    * Display as a highlighted button (Yellow).
-    * Place the button in the designated position when multiple buttons are present:
-        * TEXT, IMAGE: Must be the furst button (Top position)
-        * Other types: Must be the second button (Right position)
-    * Set the button name (name) exclusively to "Add Channel".
-    * Limit usage to a maximum of one AC button across the entire carousel.
-    * Allow only targeting types M and N..
-* Support for the BF button by providing a Business Form ID issued by Kakao.
-* Fallback can be set with resendParameter for each recipient.
-  * When using fallback, you need to register the SMS Appkey and set its sending with the fallback management API.
-  * **Nighttime delivery restrictions(8:50 PM - 8:00 AM the next day)**
+    * You can specify the message target type by setting the targeting field.
+        * M: Users who have consented to receive advertising information from the company (KakaoTalk consent)
+        * N: Users who have consented to receive advertising information from the company (KakaoTalk consent) - Channel friends
+        * I: Intersection of the company's intended delivery targets ∩ Channel friends
+* All 8 message types from the existing FriendTalk can be used.
+* BT and AC button types can be used.
+* The following restrictions apply when using the AC (Add Channel) button:
+    * It is displayed as an emphasis button (yellow).
+    * If there are multiple buttons, it must be placed at the designated position.
+        * TEXT, IMAGE: First button (topmost)
+        * Others: Second button (right)
+    * The button name is fixed as "채널 추가".
+    * For carousel type, only one AC button can be used across the entire carousel.
+    * Only targeting types M and N can be used.
+* When using the BF button, you can enter the business form ID issued by Kakao.
+* Alternative delivery can be configured using resendParameter per recipient.
+    * If you use alternative delivery, you must register an SMS AppKey and configure delivery settings using the Alternative Delivery Management API.
+* **Delivery restricted during night (20:50~08:00 on the following day)**
 
 <a id="requested-3"></a>
 
-#### Requested
+#### Request
 
-\[URL]
+[URL]
 
 ```
 POST  /brand-message/v1.0/appkeys/{appkey}/freestyle-messages
 Content-Type: application/json;charset=UTF-8
 ```
 
-\[Path parameter]
+[Path parameter]
 
-| Name| Type| Description|
-|----------|----------|----------|
-| appkey| String| Unique appkey|
+| Name | Type | Description |
+|--------|--------|--------|
+| appkey | String | Unique app key |
 
-\[Header]
+[Header]
 
 ```
 {
@@ -193,15 +193,15 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| X-Secret-Key| String| O| Available to create from the console.|
+| Name | Type | Required | Description |
+|--------------|--------|----|------------------|
+| X-Secret-Key | String | O | Can be created in the console. |
 
 <a id="request-text-type-sending"></a>
 
-#### Request text-type sending
+#### Send Text Type
 
-\[Request body]
+[Request body]
 
 ```
 {
@@ -258,56 +258,56 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| senderKey| String| O| Outgoing key (40 characters). Group outgoing key unavailable|
-| chatBubbleType| String| O| Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)|
-| pushAlarm| boolean| X| Send status for message push notifications (defaults: true)|
-| requestDate| String| X| Requested date (yyyy-MM-dd HH:mm)<br>(send immediately if not entered)<br>Available to schedule up to 60 days in advance|
-| unsubscribeNo| String| X| 080 toll-free opt-out phone number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx|
-| unsubscribeAuthNo| String| X| 080 toll-free opt-out verification number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>unsubscribeAuthNo cannot be entered without unsubscribeNo<br>ex) 1234|
-| adult| boolean| X| Message status for adults (defaults: false)|
-| content| String| O| \- For TEXT type, up to 1,300 characters (linebreak: up to 99, URL type available)<br>- For IMAGE type, up to 1,300 characters (linebreak: up to 99, URL type available)<br>- For WIDE type, up to 76 characters (linebreak: up to 5)<br>- For PREMIUM_VIDEO type, the field can be used optionally. Up 76 characters (linebreak: up to 5)<br>- For other types, the field is unavailable.|
-| buttons| List| X| Button list<br>- For TEXT, IMAGE type, up to 4 when applying a coupon; for others, up to 5<br>- For WIDE, WIDE_ITEM_LIST type, up to 2<br>- For PREMIUM_VIDEO type, up to 1<br>- For COMMERCE type, minimum 1 and up to 2|
-| \- name| String| O| Button title<br>- For TEXT, IMAGE type, up to 14 characters<br>- For other types, up to 8 characters|
-| \- type| String| O| Button type (WL: web link, AL: app link, BK: bot keyword, MD: message forwarding, AC: add channel, BT: chatbot conversion, BF: Business form)<br>- BT type is available only in the channel using the chatbot of Kakao i Open Builder<br>- BF type can only be used as the first button, and only the following three phrases can be used for names:<br>&nbsp;&nbsp;- Make a reservation via KakaoTalk<br>&nbsp;&nbsp;- Take a survey via KakaoTalk<br>&nbsp;&nbsp;- Apply via KakaoTalk|
-| \- linkMo| String| X| Mobile web link (required for WL type), limited to 1,000 characters|
-| \- linkPc| String| X| PC web link (optional for WL type), limited to 1,000 characters|
-| \- schemeAndroid| String| X| Android app link (required for AL type), limited to 1,000 characters|
-| \- schemeIos| String| X| iOS app link (required for AL type), limited to 1,000 characters|
-| \- chatExtra| String| X| Meta information to send when the button is BT type|
-| \- chatEvent| String| X| Bot event name to connect when the button is BT type|
-| \- bizFormKey| String| X| BizForm key when the button is BF type|
-| coupon| Object| X| Coupon elements|
-| \- title| String| O| Limited to 5 formats for titles<br>- "${number} won discount coupon" number is 1 or greater and 99,999,999 or less<br>- "${number}% discount coupon" number is 1 or greater and 100 or less<br>- "Shipping discount coupon"<br>- "${within 7 characters} free coupon"<br>- "${within 7 characters} UP coupon"|
-| \- description| String| O| Coupon details<br>- For WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO type, up to 18 characters. Linebreak: unavailable<br>- For other types, up to 12 characters. Linebreak: unavailable|
-| \- linkMo| String| X| Mobile web link (required for WL type), limited to 1,000 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \- linkPc| String| X| PC web link (optional for WL type), limited to 1,000 characters|
-| \- schemeAndroid| String| X| Android app link (required for AL type), limited to 1,000 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \- schemeIos| String| X| iOS app link (required for AL type), limited to 1,000 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| recipientList| List| O| Recipient list (up to 1,000)|
-| \- recipientNo| String| O| Incoming number|
-| \- resendParameter| Object| X| Fallback Information|
-| \-- isResend| boolean| X| Fallback text status if sending fails<br>When setting up fallbacks in the console, fallbacks will be sent by default.|
-| \-- resendType| String| X| Fallback type (SMS, LMS)<br>If no value exists, types are distinguished according to the length of the template body.|
-| \-- resendTitle| String| X| LMS fallback title<br>(if no value exists, it will be replaced with PlusFriend ID.)|
-| \-- resendContent| String| X| Fallback title<br>(if no value exists, it will be replaced with [message body].)|
-| \-- resendSendNo| String| X| Fallback number<br><span style="color:red">(if the outgoing number is not registered with the SMS service, the fallback may fail.)</span>|
-| \-- resendUnsubscribeNo| String| X| Fallback 080 opt-out number<br><span style="color:red">(if the 080 opt-out number is not registered with the SMS service, the fallback may fail.)</span>|
-| \- targeting| String| X| Type of message target (M: User with marketing consent, N: only users that agreed to marketing consent and are not friends, I: users who are friends)|
-| \- unsubscribeNo| String| X| 080 toll-free opt-out phone number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx|
-| \- unsubscribeAuthNo| String| X| 080 opt-out verification number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>unsubscribeAuthNo cannot be entered without unsubscribeNo<br>ex) 1234|
-| \- recipientGroupingKey| String| X| Recipient grouping key (you can specify grouping keys by recipient. Up 100 characters)|
-| senderGroupingKey| String| X| Sender grouping key (you can specify grouping keys by sender. Up 100 characters)|
-| resellerCode| String| X| Reseller code (used by resellers when sending)|
-| createUser| String| X| Registrant (stored as user UUID when sent from console)|
-| statsId| String| X| Statistics ID (not included in the outgoing search conditions. Up 8 characters)|
+| Name | Type | Required | Description |
+|------------------------|---------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| senderKey | String | O | Sender key (40 characters). Group sender keys cannot be used. |
+| chatBubbleType | String | O | Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE) |
+| pushAlarm | boolean | X | Whether to send a push notification for the message (default: true) |
+| requestDate | String | X | Date and time of request (yyyy-MM-dd HH:mm)<br>(to be sent immediately if field is not sent)<br>Can be scheduled up to 60 days in advance |
+| unsubscribeNo | String | X | 080 toll-free opt-out phone number (if neither field is entered, the opt-out information registered in the Sender Profile is used)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx |
+| unsubscribeAuthNo | String | X | 080 toll-free opt-out authentication number (up to 10 characters; if neither field is entered, the opt-out information registered in the Sender Profile is used)<br>Cannot enter unsubscribeAuthNo without unsubscribeNo<br>Example: 1234 |
+| adult | boolean | X | Whether the message is for adults only (default: false) |
+| content | String | O | - For TEXT type: up to 1,300 characters (line breaks: up to 99, URL format allowed)<br>- For IMAGE type: up to 1,300 characters (line breaks: up to 99, URL format allowed)<br>- For WIDE type: up to 76 characters (line breaks: up to 5)<br>- For PREMIUM_VIDEO type: this field is optional. Up to 76 characters (line breaks: up to 5)<br>- For all other types: this field is not used |
+| buttons | List | X | List of buttons<br>- For TEXT and IMAGE types: up to 4 buttons when a coupon is applied, up to 5 otherwise<br>- For WIDE and WIDE_ITEM_LIST types: up to 2 buttons<br>- For PREMIUM_VIDEO type: up to 1 button<br>- For COMMERCE type: minimum 1, maximum 2 buttons |
+| - name | String | O | Button title<br>- For TEXT and IMAGE types: up to 14 characters<br>- For all other types: up to 8 characters |
+| - type | String | O | Button type (WL: Web Link, AL: App Link, BK: Bot Keyword, MD: Message Delivery, AC: Channel Added, BT: Chatbot Transfer, BF: Business Form)<br>- The BT type is available only for channels that use a chatbot from Kakao OpenBuilder<br>- The BF type can only be used as the first button, and only the following three phrases are allowed for name:<br>  - 톡에서 예약하기<br>  - 톡에서 설문하기<br>  - 톡에서 응모하기 |
+| - linkMo | String | X | Mobile web link (required for the WL type), limited to 1,000 characters |
+| - linkPc | String | X | PC web link (optional for the WL type), limited to 1,000 characters |
+| - schemeAndroid | String | X | Android app link (required for the AL type), limited to 1,000 characters |
+| - schemeIos | String | X | iOS app link (required for the AL type), limited to 1,000 characters |
+| - chatExtra | String | X | Meta information to pass for the BT type button |
+| - chatEvent | String | X | Bot event name to connect for the BT type button |
+| - bizFormKey | String | X | Business form key for the BF type button |
+| coupon | Object | X | Coupon element |
+| - title | String | O | For title, you are limited to five types:<br>- "${number}KRW off coupon" with a number greater than or equal to 1 and less than or equal to 99,999,999<br>- "${number}% off coupon" with a number greater than or equal to 1 and less than or equal to 100<br>- "Shipping discount coupon"<br>- "${7 characters} Free coupon"<br>- "${7 characters} UP coupon" |
+| - description | String | O | Coupon detailed description<br>- For WIDE, WIDE_ITEM_LIST, and PREMIUM_VIDEO types: up to 18 characters. Line breaks: not allowed<br>- For all other types: up to 12 characters. Line breaks: not allowed |
+| - linkMo | String | X | Mobile web link (required for the WL type), limited to 1,000 characters<br>If the linkMo field is entered for the coupon, all remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, all remaining fields become optional. |
+| - linkPc | String | X | PC web link (optional for the WL type), limited to 1,000 characters |
+| - schemeAndroid | String | X | Android app link (required for the AL type), limited to 1,000 characters<br>If the linkMo field is entered for the coupon, all remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, all remaining fields become optional. |
+| - schemeIos | String | X | iOS app link (required for the AL type), limited to 1,000 characters<br>If the linkMo field is entered for the coupon, all remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, all remaining fields become optional. |
+| recipientList | List | O | List of recipients (up to 1,000) |
+| - recipientNo | String | O | Recipient number |
+| - resendParameter | Object | X | Alternative delivery information |
+| -- isResend | boolean | X | Whether to send the message as an SMS alternative if delivery fails<br>If alternative delivery is configured in the console, it is sent as an alternative by default. |
+| -- resendType | String | X | Alternative delivery type (SMS, LMS)<br>If no value is provided, the type is determined based on the length of the template body. |
+| -- resendTitle         | String  | X  | LMS alternative delivery title<br>(resent with PlusFriend ID if value is unavailable.)                                                                                                                                                                                                               |
+| -- resendContent       | String  | X  | Alternative delivery content<br>(If no value is provided, the message is resent with [message body].)                                                                                                                                                                                                                                  |
+| -- resendSendNo        | String  | X  | Alternative delivery sender number<br><span style="color:red">(Fallback may fail, if the sender number is not registered on the SMS service.)</span>                                                                                                                                                                                 |
+| -- resendUnsubscribeNo | String  | X  | Alternative delivery 080 opt-out number<br><span style="color:red">(If it is not the 080 opt-out number registered in the SMS service, alternative delivery may fail.)</span>                                                                                                                                                                       |
+| - targeting         | String  | X  | Target type of the message (M: users who agreed to receive marketing messages, N: users who agreed to receive marketing messages but are not friends, I: users who are friends)                                                                |
+| - unsubscribeNo       | String  | X  | 080 free opt-out phone number (if not entered, the opt-out information registered in the Sender Profile is used)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx         |
+| - unsubscribeAuthNo   | String  | X  | 080 free opt-out authentication number (up to 10 characters; if not entered, the opt-out information registered in the Sender Profile is used)<br>Cannot enter unsubscribeAuthNo without unsubscribeNo<br>Example: 1234        |
+| - recipientGroupingKey | String  | X  | Recipient's grouping key (a grouping key can be specified per recipient, up to 100 characters)                                                                                                                                                                                                                   |
+| senderGroupingKey    | String  | X  | Sender's grouping key (a grouping key can be specified per sender, up to 100 characters)                                                                                                                                                                                                                   |
+| resellerCode          | String  | X  | Reseller code (used when a reseller sends messages)                                                                                                                                                                                                                                                       |
+| createUser             | String  | X  | Registrant (saved as user UUID when sending from console)                                                                                                                                                                                                                                                   |
+| statsId                | String  | 	X | Statistics ID (not included in the delivery search conditions, up to 8 characters)                                                                                                                                                            |
 
 <a id="request-image-type-sending"></a>
 
-#### Request image-type sending
+#### Send Image Type
 
-\[Request body]
+[Request Body]
 
 ```
 {
@@ -368,59 +368,59 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| senderKey| String| O| Outgoing key (40 characters). Group outgoing key unavailable|
-| chatBubbleType| String| O| Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)|
-| pushAlarm| boolean| X| Send status for message push notifications (defaults: true)|
-| requestDate| String| X| Requested date (yyyy-MM-dd HH:mm)<br>(send immediately if not entered)<br>Available to schedule up to 60 days in advance|
-| unsubscribeNo| String| X| 080 toll-free opt-out phone number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx|
-| unsubscribeAuthNo| String| X| 080 toll-free opt-out verification number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>unsubscribeAuthNo cannot be entered without unsubscribeNo<br>ex) 1234|
-| adult| boolean| X| Message status for adults (defaults: false)|
-| content| String| O| \- For TEXT type, up to 1,300 characters (linebreak: up to 99, URL type available)<br>- For IMAGE type, up to 1,300 characters (linebreak: up to 99, URL type available)<br>- For WIDE type, up to 76 characters (linebreak: up to 5)<br>- For PREMIUM_VIDEO type, the field can be used optionally. Up 76 characters (linebreak: up to 5)<br>- For other types, the field is unavailable.|
-| image| Object| O| Image elements<br>- Required fields for IMAGE, WIDE, COMMERCE types|
-| \- imageUrl| String| O| Image URL. Use an image URL uploaded as a general image|
-| \- imageLink| String| X| URL to go to when the image is clicked. Limited to 1,000 characters<br>If not set, use the image viewer in KakaoTalk|
-| buttons| List| X| Button list<br>- For TEXT, IMAGE type, up to 4 when applying a coupon; for others, up to 5<br>- For WIDE, WIDE_ITEM_LIST type, up to 2<br>- For PREMIUM_VIDEO type, up to 1<br>- For COMMERCE type, minimum 1 and up to 2|
-| \- name| String| O| Button title<br>- For TEXT, IMAGE type, up to 14 characters<br>- For other types, up to 8 characters|
-| \- type| String| O| Button type (WL: web link, AL: app link, BK: bot keyword, MD: message forwarding, AC: add channel, BT: chatbot conversion, BF: Business form)<br>- BT type is available only in the channel using the chatbot of Kakao i Open Builder<br>- BF type can only be used as the first button, and only the following three phrases can be used for names<br>&nbsp;&nbsp;- Make a reservation via KakaoTalk<br>&nbsp;&nbsp;- Take a survey via KakaoTalk<br>&nbsp;&nbsp;- Apply via KakaoTalk|
-| \- linkMo| String| X| Mobile web link (required for WL type), limited to 1,000 characters|
-| \- linkPc| String| X| PC web link (optional for WL type), limited to 1,000 characters|
-| \- schemeAndroid| String| X| Android app link (required for AL type), limited to 1,000 characters|
-| \- schemeIos| String| X| iOS app link (required for AL type), limited to 1,000 characters|
-| \- chatExtra| String| X| Meta information to send when the button is BT type|
-| \- chatEvent| String| X| Bot event name to connect when the button is BT type|
-| \- bizFormKey| String| X| BizForm key when the button is BF type|
-| coupon| Object| X| Coupon elements|
-| \- title| String| O| Limited to 5 formats for titles<br>- "${number} won discount coupon" number is 1 or greater and 99,999,999 or less<br>- "${number}% discount coupon" number is 1 or greater and 100 or less<br>- "Shipping discount coupon"<br>- "${within 7 characters} free coupon"<br>- "${within 7 characters} UP coupon"|
-| \- description| String| O| Coupon details<br>- For WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO type, up to 18 characters. Linebreak: unavailable<br>- For other types, up to 12 characters. Linebreak: unavailable|
-| \- linkMo| String| X| Mobile web link (required for WL type), limited to 1,000 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \- linkPc| String| X| PC web link (optional for WL type), limited to 1,000 characters|
-| \- schemeAndroid| String| X| Android app link (required for AL type), limited to 1,000 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \- schemeIos| String| X| iOS app link (required for AL type), limited to 1,000 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| recipientList| List| O| Recipient list (up to 1,000)|
-| \- recipientNo| String| O| Incoming number|
-| \- resendParameter| Object| X| Fallback Information|
-| \-- isResend| boolean| X| Fallback text status if sending fails<br>When setting up fallbacks in the console, fallbacks will be sent by default.|
-| \-- resendType| String| X| Fallback type (SMS, LMS)<br>If no value exists, types are distinguished according to the length of the template body.|
-| \-- resendTitle| String| X| LMS fallback title<br>(if no value exists, it will be replaced with PlusFriend ID.)|
-| \-- resendContent| String| X| Fallback title<br>(if no value exists, it will be replaced with [message body].)|
-| \-- resendSendNo| String| X| Fallback number<br><span style="color:red">(if the outgoing number is not registered with the SMS service, the fallback may fail.)</span>|
-| \-- resendUnsubscribeNo| String| X| Fallback 080 opt-out number<br><span style="color:red">(if the 080 opt-out number is not registered with the SMS service, the fallback may fail.)</span>|
-| \- targeting| String| X| Type of message target (M: User with marketing consent, N: only users that agreed to marketing consent and are not friends, I: users who are friends)|
-| \- unsubscribeNo| String| X| 080 toll-free opt-out phone number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx|
-| \- unsubscribeAuthNo| String| X| 080 toll-free opt-out verification number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>unsubscribeAuthNo cannot be entered without unsubscribeNo<br>ex) 1234|
-| \- recipientGroupingKey| String| X| Recipient grouping key (you can specify grouping keys by recipient. Up 100 characters)|
-| senderGroupingKey| String| X| Sender grouping key (you can specify grouping keys by sender. Up 100 characters)|
-| resellerCode| String| X| Reseller code (used by resellers when sending)|
-| createUser| String| X| Registrant (stored as user UUID when sent from console)|
-| statsId| String| X| Statistics ID (not included in the outgoing search conditions. Up 8 characters)|
+| Name | Type | Required | Description |
+|------------------------|---------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| senderKey              | String  | O  | Sender key (40 characters). Group sender keys cannot be used.                                                                                                                                                                                                                                                       |
+| chatBubbleType         | String  | O  | Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)                                                                                                                                                                         |
+| pushAlarm              | boolean | X  | Whether to send a push notification for the message (default: true)                                                                                                                                                                                                                                                   |
+| requestDate            | String  | X  | Date and time of request (yyyy-MM-dd HH:mm)<br>(to be sent immediately if not entered)<br>Can be scheduled up to 60 days in advance                                                                                                                                                                                                                                                   |
+| unsubscribeNo       | String  | X  | 080 opt-out phone number (if all fields are left blank, the message is sent using the opt-out information registered in the Sender Profile)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx         |
+| unsubscribeAuthNo   | String  | X  | 080 opt-out authentication number (up to 10 characters; if all fields are left blank, the message is sent using the opt-out information registered in the Sender Profile)<br>Cannot enter unsubscribeAuthNo without unsubscribeNo<br>Example: 1234        |
+| adult                  | boolean | X  | Whether the message is for adults only (default: false)                                                                                                                                                                                                                                                       |
+| content                | String  | O  | - For the TEXT type: up to 1,300 characters (line breaks: up to 99; URL format input allowed)<br>- For the IMAGE type: up to 1,300 characters (line breaks: up to 99; URL format input allowed)<br>- For the WIDE type: up to 76 characters (line breaks: up to 5)<br>- For the PREMIUM_VIDEO type: this field is optional. Up to 76 characters (line breaks: up to 5)<br>- For all other types: this field is not used                           |
+| image                  | Object  | O  | Image element<br>- Required field for the IMAGE, WIDE, and COMMERCE types                                                                                                                                                                                                                                |
+| - imageUrl             | String  | O  | Image URL. Use the URL of an image uploaded as a general image.                                                                                                                                                                                                                                              |
+| - imageLink            | String  | X  | URL to navigate to when the image is clicked. Limited to 1,000 characters.<br>If not set, the in-app KakaoTalk image viewer is used.                                                                                                                                                                                                                            |
+| buttons                | List    | X  | Button list<br>- For the TEXT and IMAGE types: up to 4 buttons when a coupon is applied, up to 5 otherwise<br>- For the WIDE and WIDE_ITEM_LIST types: up to 2 buttons<br>- For the PREMIUM_VIDEO type: up to 1 button<br>- For the COMMERCE type: at least 1 and up to 2 buttons                                                                                                                 |
+| - name                 | String  | O  | Button title<br>- For the TEXT and IMAGE types: up to 14 characters<br>- For all other types: up to 8 characters                                                                                                                                                                                                                    |
+| - type                 | String  | O  | Button type (WL: Web Link, AL: App Link, BK: Bot Keyword, MD: Message Delivery, AC: Channel Added, BT: Bot Transfer, BF: Business Form)<br>- The BT type is available only for channels that use a chatbot from Kakao Open Builder.<br>- The BF type can only be used as the first button, and only the following three phrases are allowed for name:<br>  - Make a reservation on Talk<br>  - Complete a survey on Talk<br>  - Enter a contest on Talk |
+| - linkMo               | String  | X  | Mobile web link (required for the WL type), limited to 1,000 characters                                                                                                                                                                                                                                         |
+| - linkPc               | String  | X  | PC web link (optional for the WL type), limited to 1,000 characters                                                                                                                                                                                                                                          |
+| - schemeAndroid        | String  | X  | Android app link (required for the AL type), limited to 1,000 characters                                                                                                                                                                                                                                       |
+| - schemeIos            | String  | X  | iOS app link (required for the AL type), limited to 1,000 characters                                                                                                                                                                                                                                         |
+| - chatExtra            | String  | X  | Meta information to pass for the BT type button                                                                                                                                                                                                                                                   |
+| - chatEvent            | String  | X  | Bot event name to connect for the BT type button                                                                                                                                                                                                                                                       |
+| - bizFormKey           | String  | X  | Business form key for the BF type button                                                                                                                                                                                                                                                            |
+| coupon                 | Object  | X  | Coupon element                                                                                                                                                                                                                                                                         |
+| - title                | String  | O  | For title, you are limited to five types:<br>- "${number}KRW off coupon" with a number greater than or equal to 1 and less than or equal to 99,999,999<br>- "${number}% off coupon" with a number greater than or equal to 1 and less than or equal to 100<br>- "Shipping discount coupon"<br>- "${7 characters} Free coupon"<br>- "${7 characters} UP coupon"                                                                                                            |
+| - description          | String  | O  | Coupon detailed description<br>- For the WIDE, WIDE_ITEM_LIST, and PREMIUM_VIDEO types: up to 18 characters. Line breaks: not allowed.<br>- For all other types: up to 12 characters. Line breaks: not allowed.                                                                                                                                                                      |
+| - linkMo               | String  | X  | Mobile web link (required for the WL type), limited to 1,000 characters<br>If the linkMo field is entered for a coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional.                                                                                   |
+| - linkPc               | String  | X  | PC web link (optional for the WL type), limited to 1,000 characters                                                                                                                                                                                                                                          |
+| - schemeAndroid        | String  | X  | Android app link (required for the AL type), limited to 1,000 characters<br>If the linkMo field is entered for a coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional.                                                                                 |
+| - schemeIos            | String  | X  | iOS app link (required for the AL type), limited to 1,000 characters<br>If the linkMo field is entered for a coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional.                                                                                   |
+| recipientList          | List    | O  | Recipient list (up to 1,000 recipients)                                                                                                                                                                                                                                             |
+| - recipientNo          | String  | O  | Recipient number                                                                                                                                                                                                                                                                         |
+| - resendParameter      | Object  | X  | Alternative delivery information                                                                                                                                                                                                                                                                      |
+| -- isResend            | boolean | X  | Whether to resend as SMS if delivery fails<br>If alternative delivery is configured in the console, it is sent as alternative delivery by default.                                                                                                                                                                                                                                       |
+| -- resendType          | String  | X  | Alternative delivery type (SMS, LMS)<br>Categorized by the length of template body, if value is unavailable.                                                                                                                                                                                                                       |
+| -- resendTitle         | String  | X  | LMS alternative delivery title<br>(resent with PlusFriend ID if value is unavailable.)                                                                                                                                                                                                                               |
+| -- resendContent       | String  | X  | Alternative delivery content<br>(If value is unavailable, the [message body] is used for alternative delivery.)                                                                                                                                                                                                                                  |
+| -- resendSendNo        | String  | X  | Alternative delivery sender number<br><span style="color:red">(Fallback may fail, if the sender number is not registered on the SMS service.)</span>                                                                                                                                                                                 |
+| -- resendUnsubscribeNo | String  | X  | Alternative delivery 080 opt-out number<br><span style="color:red">(If it is not the 080 opt-out number registered in the SMS service, alternative delivery may fail.)</span>                                                                                                                                                                       |
+| - targeting         | String  | X  | Target type for the message (M: users who have consented to marketing, N: users who have consented to marketing but are not friends, I: users who are friends)                                                                |
+| - unsubscribeNo       | String  | X  | 080 toll-free opt-out number (if not entered, the opt-out information registered in the Sender Profile is used)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx         |
+| - unsubscribeAuthNo   | String  | X  | 080 toll-free opt-out authentication number (up to 10 characters; if not entered, the opt-out information registered in the Sender Profile is used)<br>Cannot enter unsubscribeAuthNo without unsubscribeNo<br>Example: 1234        |
+| - recipientGroupingKey | String  | X  | Recipient grouping key (you can specify a grouping key per recipient; up to 100 characters)                                                                                                                                                                                                                   |
+| senderGroupingKey    | String  | X  | Sender grouping key (you can specify a grouping key per sender; up to 100 characters)                                                                                                                                                                                                                   |
+| resellerCode          | String  | X  | Reseller code (used when a reseller sends messages)                                                                                                                                                                                                                                                       |
+| createUser             | String  | X  | Registrant (saved as user UUID when sending from console)                                                                                                                                                                                                                                                   |
+| statsId                | String  | 	X | Statistics ID (not included in the delivery search conditions, up to 8 characters)                                                                                                                                                                                                                                            |
 
 <a id="request-wide-image-type-sending"></a>
 
-#### Request wide image-type sending
+#### Wide Image Type Delivery Request
 
-\[Request body]
+[Request body]
 
 ```
 {
@@ -481,59 +481,59 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| senderKey| String| O| Outgoing key (40 characters). Group outgoing key unavailable|
-| chatBubbleType| String| O| Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)|
-| pushAlarm| boolean| X| Send status for message push notifications (defaults: true)|
-| requestDate| String| X| Requested date (yyyy-MM-dd HH:mm)<br>(send immediately if not entered)<br>Available to schedule up to 60 days in advance|
-| unsubscribeNo| String| X| 080 toll-free opt-out phone number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx|
-| unsubscribeAuthNo| String| X| 080 toll-free opt-out verification number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>unsubscribeAuthNo cannot be entered without unsubscribeNo<br>ex) 1234|
-| adult| boolean| X| Message status for adults (defaults: false)|
-| content| String| O| \- For TEXT type, up to 1,300 characters (linebreak: up to 99, URL type available)<br>- For IMAGE type, up to 1,300 characters (linebreak: up to 99, URL type available)<br>- For WIDE type, up to 76 characters (linebreak: up to 5)<br>- For PREMIUM_VIDEO type, the field can be used optionally. Up 76 characters (linebreak: up to 5)<br>- For other types, the field is unavailable.|
-| image| Object| O| Image elements<br>- Required fields for IMAGE, WIDE, COMMERCE types|
-| \- imageUrl| String| O| Image URL, use an image URL uploaded as a wide image|
-| \- imageLink| String| X| URL to go to when the image is clicked. Limited to 1,000 characters<br>If not set, use the image viewer in KakaoTalk|
-| buttons| List| X| Button list<br>- For TEXT, IMAGE type, up to 4 when applying a coupon; for others, up to 5<br>- For WIDE, WIDE_ITEM_LIST type, up to 2<br>- For PREMIUM_VIDEO type, up to 1<br>- For COMMERCE type, minimum 1 and up to 2|
-| \- name| String| O| Button title<br>- For TEXT, IMAGE type, up to 14 characters<br>- For other types, up to 8 characters|
-| \- type| String| O| Button type (WL: web link, AL: app link, BK: bot keyword, MD: message forwarding, AC: add channel, BT: chatbot conversion, BF: Business form)<br>- BT type is available only in the channel using the chatbot of Kakao i Open Builder<br>- BF type can only be used as the first button, and only the following three phrases can be used for names:<br>&nbsp;&nbsp;- Make a reservation via KakaoTalk<br>&nbsp;&nbsp;- Take a survey via KakaoTalk<br>&nbsp;&nbsp;- Apply via KakaoTalk|
-| \- linkMo| String| X| Mobile web link (required for WL type), limited to 1,000 characters|
-| \- linkPc| String| X| PC web link (optional for WL type), limited to 1,000 characters|
-| \- schemeAndroid| String| X| Android app link (required for AL type), limited to 1,000 characters|
-| \- schemeIos| String| X| iOS app link (required for AL type), limited to 1,000 characters|
-| \- chatExtra| String| X| Meta information to send when the button is BT type|
-| \- chatEvent| String| X| Bot event name to connect when the button is BT type|
-| \- bizFormKey| String| X| BizForm key when the button is BF type|
-| coupon| Object| X| Coupon elements|
-| \- title| String| O| Limited to 5 formats for titles<br>- "${number} won discount coupon" number is 1 or greater and 99,999,999 or less<br>- "${number}% discount coupon" number is 1 or greater and 100 or less<br>- "Shipping discount coupon"<br>- "${within 7 characters} free coupon"<br>- "${within 7 characters} UP coupon"|
-| \- description| String| O| Coupon details<br>- For WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO type, up to 18 characters. Linebreak: unavailable<br>- For other types, up to 12 characters. Linebreak: unavailable|
-| \- linkMo| String| X| Mobile web link (required for WL type), limited to 1,000 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \- linkPc| String| X| PC web link (optional for WL type), limited to 1,000 characters|
-| \- schemeAndroid| String| X| Android app link (required for AL type), limited to 1,000 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \- schemeIos| String| X| iOS app link (required for AL type), limited to 1,000 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| recipientList| List| O| Recipient list (up to 1,000)|
-| \- recipientNo| String| O| Incoming number|
-| \- resendParameter| Object| X| Fallback Information|
-| \-- isResend| boolean| X| Fallback text status if sending fails<br>When setting up fallbacks in the console, fallbacks will be sent by default.|
-| \-- resendType| String| X| Fallback type (SMS, LMS)<br>If no value exists, types are distinguished according to the length of the template body.|
-| \-- resendTitle| String| X| LMS fallback title<br>(if no value exists, it will be replaced with PlusFriend ID.)|
-| \-- resendContent| String| X| Fallback title<br>(if no value exists, it will be replaced with [message body].)|
-| \-- resendSendNo| String| X| Fallback number<br><span style="color:red">(if the outgoing number is not registered with the SMS service, the fallback may fail.)</span>|
-| \-- resendUnsubscribeNo| String| X| Fallback 080 opt-out number<br><span style="color:red">(if the 080 opt-out number is not registered with the SMS service, the fallback may fail.)</span>|
-| \- targeting| String| X| Type of message target (M: User with marketing consent, N: only users that agreed to marketing consent and are not friends, I: users who are friends)|
-| \- unsubscribeNo| String| X| 080 toll-free opt-out phone number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx|
-| \- unsubscribeAuthNo| String| X| 080 toll-free opt-out verification number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>unsubscribeAuthNo cannot be entered without unsubscribeNo<br>ex) 1234|
-| \- recipientGroupingKey| String| X| Recipient grouping key (you can specify grouping keys by recipient. Up 100 characters)|
-| senderGroupingKey| String| X| Sender grouping key (you can specify grouping keys by sender. Up 100 characters)|
-| resellerCode| String| X| Reseller code (used by resellers when sending)|
-| createUser| String| X| Registrant (stored as user UUID when sent from console)|
-| statsId| String| X| Statistics ID (not included in the outgoing search conditions. Up 8 characters)|
+| Name | Type | Required | Description |
+|------------------------|---------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| senderKey              | String  | O  | Sender key (40 characters). Group sender keys cannot be used.                                                                                                                                                                                                                 |
+| chatBubbleType         | String  | O  | Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)                                                                                                                                                                   |
+| pushAlarm              | boolean | X  | Whether to send a push notification for the message (default: true)                                                                                                                                                                                                           |
+| requestDate            | String  | X  | Date and time of request (yyyy-MM-dd HH:mm)<br>(to be sent immediately if not entered)<br>Can be scheduled up to 60 days in advance                                                                                                                                           |
+| unsubscribeNo       | String  | X  | 080 free opt-out phone number (if none entered, the opt-out information registered in the Sender Profile is used)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx         |
+| unsubscribeAuthNo   | String  | X  | 080 free opt-out authentication number (up to 10 characters; if none entered, the opt-out information registered in the Sender Profile is used)<br>Cannot enter unsubscribeAuthNo without unsubscribeNo<br>Example: 1234        |
+| adult                  | boolean | X  | Whether the message is for adults (default: false)                                                                                                                                                                                                                            |
+| content                | String  | O  | - For TEXT type: up to 1,300 characters (line breaks: up to 99, URL format allowed)<br>- For IMAGE type: up to 1,300 characters (line breaks: up to 99, URL format allowed)<br>- For WIDE type: up to 76 characters (line breaks: up to 5)<br>- For PREMIUM_VIDEO type: this field can be used optionally, up to 76 characters (line breaks: up to 5)<br>- For all other types: this field is not used |
+| image                  | Object  | O  | Image element<br>- Required field for IMAGE, WIDE, and COMMERCE types                                                                                                                                                                                                         |
+| - imageUrl             | String  | O  | Image URL; use the URL of an image uploaded as a wide image                                                                                                                                                                                                                   |
+| - imageLink            | String  | X  | URL to navigate to when the image is clicked. Limited to 1,000 characters.<br>If not set, the KakaoTalk in-app image viewer is used.                                                                                                                                          |
+| buttons                | List    | X  | Button list<br>- For TEXT and IMAGE types: up to 4 buttons when a coupon is applied, up to 5 otherwise<br>- For WIDE and WIDE_ITEM_LIST types: up to 2 buttons<br>- For PREMIUM_VIDEO type: up to 1 button<br>- For COMMERCE type: at least 1 button, up to 2 buttons         |
+| - name                 | String  | O  | Button title<br>- For TEXT and IMAGE types: up to 14 characters<br>- For all other types: up to 8 characters                                                                                                                                                                  |
+| - type                 | String  | O  | Button type (WL: Web Link, AL: App Link, BK: Bot Keyword, MD: Message Delivery, AC: Add Channel, BT: Bot Transfer, BF: Business Form)<br>- The BT type is available only for channels that use a chatbot from Kakao Open Builder.<br>- The BF type can only be used as the first button, and the name field can only use one of the following three phrases:<br>  - 톡에서 예약하기<br>  - 톡에서 설문하기<br>  - 톡에서 응모하기 |
+| - linkMo               | String  | X  | Mobile web link (required for the WL type), limited to 1,000 characters                                                                                                                                                                                                       |
+| - linkPc               | String  | X  | PC web link (optional for the WL type), limited to 1,000 characters                                                                                                                                                                                                           |
+| - schemeAndroid        | String  | X  | Android app link (required for the AL type), limited to 1,000 characters                                                                                                                                                                                                      |
+| - schemeIos            | String  | X  | iOS app link (required for the AL type), limited to 1,000 characters                                                                                                                                                                                                          |
+| - chatExtra            | String  | X  | Meta information to pass when using a BT type button                                                                                                                                                                                                                          |
+| - chatEvent            | String  | X  | Bot event name to connect when using a BT type button                                                                                                                                                                                                                         |
+| - bizFormKey           | String  | X  | Business form key for a BF type button                                                                                                                                                                                                                                        |
+| coupon                 | Object  | X  | Coupon element                                                                                                                                                                                                                                                                |
+| - title                | String  | O  | For title, you are limited to five types:<br>- "${number}KRW off coupon" with a number greater than or equal to 1 and less than or equal to 99,999,999<br>- "${number}% off coupon" with a number greater than or equal to 1 and less than or equal to 100<br>- "Shipping discount coupon"<br>- "${7 characters} Free coupon"<br>- "${7 characters} UP coupon" |
+| - description          | String  | O  | Coupon detailed description<br>- For WIDE, WIDE_ITEM_LIST, and PREMIUM_VIDEO types: up to 18 characters. Line breaks: not allowed.<br>- For all other types: up to 12 characters. Line breaks: not allowed.                                                                   |
+| - linkMo               | String  | X  | Mobile web link (required for the WL type), limited to 1,000 characters.<br>If the linkMo field is entered for the coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional. |
+| - linkPc               | String  | X  | PC web link (optional for the WL type), limited to 1,000 characters                                                                                                                                                                                                          |
+| - schemeAndroid        | String  | X  | Android app link (required for the AL type), limited to 1,000 characters.<br>If the linkMo field is entered for the coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional. |
+| - schemeIos            | String  | X  | iOS app link (required for the AL type), limited to 1,000 characters.<br>If the linkMo field is entered for the coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional. |
+| recipientList          | List    | O  | Recipient list (up to 1,000 recipients)                                                                                                                                                                                                                                       |
+| - recipientNo          | String  | O  | Recipient number                                                                                                                                                                                                                                                              |
+| - resendParameter      | Object  | X  | Alternative delivery information                                                                                                                                                                                                                                                                      |
+| -- isResend            | boolean | X  | Whether to send an alternative message if delivery fails<br>If alternative delivery is set in the console, it is sent as the default.                                                                                                                                                                                                                                       |
+| -- resendType          | String  | X  | Alternative delivery type (SMS, LMS)<br>Categorized by the length of template body, if value is unavailable.                                                                                                                                                                                                                       |
+| -- resendTitle         | String  | X  | LMS alternative delivery title<br>(resent with PlusFriend ID if value is unavailable.)                                                                                                                                                                                                                               |
+| -- resendContent       | String  | X  | Alternative delivery content<br>(If value is unavailable, the [message body] is used.)                                                                                                                                                                                                                                  |
+| -- resendSendNo        | String  | X  | Alternative delivery sender number<br><span style="color:red">(Fallback may fail, if the sender number is not registered on the SMS service.)</span>                                                                                                                                                                                 |
+| -- resendUnsubscribeNo | String  | X  | Alternative delivery 080 opt-out number<br><span style="color:red">(If it is not the 080 opt-out number registered in the SMS service, alternative delivery may fail.)</span>                                                                                                                                                                       |
+| - targeting         | String  | X  | Type of message target (M: users who have consented to marketing, N: users who have consented to marketing but are not friends, I: users who are friends)                                                                |
+| - unsubscribeNo       | String  | X  | 080 free opt-out phone number (if none is entered, the opt-out information registered in the Sender Profile is used)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx         |
+| - unsubscribeAuthNo   | String  | X  | 080 free opt-out authentication number (up to 10 characters; if none is entered, the opt-out information registered in the Sender Profile is used)<br>Cannot enter unsubscribeAuthNo without unsubscribeNo<br>Example: 1234        |
+| - recipientGroupingKey | String  | X  | Recipient grouping key (a grouping key can be specified for each recipient, up to 100 characters)                                                                                                                                                                                                                   |
+| senderGroupingKey    | String  | X  | Sender grouping key (a grouping key can be specified for each sender, up to 100 characters)                                                                                                                                                                                                                   |
+| resellerCode          | String  | X  | Reseller code (used when a reseller sends a message)                                                                                                                                                                                                                                                       |
+| createUser             | String  | X  | Registrant (saved as user UUID when sending from console)                                                                                                                                                                                                                                                   |
+| statsId                | String  | 	X | Statistics ID (not included in the delivery search conditions, up to 8 characters)                                                                                                                                                                                                                                            |
 
 <a id="request-to-send-wide-item-list-type"></a>
 
-#### Request to send wide item list type
+#### Wide Item List Type Delivery Request
 
-\[Request body]
+[Request body]
 
 ```
 {
@@ -618,64 +618,64 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| senderKey| String| O| Outgoing key (40 characters). Group outgoing key unavailable|
-| chatBubbleType| String| O| Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)|
-| pushAlarm| boolean| X| Send status for message push notifications (defaults: true)|
-| requestDate| String| X| Requested date (yyyy-MM-dd HH:mm)<br>(send immediately if not entered)<br>Available to schedule up to 60 days in advance|
-| unsubscribeNo| String| X| 080 toll-free opt-out phone number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx|
-| unsubscribeAuthNo| String| X| 080 toll-free opt-out verification number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>unsubscribeAuthNo cannot be entered without unsubscribeNo<br>ex) 1234|
-| adult| boolean| X| Message status for adults (defaults: false)|
-| header| String| O| Header<br>- Required field for WIDE_ITEM_LIST type, up to 20 characters (linebreak: unavailable)<br>- Optional field for WIDE_ITEM_LIST type, up to 20 characters (linebreak: unavailable)|
-| item| Object| O| Wide list item (available only for WIDE_ITEM_LIST type)|
-| \- list| List| O| Wide list (minimum: 3, maximum 4)|
-| \-- title| String| O| Item title<br>- The first item is limited to up to 25 characters (linebreak: up to 1; for the first item, title is not required)<br>- 2 to 4th items are limited to up to 30 characters (linebreak: up 1 item)|
-| \-- imageUrl| String| O| Item image URL<br>- The first item uses the image URL uploaded as the first wide item list image.<br>- 2 to 4th items use the image URL uploaded as a general wide item list image.|
-| \-- linkMo| String| O| Mobile web link, limited to 1,000 characters|
-| \-- linkPc| String| X| PC web link, limited to 1,000 characters|
-| \-- schemeAndroid| String| X| Android app link, limited to 1,000 characters|
-| \-- schemeIos| String| X| iOS app link, limited to 1,000 characters|
-| buttons| List| X| Button list<br>- For TEXT, IMAGE type, up to 4 when applying a coupon; for others, up to 5<br>- For WIDE, WIDE_ITEM_LIST type, up to 2<br>- For PREMIUM_VIDEO type, up to 1<br>- For COMMERCE type, minimum 1 and up to 2|
-| \- name| String| O| Button title<br>- For TEXT, IMAGE type, up to 14 characters<br>- For other types, up to 8 characters|
-| \- type| String| O| Button type (WL: web link, AL: app link, BK: bot keyword, MD: message forwarding, AC: add channel, BT: chatbot conversion, BF: Business form)<br>- BT type is available only in the channel using the chatbot of Kakao i Open Builder<br>- BF type can only be used as the first button, and only the following three phrases can be used for names:<br>&nbsp;&nbsp;- Make a reservation via KakaoTalk<br>&nbsp;&nbsp;- Take a survey via KakaoTalk<br>&nbsp;&nbsp;- Apply via KakaoTalk|
-| \- linkMo| String| X| Mobile web link (required for WL type), limited to 1,000 characters|
-| \- linkPc| String| X| PC web link (optional for WL type), limited to 1,000 characters|
-| \- schemeAndroid| String| X| Android app link (required for AL type), limited to 1,000 characters|
-| \- schemeIos| String| X| iOS app link (required for AL type), limited to 1,000 characters|
-| \- chatExtra| String| X| Meta information to send when the button is BT type|
-| \- chatEvent| String| X| Bot event name to connect when the button is BT type|
-| \- bizFormKey| String| X| BizForm key when the button is BF type|
-| coupon| Object| X| Coupon elements|
-| \- title| String| O| Limited to 5 formats for titles<br>- "${number} won discount coupon" number is 1 or greater and 99,999,999 or less<br>- "${number}% discount coupon" number is 1 or greater and 100 or less<br>- "Shipping discount coupon"<br>- "${within 7 characters} free coupon"<br>- "${within 7 characters} UP coupon"|
-| \- description| String| O| Coupon details<br>- For WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO type, up to 18 characters. Linebreak: unavailable<br>- For other types, up to 12 characters. Linebreak: unavailable|
-| \- linkMo| String| X| Mobile web link (required for WL type), limited to 1,000 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \- linkPc| String| X| PC web link (optional for WL type), limited to 1,000 characters|
-| \- schemeAndroid| String| X| Android app link (required for AL type), limited to 1,000 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \- schemeIos| String| X| iOS app link (required for AL type), limited to 1,000 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| recipientList| List| O| Recipient list (up to 1,000)|
-| \- recipientNo| String| O| Incoming number|
-| \- resendParameter| Object| X| Fallback Information|
-| \-- isResend| boolean| X| Fallback text status if sending fails<br>When setting up fallbacks in the console, fallbacks will be sent by default.|
-| \-- resendType| String| X| Fallback type (SMS, LMS)<br>If no value exists, types are distinguished according to the length of the template body.|
-| \-- resendTitle| String| X| LMS fallback title<br>(if no value exists, it will be replaced with PlusFriend ID.)|
-| \-- resendContent| String| X| Fallback title<br>(if no value exists, it will be replaced with [message body].)|
-| \-- resendSendNo| String| X| Fallback number<br><span style="color:red">(if the outgoing number is not registered with the SMS service, the fallback may fail.)</span>|
-| \-- resendUnsubscribeNo| String| X| Fallback 080 opt-out number<br><span style="color:red">(if the 080 opt-out number is not registered with the SMS service, the fallback may fail.)</span>|
-| \- targeting| String| X| Type of message target (M: User with marketing consent, N: only users that agreed to marketing consent and are not friends, I: users who are friends)|
-| \- unsubscribeNo| String| X| 080 toll-free opt-out phone number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx|
-| \- unsubscribeAuthNo| String| X| 080 toll-free opt-out verification number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>unsubscribeAuthNo cannot be entered without unsubscribeNo<br>ex) 1234|
-| \- recipientGroupingKey| String| X| Recipient grouping key (you can specify grouping keys by recipient. Up 100 characters)|
-| senderGroupingKey| String| X| Sender grouping key (you can specify grouping keys by sender. Up 100 characters)|
-| resellerCode| String| X| Reseller code (used by resellers when sending)|
-| createUser| String| X| Registrant (stored as user UUID when sent from console)|
-| statsId| String| X| Statistics ID (not included in the outgoing search conditions. Up 8 characters)|
+| Name | Type | Required | Description |
+|------------------------|---------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| senderKey | String | O | Sender Key (40 characters). Group sender keys are not supported. |
+| chatBubbleType | String | O | Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE) |
+| pushAlarm | boolean | X | Whether to send a push notification for the message (default: true) |
+| requestDate | String | X | Date and time of request (yyyy-MM-dd HH:mm)<br>(Sent immediately if not entered)<br>Scheduling is available up to 60 days in advance. |
+| unsubscribeNo | String | X | 080 toll-free opt-out phone number (if neither field is entered, the opt-out information registered in the Sender Profile is used)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx |
+| unsubscribeAuthNo | String | X | 080 toll-free opt-out authentication number (up to 10 characters; if neither field is entered, the opt-out information registered in the Sender Profile is used)<br>Cannot enter unsubscribeAuthNo without unsubscribeNo<br>Example: 1234 |
+| adult | boolean | X | Whether the message is for adults (default: false) |
+| header | String | O | Header<br>- Required for the WIDE_ITEM_LIST type; up to 20 characters (line breaks not allowed)<br>- Optional for the PREMIUM_VIDEO type; up to 20 characters (line breaks not allowed) |
+| item | Object | O | Wide list element (available only for the WIDE_ITEM_LIST type) |
+| - list | List | O | Wide list (minimum: 3, maximum: 4) |
+| -- title | String | O | Item title<br>- First item: up to 25 characters (maximum 1 line break; title is not required for the first item)<br>- Items 2–4: up to 30 characters (maximum 1 line break) |
+| -- imageUrl | String | O | Item image URL<br>- For the first item, use the image URL uploaded as the first wide item list image<br>- For items 2–4, use the image URL uploaded as a regular wide item list image |
+| -- linkMo | String | O | Mobile web link, up to 1,000 characters |
+| -- linkPc | String | X | PC web link, up to 1,000 characters |
+| -- schemeAndroid | String | X | Android app link, up to 1,000 characters |
+| -- schemeIos | String | X | iOS app link, up to 1,000 characters |
+| buttons | List | X | Button list<br>- For TEXT and IMAGE types: up to 4 buttons when a coupon is applied, otherwise up to 5<br>- For WIDE and WIDE_ITEM_LIST types: up to 2 buttons<br>- For the PREMIUM_VIDEO type: up to 1 button<br>- For the COMMERCE type: at least 1 button, up to 2 buttons |
+| - name | String | O | Button title<br>- For TEXT and IMAGE types: up to 14 characters<br>- For all other types: up to 8 characters |
+| - type | String | O | Button type (WL: Web Link, AL: App Link, BK: Bot Keyword, MD: Message Delivery, AC: Channel Added, BT: Bot Transfer, BF: Business Form)<br>- The BT type is available only for channels using a chatbot built with Kakao Open Builder<br>- The BF type can only be used as the first button, and only the following three phrases are allowed for name:<br>  - Make a reservation in Talk<br>  - Take a survey in Talk<br>  - Enter a contest in Talk |
+| - linkMo | String | X | Mobile web link (required for the WL type), up to 1,000 characters |
+| - linkPc | String | X | PC web link (optional for the WL type), up to 1,000 characters |
+| - schemeAndroid | String | X | Android app link (required for the AL type), up to 1,000 characters |
+| - schemeIos | String | X | iOS app link (required for the AL type), up to 1,000 characters |
+| - chatExtra | String | X | Meta information to pass when using the BT type button |
+| - chatEvent | String | X | Bot event name to connect when using the BT type button |
+| - bizFormKey | String | X | Business form key for the BF type button |
+| coupon | Object | X | Coupon element |
+| - title | String | O | For title, you are limited to five types:<br>- "${number}KRW off coupon" with a number greater than or equal to 1 and less than or equal to 99,999,999<br>- "${number}% off coupon" with a number greater than or equal to 1 and less than or equal to 100<br>- "Shipping discount coupon"<br>- "${7 characters} Free coupon"<br>- "${7 characters} UP coupon" |
+| - description | String | O | Coupon detailed description<br>- For WIDE, WIDE_ITEM_LIST, and PREMIUM_VIDEO types: up to 18 characters (line breaks not allowed)<br>- For all other types: up to 12 characters (line breaks not allowed) |
+| - linkMo | String | X | Mobile web link (required for the WL type), up to 1,000 characters<br>If the linkMo field is entered for a coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional. |
+| - linkPc               | String  | X  | PC web link (optional for the WL type), limited to 1,000 characters                                                                                                                                                                                                                                                          |
+| - schemeAndroid        | String  | X  | Android app link (required for the AL type), limited to 1,000 characters<br>If the linkMo field is entered for a coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional.                                                                                 |
+| - schemeIos            | String  | X  | iOS app link (required for the AL type), limited to 1,000 characters<br>If the linkMo field is entered for a coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional.                                                                                   |
+| recipientList          | List    | O  | List of recipients (up to 1,000)                                                                                                                                                                                                                                                             |
+| - recipientNo          | String  | O  | Recipient number                                                                                                                                                                                                                                                                         |
+| - resendParameter      | Object  | X  | Alternative delivery information                                                                                                                                                                                                                                                                      |
+| -- isResend            | boolean | X  | Whether to use SMS as an alternative delivery method if the delivery fails<br>If alternative delivery is configured in the console, it is used as the default.                                                                                                                                                                                                                                       |
+| -- resendType          | String  | X  | Alternative delivery type (SMS, LMS)<br>Categorized by the length of template body, if value is unavailable.                                                                                                                                                                                                                       |
+| -- resendTitle         | String  | X  | Title for LMS alternative delivery<br>(resent with PlusFriend ID if value is unavailable.)                                                                                                                                                                                                                               |
+| -- resendContent       | String  | X  | Alternative delivery content<br>(If value is unavailable, the [message body] is used for alternative delivery.)                                                                                                                                                                                                                                  |
+| -- resendSendNo        | String  | X  | Sender number for alternative delivery<br><span style="color:red">(Fallback may fail, if the sender number is not registered on the SMS service.)</span>                                                                                                                                                                                 |
+| -- resendUnsubscribeNo | String  | X  | 080 opt-out number for alternative delivery<br><span style="color:red">(If it is not the 080 opt-out number registered in the SMS service, alternative delivery may fail.)</span>                                                                                                                                                                       |
+| - targeting         | String  | X  | Target type for the message (M: users who agreed to receive marketing messages, N: users who agreed to receive marketing messages but are not friends, I: users who are friends)                                                                |
+| - unsubscribeNo       | String  | X  | 080 free opt-out phone number (if not entered, the opt-out information registered in the Sender Profile is used)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx         |
+| - unsubscribeAuthNo   | String  | X  | 080 free opt-out authentication number (up to 10 characters; if not entered, the opt-out information registered in the Sender Profile is used)<br>Cannot enter unsubscribeAuthNo without unsubscribeNo<br>Example: 1234        |
+| - recipientGroupingKey | String  | X  | Recipient grouping key (a grouping key can be assigned per recipient, up to 100 characters)                                                                                                                                                                                                                   |
+| senderGroupingKey    | String  | X  | Sender grouping key (a grouping key can be assigned per sender, up to 100 characters)                                                                                                                                                                                                                   |
+| resellerCode          | String  | X  | Reseller code (used when a reseller sends a message)                                                                                                                                                                                                                                                       |
+| createUser             | String  | X  | Registrant (saved as the user UUID when sending from the console)                                                                                                                                                                                                                                                   |
+| statsId                | String  | 	X | Statistics ID (not included in the delivery search conditions, up to 8 characters)                                                                                                                                                                                                                                            |
 
 <a id="request-to-send-premium-video-type"></a>
 
-#### Request to send premium video type
+#### Send Premium Video Type
 
-\[Request body]
+[Request Body]
 
 ```
 {
@@ -737,60 +737,60 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| senderKey| String| O| Outgoing key (40 characters). Group outgoing key unavailable|
-| chatBubbleType| String| O| Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)|
-| pushAlarm| boolean| X| Send status for message push notifications (defaults: true)|
-| requestDate| String| X| Requested date (yyyy-MM-dd HH:mm)<br>(send immediately if not entered)<br>Available to schedule up to 60 days in advance|
-| unsubscribeNo| String| X| 080 toll-free opt-out phone number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx|
-| unsubscribeAuthNo| String| X| 080 toll-free opt-out verification number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>unsubscribeAuthNo cannot be entered without unsubscribeNo<br>ex) 1234|
-| adult| boolean| X| Message status for adults (defaults: false)|
-| content| String| X| \- For TEXT type, up to 1,300 characters (linebreak: up to 99, URL type available)<br>- For IMAGE type, up to 1,300 characters (linebreak: up to 99, URL type available)<br>- For WIDE type, up to 76 characters (linebreak: up to 5)<br>- For PREMIUM_VIDEO type, the field can be used optionally, 76 characters (linebreak: up to 5)<br>- For other types, the field is unavailable.|
-| header| String| X| Header<br>- Required field for WIDE_ITEM_LIST type, up to 20 characters (linebreak: unavailable)<br>- Optional field for WIDE_ITEM_LIST type, up to 20 characters (linebreak: unavailable)|
-| video| Object| O| Video elements (only PREMIUM_VIDEO type available)|
-| \- videoUrl| String| O| KakaoTV video URL (only video addresses uploaded on KakaoTV available), limited to up to 500 characters|
-| \- thumbnailUrl| String| X| Image URL for video thumbnail, only URLs uploaded as general images available (if none is available, the default KakaoTV video thumbnail is used). Limited to up to 500 characters.|
-| buttons| List| X| Button list<br>- For TEXT, IMAGE type, up to 4 when applying a coupon; for others, up to 5<br>- For WIDE, WIDE_ITEM_LIST type, up to 2<br>- For PREMIUM_VIDEO type, up to 1<br>- For COMMERCE type, minimum 1 and up to 2|
-| \- name| String| O| Button title<br>- For TEXT, IMAGE type, up to 14 characters<br>- For other types, up to 8 characters|
-| \- type| String| O| Button type (WL: web link, AL: app link, BK: bot keyword, MD: message forwarding, AC: add channel, BT: chatbot conversion, BF: Business form)<br>- BT type is available only in the channel using the chatbot of Kakao i Open Builder<br>- BF type can only be used as the first button, and only the following three phrases can be used for names:<br>&nbsp;&nbsp;- Make a reservation via KakaoTalk<br>&nbsp;&nbsp;- Take a survey via KakaoTalk<br>&nbsp;&nbsp;- Apply via KakaoTalk|
-| \- linkMo| String| X| Mobile web link (required for WL type), limited to 1,000 characters|
-| \- linkPc| String| X| PC web link (optional for WL type), limited to 1,000 characters|
-| \- schemeAndroid| String| X| Android app link (required for AL type), limited to 1,000 characters|
-| \- schemeIos| String| X| iOS app link (required for AL type), limited to 1,000 characters|
-| \- chatExtra| String| X| Meta information to send when the button is BT type|
-| \- chatEvent| String| X| Bot event name to connect when the button is BT type|
-| \- bizFormKey| String| X| BizForm key when the button is BF type|
-| coupon| Object| X| Coupon elements|
-| \- title| String| O| Limited to 5 formats for titles<br>- "${number} won discount coupon" number is 1 or greater and 99,999,999 or less<br>- "${number}% discount coupon" number is 1 or greater and 100 or less<br>- "Shipping discount coupon"<br>- "${within 7 characters} free coupon"<br>- "${within 7 characters} UP coupon"|
-| \- description| String| O| Coupon details<br>- For WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO type, up to 18 characters. Linebreak: unavailable<br>- For other types, up to 12 characters. Linebreak: unavailable|
-| \- linkMo| String| X| Mobile web link (required for WL type), limited to 1,000 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \- linkPc| String| X| PC web link (optional for WL type), limited to 1,000 characters|
-| \- schemeAndroid| String| X| Android app link (required for AL type), limited to 1,000 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \- schemeIos| String| X| iOS app link (required for AL type), limited to 1,000 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| recipientList| List| O| Recipient list (up to 1,000)|
-| \- recipientNo| String| O| Incoming number|
-| \- resendParameter| Object| X| Fallback Information|
-| \-- isResend| boolean| X| Fallback text status if sending fails<br>When setting up fallbacks in the console, fallbacks will be sent by default.|
-| \-- resendType| String| X| Fallback type (SMS, LMS)<br>If no value exists, types are distinguished according to the length of the template body.|
-| \-- resendTitle| String| X| LMS fallback title<br>(if no value exists, it will be replaced with PlusFriend ID.)|
-| \-- resendContent| String| X| Fallback title<br>(if no value exists, it will be replaced with [message body].)|
-| \-- resendSendNo| String| X| Fallback number<br><span style="color:red">(if the outgoing number is not registered with the SMS service, the fallback may fail.)</span>|
-| \-- resendUnsubscribeNo| String| X| Fallback 080 opt-out number<br><span style="color:red">(if the 080 opt-out number is not registered with the SMS service, the fallback may fail.)</span>|
-| \- targeting| String| X| Type of message target (M: User with marketing consent, N: only users that agreed to marketing consent and are not friends, I: users who are friends)|
-| \- unsubscribeNo| String| X| 080 toll-free opt-out phone number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx|
-| \- unsubscribeAuthNo| String| X| 080 toll-free opt-out verification number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>unsubscribeAuthNo cannot be entered without unsubscribeNo<br>ex) 1234|
-| \- recipientGroupingKey| String| X| Recipient grouping key (you can specify grouping keys by recipient. Up 100 characters)|
-| senderGroupingKey| String| X| Sender grouping key (you can specify grouping keys by sender. Up 100 characters)|
-| resellerCode| String| X| Reseller code (used by resellers when sending)|
-| createUser| String| X| Registrant (stored as user UUID when sent from console)|
-| statsId| String| X| Statistics ID (not included in the outgoing search conditions. Up 8 characters)|
+| Name | Type | Required | Description |
+|------------------------|---------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| senderKey | String | O | Sender key (40 characters). Group sender keys cannot be used. |
+| chatBubbleType | String | O | Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE) |
+| pushAlarm | boolean | X | Whether to send a push alarm for the message (default: true) |
+| requestDate | String | X | Date and time of request (yyyy-MM-dd HH:mm)<br>(to be sent immediately if not entered)<br>Can be scheduled up to 60 days in advance |
+| unsubscribeNo | String | X | 080 free opt-out phone number (if none is entered, the opt-out information registered in the Sender Profile is used for sending)<br>- 080-xxx-xxxx<br>- 080-xxxx-xxxx<br>- 080xxxxxxx<br>- 080xxxxxxxx |
+| unsubscribeAuthNo | String | X | 080 free opt-out authentication number (up to 10 characters; if none is entered, the opt-out information registered in the Sender Profile is used for sending)<br>Cannot enter unsubscribeAuthNo without unsubscribeNo<br>Example: 1234 |
+| adult | boolean | X | Whether the message is for adults (default: false) |
+| content | String | X | - For the TEXT type: up to 1,300 characters (line breaks: up to 99, URL format allowed)<br>- For the IMAGE type: up to 1,300 characters (line breaks: up to 99, URL format allowed)<br>- For the WIDE type: up to 76 characters (line breaks: up to 5)<br>- For the PREMIUM_VIDEO type: this field is optional, up to 76 characters (line breaks: up to 5)<br>- For all other types: this field is not used |
+| header | String | X | Header<br>- For the WIDE_ITEM_LIST type: required field, up to 20 characters (line breaks: not allowed)<br>- For the PREMIUM_VIDEO type: optional field, up to 20 characters (line breaks: not allowed) |
+| video | Object | O | Video element (available only for the PREMIUM_VIDEO type) |
+| - videoUrl | String | O | KakaoTV video URL (only URLs of videos uploaded to KakaoTV can be used), limited to 500 characters |
+| - thumbnailUrl | String | X | Image URL for the video thumbnail (only URLs uploaded as regular images can be used; if not provided, the default KakaoTV video thumbnail is used), limited to 500 characters |
+| buttons | List | X | Button list<br>- For the TEXT and IMAGE types: up to 4 buttons when a coupon is applied, otherwise up to 5<br>- For the WIDE and WIDE_ITEM_LIST types: up to 2 buttons<br>- For the PREMIUM_VIDEO type: up to 1 button<br>- For the COMMERCE type: at least 1 and up to 2 buttons |
+| - name | String | O | Button title<br>- For the TEXT and IMAGE types: up to 14 characters<br>- For all other types: up to 8 characters |
+| - type | String | O | Button type (WL: Web Link, AL: App Link, BK: Bot Keyword, MD: Message Delivery, AC: Add Channel, BT: Chatbot Transfer, BF: Business Form)<br>- The BT type is only available for channels that use a chatbot from Kakao Open Builder<br>- The BF type can only be used as the first button, and only the following three phrases are allowed for name:<br>  - 톡에서 예약하기<br>  - 톡에서 설문하기<br>  - 톡에서 응모하기 |
+| - linkMo | String | X | Mobile web link (required for the WL type), limited to 1,000 characters |
+| - linkPc | String | X | PC web link (optional for the WL type), limited to 1,000 characters |
+| - schemeAndroid | String | X | Android app link (required for the AL type), limited to 1,000 characters |
+| - schemeIos | String | X | iOS app link (required for the AL type), limited to 1,000 characters |
+| - chatExtra | String | X | Meta information to pass when the button type is BT |
+| - chatEvent | String | X | Bot event name to connect when the button type is BT |
+| - bizFormKey | String | X | Business form key when the button type is BF |
+| coupon | Object | X | Coupon element |
+| - title | String | O | For title, you are limited to five types:<br>- "${number}KRW off coupon" with a number greater than or equal to 1 and less than or equal to 99,999,999<br>- "${number}% off coupon" with a number greater than or equal to 1 and less than or equal to 100<br>- "Shipping discount coupon"<br>- "${7 characters} Free coupon"<br>- "${7 characters} UP coupon" |
+| - description | String | O | Coupon detailed description<br>- For the WIDE, WIDE_ITEM_LIST, and PREMIUM_VIDEO types: up to 18 characters. Line breaks: not allowed<br>- For all other types: up to 12 characters. Line breaks: not allowed |
+| - linkMo | String | X | Mobile web link (required for the WL type), limited to 1,000 characters<br>If the linkMo field is entered for the coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional. |
+| - linkPc | String | X | PC web link (optional for the WL type), limited to 1,000 characters |
+| - schemeAndroid | String | X | Android app link (required for the AL type), limited to 1,000 characters<br>If the linkMo field is entered for the coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional. |
+| - schemeIos | String | X | iOS app link (required for the AL type), limited to 1,000 characters<br>If the linkMo field is entered for the coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional. |
+| recipientList | List | O | Recipient list (up to 1,000 recipients) |
+| - recipientNo          | String  | O  | Recipient number                                                                                                                                                                                                                                                                         |
+| - resendParameter      | Object  | X  | Alternative delivery information                                                                                                                                                                                                                                                      |
+| -- isResend            | boolean | X  | Whether to send as an alternative text message if delivery fails<br>If alternative delivery is set in the console, it is sent as an alternative by default.                                                                                                                                                                                                                       |
+| -- resendType          | String  | X  | Alternative delivery type (SMS, LMS)<br>Categorized by the length of template body, if value is unavailable.                                                                                                                                                                                                                       |
+| -- resendTitle         | String  | X  | LMS alternative delivery title<br>(resent with PlusFriend ID if value is unavailable.)                                                                                                                                                                                                                               |
+| -- resendContent       | String  | X  | Alternative delivery content<br>(If value is unavailable, sent with [message body] as alternative.)                                                                                                                                                                                                                                  |
+| -- resendSendNo        | String  | X  | Alternative delivery sender number<br><span style="color:red">(Fallback may fail, if the sender number is not registered on the SMS service.)</span>                                                                                                                                                                                 |
+| -- resendUnsubscribeNo | String  | X  | Alternative delivery 080 opt-out number<br><span style="color:red">(If it is not the 080 opt-out number registered in the SMS service, alternative delivery may fail.)</span>                                                                                                                                                                       |
+| - targeting         | String  | X  | Type of message target (M: users who agreed to receive marketing messages, N: users who agreed to receive marketing messages but are not friends, I: users who are friends)                                                                |
+| - unsubscribeNo       | String  | X  | 080 free opt-out phone number (if all are left blank, sent with the opt-out information registered in the Sender Profile)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx         |
+| - unsubscribeAuthNo   | String  | X  | 080 free opt-out authentication number (up to 10 characters; if all are left blank, sent with the opt-out information registered in the Sender Profile)<br>Cannot enter unsubscribeAuthNo without unsubscribeNo<br>Example: 1234        |
+| - recipientGroupingKey | String  | X  | Recipient grouping key (you can specify a grouping key per recipient; up to 100 characters)                                                                                                                                                                                                                   |
+| senderGroupingKey    | String  | X  | Sender grouping key (you can specify a grouping key per sender; up to 100 characters)                                                                                                                                                                                                                   |
+| resellerCode          | String  | X  | Reseller code (used when a reseller sends messages)                                                                                                                                                                                                                                                       |
+| createUser             | String  | X  | Registrant (saved as user UUID when sending from console)                                                                                                                                                                                                                                                   |
+| statsId                | String  | 	X | Statistics ID (not included in the delivery search conditions, up to 8 characters)                                                                                                                                                            |
 
 <a id="request-to-send-commerce"></a>
 
-#### Request to send commerce
+#### Commerce Type Delivery Request
 
-\[Request body]
+[Request Body]
 
 ```
 {
@@ -858,85 +858,86 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| senderKey| String| O| Outgoing key (40 characters). Group outgoing key unavailable|
-| chatBubbleType| String| O| Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)|
-| pushAlarm| boolean| X| Send status for message push notifications (defaults: true)|
-| requestDate| String| X| Requested date (yyyy-MM-dd HH:mm)<br>(send immediately if not entered)<br>Available to schedule up to 60 days in advance|
-| unsubscribeNo| String| X| 080 toll-free opt-out phone number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx|
-| unsubscribeAuthNo| String| X| 080 toll-free opt-out verification number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>unsubscribeAuthNo cannot be entered without unsubscribeNo<br>ex) 1234|
-| adult| boolean| X| Message status for adults (defaults: false)|
-| additionalContent| String| X| Additional information (up to 34 characters, linebreak: up to 1), available only for commerce type|
-| image| Object| O| Image elements<br>- Required fields for IMAGE, WIDE, COMMERCE types|
-| \- imageUrl| String| O| Image URL. Use an image URL uploaded as a general image|
-| \- imageLink| String| X| URL to go to when the image is clicked. Limited to 1,000 characters<br>If not set, use the image viewer in KakaoTalk|
-| commerce| Object| O| Commerce (available only for COMMERCE type)|
-| title| String| O| Product title (up to 30 characters, linebreak: unavailable)|
-| regularPrice| Integer| O| Regular price (0 to 99,999,999)|
-| discountPrice| Integer| X| Discount price (0 to 99,999,999)|
-| discountRate| Integer| X| Discount rate (0 to 100), discount rate when a discount price exists. One of the fixed discount price is required|
-| discountFixed| Integer| X| Fixed discount price (0 to 999,999), discount rate when a discount price exists., One of the fixed discount prices is required|
-| buttons| List| O| Button list<br>- For TEXT, IMAGE type, up to 4 when applying a coupon; for others, up to 5<br>- For WIDE, WIDE_ITEM_LIST type, up to 2<br>- For PREMIUM_VIDEO type, up to 1<br>- For COMMERCE type, minimum 1 and up to 2|
-| \- name| String| O| Button title<br>- For TEXT, IMAGE type, up to 14 characters<br>- For other types, up to 8 characters|
-| \- type| String| O| Button type (WL: web link, AL: app link, BK: bot keyword, MD: message forwarding, AC: add channel, BT: chatbot conversion, BF: Business form)<br>- BT type is available only in the channel using the chatbot of Kakao i Open Builder<br>- BF type can only be used as the first button, and only the following three phrases can be used for names:<br>&nbsp;&nbsp;- Make a reservation via KakaoTalk<br>&nbsp;&nbsp;- Take a survey via KakaoTalk<br>&nbsp;&nbsp;- Apply via KakaoTalk|
-| \- linkMo| String| X| Mobile web link (required for WL type), limited to 1,000 characters|
-| \- linkPc| String| X| PC web link (optional for WL type), limited to 1,000 characters|
-| \- schemeAndroid| String| X| Android app link (required for AL type), limited to 1,000 characters|
-| \- schemeIos| String| X| iOS app link (required for AL type), limited to 1,000 characters|
-| \- chatExtra| String| X| Meta information to send when the button is BT type|
-| \- chatEvent| String| X| Bot event name to connect when the button is BT type|
-| \- bizFormKey| String| X| BizForm key when the button is BF type|
-| coupon| Object| X| Coupon elements|
-| \- title| String| O| Limited to 5 formats for titles<br>- "${number} won discount coupon" number is 1 or greater and 99,999,999 or less<br>- "${number}% discount coupon" number is 1 or greater and 100 or less<br>- "Shipping discount coupon"<br>- "${within 7 characters} free coupon"<br>- "${within 7 characters} UP coupon"|
-| \- description| String| O| Coupon details<br>- For WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO type, up to 18 characters. Linebreak: unavailable<br>- For other types, up to 12 characters. Linebreak: unavailable|
-| \- linkMo| String| X| Mobile web link (required for WL type), limited to 1,000 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \- linkPc| String| X| PC web link (optional for WL type), limited to 1,000 characters|
-| \- schemeAndroid| String| X| Android app link (required for AL type), limited to 1,000 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \- schemeIos| String| X| iOS app link (required for AL type), limited to 1,000 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| recipientList| List| O| Recipient list (up to 1,000)|
-| \- recipientNo| String| O| Incoming number|
-| \- resendParameter| Object| X| Fallback Information|
-| \-- isResend| boolean| X| Fallback text status if sending fails<br>When setting up fallbacks in the console, fallbacks will be sent by default.|
-| \-- resendType| String| X| Fallback type (SMS, LMS)<br>If no value exists, types are distinguished according to the length of the template body.|
-| \-- resendTitle| String| X| LMS fallback title<br>(if no value exists, it will be replaced with PlusFriend ID.)|
-| \-- resendContent| String| X| Fallback title<br>(if no value exists, it will be replaced with [message body].)|
-| \-- resendSendNo| String| X| Fallback number<br><span style="color:red">(if the outgoing number is not registered with the SMS service, the fallback may fail.)</span>|
-| \-- resendUnsubscribeNo| String| X| Fallback 080 opt-out number<br><span style="color:red">(if the 080 opt-out number is not registered with the SMS service, the fallback may fail.)</span>|
-| \- targeting| String| X| Type of message target (M: User with marketing consent, N: only users that agreed to marketing consent and are not friends, I: users who are friends)|
-| \- unsubscribeNo| String| X| 080 toll-free opt-out phone number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx|
-| \- unsubscribeAuthNo| String| X| 080 toll-free opt-out verification number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>unsubscribeAuthNo cannot be entered without unsubscribeNo<br>ex) 1234|
-| \- recipientGroupingKey| String| X| Recipient grouping key (you can specify grouping keys by recipient. Up 100 characters)|
-| senderGroupingKey| String| X| Sender grouping key (you can specify grouping keys by sender. Up 100 characters)|
-| resellerCode| String| X| Reseller code (used by resellers when sending)|
-| createUser| String| X| Registrant (stored as user UUID when sent from console)|
-| statsId| String| X| Statistics ID (not included in the outgoing search conditions. Up 8 characters)|
+| Name | Type | Required | Description |
+|------------------------|---------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| senderKey | String | O | Sender key (40 characters). Group sender keys are not available. |
+| chatBubbleType | String | O | Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE) |
+| pushAlarm | boolean | X | Whether to send a push notification for the message (default: true) |
+| requestDate | String | X | Request date and time (yyyy-MM-dd HH:mm)<br>(If not entered, the message is sent immediately.)<br>Can be scheduled up to 60 days in advance. |
+| unsubscribeNo | String | X | 080 toll-free opt-out number (if neither field is entered, the opt-out information registered in the Sender Profile is used for sending)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx |
+| unsubscribeAuthNo | String | X | 080 toll-free opt-out authentication number (up to 10 characters; if neither field is entered, the opt-out information registered in the Sender Profile is used for sending)<br>Cannot enter unsubscribeAuthNo without unsubscribeNo<br>Example: 1234 |
+| adult | boolean | X | Whether the message is for adults only (default: false) |
+| additionalContent | String | X | Additional information (up to 34 characters, line breaks: up to 1). Available only for the Commerce type. |
+| image | Object | O | Image element<br>- Required for the IMAGE, WIDE, and COMMERCE types |
+| - imageUrl | String | O | Image URL. Use the URL of an image uploaded as a general image. |
+| - imageLink | String | X | URL to navigate to when the image is clicked. Limited to 1,000 characters.<br>If not set, the KakaoTalk in-app image viewer is used. |
+| commerce | Object | O | Commerce (available only for the COMMERCE type) |
+| title | String | O | Product title (up to 30 characters, line breaks: not allowed) |
+| regularPrice | Integer | O | Regular price (0–99,999,999) |
+| discountPrice | Integer | X | Discounted price (0–99,999,999) |
+| discountRate | Integer | X | Discount rate (0–100). When a discounted price exists, either the discount rate or the fixed discount price is required. |
+| discountFixed | Integer | X | Fixed discount price (0–999,999). When a discounted price exists, either the discount rate or the fixed discount price is required. |
+| buttons | List | O | Button list<br>- For the TEXT and IMAGE types: up to 4 buttons when a coupon is applied, otherwise up to 5<br>- For the WIDE and WIDE_ITEM_LIST types: up to 2 buttons<br>- For the PREMIUM_VIDEO type: up to 1 button<br>- For the COMMERCE type: at least 1 and up to 2 buttons |
+| - name | String | O | Button title<br>- For the TEXT and IMAGE types: up to 14 characters<br>- For all other types: up to 8 characters |
+| - type | String | O | Button type (WL: Web Link, AL: App Link, BK: Bot Keyword, MD: Message Delivery, AC: Add Channel, BT: Bot Transfer, BF: Business Form)<br>- The BT type is available only for channels that use a chatbot from Kakao Open Builder.<br>- The BF type can only be used as the first button, and only the following three phrases are allowed for name:<br>  - 톡에서 예약하기<br>  - 톡에서 설문하기<br>  - 톡에서 응모하기 |
+| - linkMo | String | X | Mobile web link (required for the WL type), limited to 1,000 characters |
+| - linkPc | String | X | PC web link (optional for the WL type), limited to 1,000 characters |
+| - schemeAndroid | String | X | Android app link (required for the AL type), limited to 1,000 characters |
+| - schemeIos | String | X | iOS app link (required for the AL type), limited to 1,000 characters |
+| - chatExtra | String | X | Meta information to pass when using a BT type button |
+| - chatEvent | String | X | Bot event name to connect when using a BT type button |
+| - bizFormKey | String | X | Biz form key for a BF type button |
+| coupon | Object | X | Coupon element |
+| - title | String | O | For title, you are limited to five types:<br>- "${number}KRW off coupon" with a number greater than or equal to 1 and less than or equal to 99,999,999<br>- "${number}% off coupon" with a number greater than or equal to 1 and less than or equal to 100<br>- "Shipping discount coupon"<br>- "${7 characters} Free coupon"<br>- "${7 characters} UP coupon" |
+| - description | String | O | Coupon detailed description<br>- For the WIDE, WIDE_ITEM_LIST, and PREMIUM_VIDEO types: up to 18 characters. Line breaks: not allowed.<br>- For all other types: up to 12 characters. Line breaks: not allowed. |
+| - linkMo               | String  | X  | Mobile web link (required for the WL type), up to 1,000 characters<br>If you enter a value in the linkMo field for a coupon, the remaining fields become optional.<br>If you enter a channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.                                                                                   |
+| - linkPc               | String  | X  | PC web link (optional for the WL type), up to 1,000 characters                                                                                                                                                                                                                          |
+| - schemeAndroid        | String  | X  | Android app link (required for the AL type), up to 1,000 characters<br>If you enter a value in the linkMo field for a coupon, the remaining fields become optional.<br>If you enter a channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.                                                                                 |
+| - schemeIos            | String  | X  | iOS app link (required for the AL type), up to 1,000 characters<br>If you enter a value in the linkMo field for a coupon, the remaining fields become optional.<br>If you enter a channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.                                                                                   |
+| recipientList          | List    | O  | List of recipients (up to 1,000)                                                                                                                                                                                                                                                             |
+| - recipientNo          | String  | O  | Recipient number                                                                                                                                                                                                                                                                         |
+| - resendParameter      | Object  | X  | Alternative delivery information                                                                                                                                                                                                                                                      |
+| -- isResend            | boolean | X  | Whether to send as an alternative text message if delivery fails<br>If alternative delivery is configured in the console, it is sent as an alternative by default.                                                                                                                                                                                                                                       |
+| -- resendType          | String  | X  | Alternative delivery type (SMS, LMS)<br>Categorized by the length of template body, if value is unavailable.                                                                                                                                                                                                                       |
+| -- resendTitle         | String  | X  | Title for LMS alternative delivery<br>(resent with PlusFriend ID if value is unavailable.)                                                                                                                                                                                                                               |
+| -- resendContent       | String  | X  | Alternative delivery content<br>(If value is unavailable, it is sent with [message body].)                                                                                                                                                                                                                                  |
+| -- resendSendNo        | String  | X  | Sender number for alternative delivery<br><span style="color:red">(Fallback may fail, if the sender number is not registered on the SMS service.)</span>                                                                                                                                                                                 |
+| -- resendUnsubscribeNo | String  | X  | 080 opt-out number for alternative delivery<br><span style="color:red">(If it is not the 080 opt-out number registered in the SMS service, alternative delivery may fail.)</span>                                                                                                                                                                       |
+| - targeting         | String  | X  | Target type for the message (M: users who have consented to marketing, N: users who have consented to marketing but are not friends, I: users who are friends)                                                                |
+| - unsubscribeNo       | String  | X  | 080 toll-free opt-out phone number (if all fields are left blank, the opt-out information registered in the Sender Profile is used for delivery)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx         |
+| - unsubscribeAuthNo   | String  | X  | 080 toll-free opt-out authentication number (up to 10 characters; if all fields are left blank, the opt-out information registered in the Sender Profile is used for delivery)<br>Cannot enter unsubscribeAuthNo alone without unsubscribeNo<br>Example: 1234        |
+| - recipientGroupingKey | String  | X  | Recipient grouping key (you can specify a grouping key per recipient, up to 100 characters)                                                                                                                                                                                                                   |
+| senderGroupingKey    | String  | X  | Sender grouping key (you can specify a grouping key per sender, up to 100 characters)                                                                                                                                                                                                                   |
+| resellerCode          | String  | X  | Reseller code (used when a reseller sends messages)                                                                                                                                                                                                                                                       |
+| createUser             | String  | X  | Registrant (saved as the user UUID when sent from the console)                                                                                                                                                                                                                                                   |
+| statsId                | String  | 	X | Statistics ID (not included in the delivery search conditions, up to 8 characters)                                                                                                                                                                                                                                            |
 
 <a id="request-to-send-carousel-feed-type"></a>
 
-#### Request to send carousel feed type
-##### Carousel fixed placeholders (path-based template parameter)
+#### Send Carousel Feed
 
-Allow unique placeholder values for each item in a carousel-type template.
+##### Carousel Fixed Replacement Variables (Path-Based Template Parameters)
 
-* **Usage format**: `key@$.carousel.list[index]`(e.g. `productName@$.carousel.list[0]`)
-* If a carousel intro (head) is present, it occupies `list[0]`, while actual content items begin from `list[1]`.
-* If no value is matched using the path-based key, it will fall back to the standard key.
+In the carousel type, you can apply different replacement variable values to each item.
 
-| Category | Replaceable fields | path format |
+* **Format**: `key@$.carousel.list[index]` (e.g., `productName@$.carousel.list[0]`)
+* If a head (carousel intro) is present, it occupies `list[0]`, and the actual items start from `list[1]`.
+* If a value cannot be found using a path-based key, it falls back to the regular key.
+
+| Category | Replaceable Fields | Path Format |
 |------|--------------|----------|
-| Carousel intro (head) | header, content, linkMo, linkPc, schemeAndroid, schemeIos | `key@$.carousel.list[0]`(if head exists) |
+| Carousel intro (head) | header, content, linkMo, linkPc, schemeAndroid, schemeIos | `key@$.carousel.list[0]` (when head is present) |
 | Carousel item | header, message, additionalContent | `key@$.carousel.list[index]` |
 | Carousel item button | linkMo, linkPc, schemeAndroid, schemeIos | `key@$.carousel.list[index]` |
 | Carousel item coupon | title, description, linkMo, linkPc, schemeAndroid, schemeIos | `key@$.carousel.list[index]` |
 | Carousel item commerce | title | `key@$.carousel.list[index]` |
 
-* **Tail**: Placeholders are not supported
-* Button indices are not included in the path. All buttons within the same item are replaced using the same path value.
+* **Tail**: Replacement variables cannot be used.
+* Button indexes are not included in the path. Buttons within the same item are replaced with the same path value.
 
-> **Caution** The @ character cannot be used in placeholder keys (#{key}). The @ character is reserved as a path delimiter within the system.
+> **Caution** The `@` character cannot be used in replacement variable keys (`#{key}`). The `@` character is used by the system as a path delimiter.
 
-\[Request body]
+[Request body]
 
 ```
 {
@@ -1035,66 +1036,66 @@ Allow unique placeholder values for each item in a carousel-type template.
 }
 ```
 
-| Name| Type| Required | Description|
-|----------|----------|----------|----------|
-| senderKey| String| O        | Outgoing key (40 characters). Group outgoing key unavailable|
-| chatBubbleType| String| O        | Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)|
-| pushAlarm| boolean| X        | Send status for message push notifications (defaults: true)|
-| requestDate| String| X        | Requested date (yyyy-MM-dd HH:mm)<br>(send immediately if not entered)<br>Available to schedule up to 60 days in advance|
-| unsubscribeNo| String| X        | 080 toll-free opt-out phone number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx|
-| unsubscribeAuthNo| String| X        | 080 toll-free opt-out verification number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>unsubscribeAuthNo cannot be entered without unsubscribeNo<br>ex) 1234|
-| adult| boolean| X        | Message status for adults (defaults: false)|
-| carousel| Object| O        | Carousel|
-| \- list| List| O        | Carousel list (minimum 2, maximum 6)|
-| \-- header| String| O        | Carousel item title (up to 20 characters). Available only for carousel feed type|
-| \-- message| String| O        | Carousel item title (up to 20 characters), carousel item message (up to 180 characters). Available only for carousel feed type|
-| \-- imageUrl| String| O        | Image URL (Only images uploaded as carousel feed type images are available)|
-| \-- imageLink| String| X        | Image link, limited to 1,000 characters|
-| \-- buttons| List| O        | Carousel list button list, minimum 1, maximum 2|
-| \--- name| String| O        | Button title<br>- For TEXT, IMAGE type, up to 14 characters<br>- For other types, up to 8 characters|
-| \--- type| String| O        | Button type (WL: web link, AL: app link, BK: bot keyword, MD: message forwarding, AC: add channel, BT: chatbot conversion, BF: Business form)<br>- BT type is available only in the channel using the chatbot of Kakao i Open Builder<br>- BF type can only be used as the first button, and only the following three phrases can be used for names:<br>&nbsp;&nbsp;- Make a reservation via KakaoTalk<br>&nbsp;&nbsp;- Take a survey via KakaoTalk<br>&nbsp;&nbsp;- Apply via KakaoTalk|
-| \--- linkMo| String| X        | Mobile web link (required for WL type), limited to 1,000 characters|
-| \--- linkPc| String| X        | PC web link (optional for WL type), limited to 1,000 characters|
-| \--- schemeAndroid| String| X        | Android app link (required for AL type), limited to 1,000 characters|
-| \--- schemeIos| String| X        | iOS app link (required for AL type), limited to 1,000 characters|
-| \--- chatExtra| String| X        | Meta information to send when the button is BT type|
-| \--- chatEvent| String| X        | Bot event name to connect when the button is BT type|
-| \--- bizFormKey| String| X        | BizForm key when the button is BF type|
-| \-- coupon| Object| X        | Coupon elements|
-| \--- title| String| O        | Limited to 5 formats for titles<br>- "${number} won discount coupon" number is 1 or greater and 99,999,999 or less<br>- "${number}% discount coupon" number is 1 or greater and 100 or less<br>- "Shipping discount coupon"<br>- "${within 7 characters} free coupon"<br>- "${within 7 characters} UP coupon"|
-| \--- description| String| O        | Coupon details<br>- For WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO type, up to 18, linebreak: unavailable<br>- For other types, up to 12 characters, linebreak: unavailable|
-| \--- linkMo| String| X        | Mobile web link (required for WL type), limited to 1,000 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \--- linkPc| String| X        | PC web link (optional for WL type), limited to 1,000 characters|
-| \--- schemeAndroid| String| X        | Android app link (required for AL type), limited to 1,000 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \--- schemeIos| String| X        | iOS app link (required for AL type), limited to 1,000 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \- tail| Object| X        | More button information|
-| \-- linkMo| String| O        | Mobile web link, limited to 1,000 characters|
-| \-- linkPc| String| X        | PC web link, limited to 1,000 characters|
-| \-- schemeAndroid| String| X        | Android app link, limited to 1,000 characters|
-| \-- schemeIos| String| X        | iOS app link, limited to 1,000 characters|
-| recipientList| List| O        | Recipient list (up to 1,000)|
-| \- recipientNo| String| O        | Incoming number|
-| \- resendParameter| Object| X        | Fallback Information|
-| \-- isResend| boolean| X        | Fallback text status if sending fails<br>When setting up fallbacks in the console, fallbacks will be sent by default.|
-| \-- resendType| String| X        | Fallback type (SMS, LMS)<br>If no value exists, types are distinguished according to the length of the template body.|
-| \-- resendTitle| String| X        | LMS fallback title<br>(if no value exists, it will be replaced with PlusFriend ID.)|
-| \-- resendContent| String| X        | Fallback title<br>(if no value exists, it will be replaced with [message body].)|
-| \-- resendSendNo| String| X        | Fallback number<br><span style="color:red">(if the outgoing number is not registered with the SMS service, the fallback may fail.)</span>|
-| \-- resendUnsubscribeNo| String| X        | Fallback 080 opt-out number<br><span style="color:red">(if the 080 opt-out number is not registered with the SMS service, the fallback may fail.)</span>|
-| \- targeting| String| X        | Type of message target (M: User with marketing consent, N: only users that agreed to marketing consent and are not friends, I: users who are friends)|
-| \- unsubscribeNo| String| X        | 080 toll-free opt-out phone number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx|
-| \- unsubscribeAuthNo| String| X        | 080 toll-free opt-out verification number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>unsubscribeAuthNo cannot be entered without unsubscribeNo<br>ex) 1234|
-| \- recipientGroupingKey| String| X        | Recipient grouping key (you can specify grouping keys by recipient. Up 100 characters)|
-| senderGroupingKey| String| X        | Sender grouping key (you can specify grouping keys by sender. Up 100 characters)|
-| resellerCode| String| X        | Reseller code (used by resellers when sending)|
-| createUser| String| X        | Registrant (stored as user UUID when sent from console)|
-| statsId| String| X        | Statistics ID (not included in the outgoing search conditions. Up 8 characters)|
+| Name                     | Type      | Required | Description                                                                                                                                                                                                                                                                            |
+|------------------------|---------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| senderKey              | String  | O  | Sender key (40 characters). Group sender keys cannot be used.                                                                                                                                                                                                                                                       |
+| chatBubbleType         | String  | O  | Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)                                                                                                                                                                         |
+| pushAlarm              | boolean | X  | Whether to send a push notification for the message (default: true)                                                                                                                                                                                                                                                   |
+| requestDate            | String  | X  | Date and time of request (yyyy-MM-dd HH:mm)<br>(to be sent immediately if not entered)<br>Can be scheduled up to 60 days in advance                                                                                                                                                                                                                                                   |
+| unsubscribeNo       | String  | X  | 080 toll-free opt-out number (if neither field is entered, the message is sent using the opt-out information registered in the Sender Profile)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx         |
+| unsubscribeAuthNo   | String  | X  | 080 toll-free opt-out authentication number (up to 10 characters; if neither field is entered, the message is sent using the opt-out information registered in the Sender Profile)<br>Cannot enter unsubscribeAuthNo without unsubscribeNo<br>Example: 1234        |
+| adult                  | boolean | X  | Whether the message is for adults (default: false)                                                                                                                                                                                                                                                                       |
+| carousel               | Object  | O  | Carousel                                                                                                                                                                                                                                                                           |
+| - list                 | List    | O  | Carousel list (minimum 2, maximum 6)                                                                                                                                                                                                                                                        |
+| -- header              | String  | O  | Carousel item title (up to 20 characters). Only available in carousel feeds.                                                                                                                                                                                                                                          |
+| -- message             | String  | O  | Carousel item title (up to 20 characters), carousel item message (up to 180 characters). Only available in carousel feeds.                                                                                                                                                                                                                    |
+| -- imageUrl            | String  | O  | Image URL (only images uploaded as carousel feed images can be used)                                                                                                                                                                                                                                        |
+| -- imageLink           | String  | X  | Image link, up to 1,000 characters                                                                                                                                                                                                                                              |
+| -- buttons             | List    | O  | Carousel list button list: minimum 1, maximum 2                                                                                                                                                                                                                                                                    |
+| --- name               | String  | O  | Button title<br>- Up to 14 characters for TEXT and IMAGE types<br>- Up to 8 characters for all other types                                                                                                                                                                                                                    |
+| --- type               | String  | O  | Button type (WL: Web Link, AL: App Link, BK: Bot Keyword, MD: Message Delivery, AC: Channel Added, BT: Chatbot Transfer, BF: Business Form)<br>- The BT type is only available for channels that use a chatbot from Kakao Open Builder.<br>- The BF type can only be used as the first button, and the name field must use one of the following three phrases only:<br>  - Reserve via Talk<br>  - Survey via Talk<br>  - Enter via Talk |
+| --- linkMo             | String  | X  | Mobile web link (required for the WL type), up to 1,000 characters                                                                                                                                                                                                                                         |
+| --- linkPc             | String  | X  | PC web link (optional for the WL type), up to 1,000 characters                                                                                                                                                                                                                          |
+| --- schemeAndroid      | String  | X  | Android app link (required for the AL type), up to 1,000 characters                                                                                                                                                                                                                                       |
+| --- schemeIos          | String  | X  | iOS app link (required for the AL type), up to 1,000 characters                                                                                                                                                                                                                         |
+| --- chatExtra          | String  | X  | Meta information to pass for BT type buttons                                                                                                                                                                                                                                                   |
+| --- chatEvent          | String  | X  | Bot event name to connect for BT type buttons                                                                                                                                                                                                                                                       |
+| --- bizFormKey         | String  | X  | Business form key for BF type buttons                                                                                                                                                                                                                                                            |
+| -- coupon              | Object  | X  | Coupon element                                                                                                                                                                                                                                                                         |
+| --- title              | String  | O  | For title, you are limited to five types:<br>- "${number}KRW off coupon" with a number greater than or equal to 1 and less than or equal to 99,999,999<br>- "${number}% off coupon" with a number greater than or equal to 1 and less than or equal to 100<br>- "Shipping discount coupon"<br>- "${7 characters} Free coupon"<br>- "${7 characters} UP coupon"                                                                                                            |
+| --- description        | String  | O  | Coupon detailed description<br>- Up to 18 characters for WIDE, WIDE_ITEM_LIST, and PREMIUM_VIDEO types; line breaks not allowed<br>- Up to 12 characters for all other types; line breaks not allowed                                                                                                                                                                      |
+| --- linkMo             | String  | X  | Mobile web link (required for the WL type), up to 1,000 characters<br>If the linkMo field is entered for a coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional.                                                                                   |
+| --- linkPc             | String  | X  | PC web link (optional for the WL type), up to 1,000 characters                                                                                                                                                                                                                          |
+| --- schemeAndroid      | String  | X  | Android app link (required for the AL type), up to 1,000 characters<br>If the linkMo field is entered for a coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional.                                                                                 |
+| --- schemeIos          | String  | X  | iOS app link (required for the AL type), up to 1,000 characters<br>If the linkMo field is entered for a coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional.                                                                                   |
+| - tail                 | Object  | X  | More button information                                                                                                                                                                                                                                                                     |
+| -- linkMo              | String  | O  | Mobile web link, up to 1,000 characters                                                                                                                                                                                                                                                           |
+| -- linkPc              | String  | X  | PC web link, up to 1,000 characters                                                                                                                                                                                                                                                            |
+| -- schemeAndroid       | String  | X  | Android app link, up to 1,000 characters                                                                                                                                                                                                                                                         |
+| -- schemeIos           | String  | X  | iOS app link, up to 1,000 characters                                                                                                                                                                                                                                                           |
+| recipientList          | List    | O  | List of recipients (up to 1,000)                                                                                                                                                                                                                                                             |
+| - recipientNo          | String  | O  | Recipient number                                                                                                                                                                                                                                                                         |
+| - resendParameter      | Object  | X  | Alternative delivery information                                                                                                                                                                                                                                                                      |
+| -- isResend            | boolean | X  | Whether to send via SMS if delivery fails<br>If alternative delivery is configured in the console, it is sent as alternative delivery by default.                                                                                                                                                                                                                                       |
+| -- resendType          | String  | X  | Alternative delivery type (SMS, LMS)<br>Categorized by the length of template body, if value is unavailable.                                                                                                                                                                                                                       |
+| -- resendTitle         | String  | X  | LMS alternative delivery title<br>(resent with PlusFriend ID if value is unavailable.)                                                                                                                                                                                                                               |
+| -- resendContent       | String  | X  | Alternative delivery content<br>(If value is unavailable, it is sent with [message body].)                                                                                                                                                                                                                                  |
+| -- resendSendNo        | String  | X  | Alternative delivery sender number<br><span style="color:red">(Fallback may fail, if the sender number is not registered on the SMS service.)</span>                                                                                                                                                                                 |
+| -- resendUnsubscribeNo | String  | X  | Alternative delivery 080 opt-out number<br><span style="color:red">(If it is not the 080 opt-out number registered in the SMS service, alternative delivery may fail.)</span>                                                                                                                                                                       |
+| - targeting         | String  | X  | Target type of the message (M: users who agreed to receive marketing messages, N: users who are not friends but agreed to receive marketing messages, I: users who are friends)                                                                |
+| - unsubscribeNo       | String  | X  | 080 free opt-out phone number (if all fields are left blank, the opt-out information registered in the Sender Profile is used)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx         |
+| - unsubscribeAuthNo   | String  | X  | 080 free opt-out authentication number (up to 10 characters; if all fields are left blank, the opt-out information registered in the Sender Profile is used)<br>Cannot enter unsubscribeAuthNo without unsubscribeNo<br>Example: 1234        |
+| - recipientGroupingKey | String  | X  | Recipient grouping key (you can specify a grouping key per recipient, up to 100 characters)                                                                                                                                                                                                                   |
+| senderGroupingKey    | String  | X  | Sender grouping key (you can specify a grouping key per sender, up to 100 characters)                                                                                                                                                                                                                   |
+| resellerCode          | String  | X  | Reseller code (used when a reseller sends messages)                                                                                                                                                                                                                                                       |
+| createUser             | String  | X  | Registrant (saved as user UUID when sending from console)                                                                                                                                                                                                                                                   |
+| statsId                | String  | 	X | Statistics ID (not included in the delivery search conditions, up to 8 characters)                                                                                                                                                                                                                            |
 
 <a id="request-to-send-carousel-commerce-type"></a>
 
-#### Request to send carousel commerce type
+#### Carousel Commerce Delivery Request
 
-\[Request body]
+[Request Body]
 
 ```
 {
@@ -1181,72 +1182,72 @@ Allow unique placeholder values for each item in a carousel-type template.
 }
 ```
 
-| Name| Type| Required | Description|
-|----------|----------|----------|----------|
-| senderKey| String| O        | Outgoing key (40 characters), group outgoing key unavailable|
-| chatBubbleType| String| O        | Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)|
-| pushAlarm| boolean| X        | Sending status for message push notifications (defaults: true)|
-| requestDate| String| X        | Requested date (yyyy-MM-dd HH:mm)<br>(send immediately if not entered)<br>Available to schedule up to 60 days in advance|
-| unsubscribeNo| String| X        | 080 toll-free opt-out phone number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx|
-| unsubscribeAuthNo| String| X        | 080 toll-free opt-out verification number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>unsubscribeAuthNo cannot be entered without unsubscribeNo<br>ex) 1234|
-| adult| boolean| X        | Message status for adults (defaults: false)|
-| carousel| Object| O        | Carousel|
-| \- head| Object| X        | Carousel intro|
-| \-- header| String| O        | Carousel intro header (up to 20 characters)|
-| \-- content| String| O        | Carousel intro content (up to 50 characters)|
-| \-- imageUrl| String| O        | Carousel intro image address (use an image uploaded as a carousel commerce type image; the used image should have the same image and ratio of the carousel.)|
-| \-- linkMo| String| X        | Mobile web link (linkMo is required if one of the linkMo, linkPc, schemeAndroid, schemeIos will be used), limited to up to 1,000 characters|
-| \-- linkPc| String| X        | PC web link, limited to 1,000 characters|
-| \-- schemeAndroid| String| X        | Android app link, limited to 1,000 characters|
-| \-- schemeIos| String| X        | iOS app link, limited to 1,000 characters|
-| \- list| List| O        | Carousel list (If head exists, minimum 1, maximum 5 / otherwise minimum 2, maximum 6)|
-| \-- additionalContent| String| X        | Additional info (up to 34 characters), available only for carousel commerce|
-| \-- imageUrl| String| O        | Image URL (Only images uploaded as carousel commerce type images are available)|
-| \-- imageLink| String| X        | Image link, limited to 1,000 characters|
-| \-- commerce| Object| O        | Commerce (available only for CAROUSEL_COMMERCE type)|
-| \--- title| String| O        | Product title (up to 30 characters, linebreak: unavailable)|
-| \--- regularPrice| Integer| O        | Regular price (0 to 99,999,999)|
-| \--- discountPrice| Integer| X        | Discount price (0 to 99,999,999)|
-| \--- discountRate| Integer| X        | Discount rate (0 to 100), discount rate when a discount price exists., One of the fixed discount prices is required|
-| \--- discountFixed| Integer| X        | Fixed discount price (0 to 999,999), discount rate when a discount price exists., One of the fixed discount prices is required|
-| \-- buttons| List| O        | Carousel list button list, minimum 1, maximum 2|
-| \--- name| String| O        | Button title<br>- For TEXT, IMAGE type, up to 14 characters<br>- For other types, up to 8 characters|
-| \--- type| String| O        | Button type (WL: web link, AL: app link, BK: bot keyword, MD: message forwarding, AC: add channel, BT: chatbot conversion, BF: Business form)<br>- BT type is available only in the channel using the chatbot of Kakao i Open Builder<br>- BF type can only be used as the first button, and only the following three phrases can be used for names:<br>&nbsp;&nbsp;- Make a reservation via KakaoTalk<br>&nbsp;&nbsp;- Take a survey via KakaoTalk<br>&nbsp;&nbsp;- Apply via KakaoTalk|
-| \--- linkMo| String| X        | Mobile web link (required for WL type), limited to 1,000 characters|
-| \--- linkPc| String| X        | PC web link (optional for WL type), limited to 1,000 characters|
-| \--- schemeAndroid| String| X        | Android app link (required for AL type), limited to 1,000 characters|
-| \--- schemeIos| String| X        | iOS app link (required for AL type), limited to 1,000 characters|
-| \--- chatExtra| String| X        | Meta information to send when the button is BT type|
-| \--- chatEvent| String| X        | Bot event name to connect when the button is BT type|
-| \--- bizFormKey| String| X        | BizForm key when the button is BF type|
-| \-- coupon| Object| X        | Coupon elements|
-| \--- title| String| O        | Limited to 5 formats for titles<br>- "${number} won discount coupon" number is 1 or greater and 99,999,999 or less<br>- "${number}% discount coupon" number is 1 or greater and 100 or less<br>- "Shipping discount coupon"<br>- "${within 7 characters} free coupon"<br>- "${within 7 characters} UP coupon"|
-| \--- description| String| O        | Coupon details<br>- For WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO type, up to 18, linebreak: unavailable<br>- For other types, up to 12 characters, linebreak: unavailable|
-| \--- linkMo| String| X        | Mobile web link (required for WL type), limited to 1,000 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \--- linkPc| String| X        | PC web link (optional for WL type), limited to 1,000 characters|
-| \--- schemeAndroid| String| X        | Android app link (required for AL type), limited to 1,000 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \--- schemeIos| String| X        | iOS app link (required field for AL type), limited to 1,000 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \- tail| Object| X        | More button information|
-| \-- linkMo| String| O        | Mobile web link, limited to 1,000 characters|
-| \-- linkPc| String| X        | PC web link, limited to 1,000 characters|
-| \-- schemeAndroid| String| X        | Android app link, limited to 1,000 characters|
-| \-- schemeIos| String| X        | iOS app link, limited to 1,000 characters|
-| recipientList| List| O        | Recipient list (up to 1,000)|
-| \- recipientNo| String| O        | Incoming number|
-| \- resendParameter| Object| X        | Fallback Information|
-| \-- isResend| boolean| X        | Fallback text status if sending fails<br>When setting up fallbacks in the console, fallbacks will be sent by default.|
-| \-- resendType| String| X        | Fallback type (SMS, LMS)<br>If no value exists, types are distinguished according to the length of the template body.|
-| \-- resendTitle| String| X        | LMS fallback title<br>(if no value exists, it will be replaced with PlusFriend ID.)|
-| \-- resendContent| String| X        | Fallback title<br>(if no value exists, it will be replaced with [message body].)|
-| \-- resendSendNo| String| X        | Fallback number<br><span style="color:red">(if the outgoing number is not registered with the SMS service, the fallback may fail.)</span>|
-| \- targeting| String| X        | Type of message target (M: User with marketing consent, N: only users that agreed to marketing consent and are not friends, I: users who are friends)|
-| \- unsubscribeNo| String| X        | 080 toll-free opt-out phone number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx|
-| \- unsubscribeAuthNo| String| X        | 080 toll-free opt-out verification number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>unsubscribeAuthNo cannot be entered without unsubscribeNo<br>ex) 1234|
-| \- recipientGroupingKey| String| X        | Recipient grouping key (you can specify grouping keys by recipient. Up 100 characters)|
-| senderGroupingKey| String| X        | Sender grouping key (you can specify grouping keys by sender. Up 100 characters)|
-| resellerCode| String| X        | Reseller code (used by resellers when sending)|
-| createUser| String| X        | Registrant (stored as user UUID when sent from console)|
-| statsId| String| X        | Statistics ID (not included in the outgoing search conditions, up to 8 characters)|
+| Name                   | Type      | Required | Description                                                                                                                                                                                                                                                                            |
+|----------------------|---------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| senderKey            | String  | O  | Sender key (40 characters), group sender key not available                                                                                                                                                                                                                                                       |
+| chatBubbleType       | String  | O  | Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)                                                                                                                                                                         |
+| pushAlarm            | boolean | X  | Whether to send a message push alarm (default: true)                                                                                                                                                                                                                                                   |
+| requestDate          | String  | X  | Date and time of request (yyyy-MM-dd HH:mm)<br>(to be sent immediately if not entered)<br>Can be scheduled up to 60 days in advance                                                                                                                                                                                                                                                   |
+| unsubscribeNo       | String  | X  | 080 opt-out toll-free number (if none is entered, the opt-out information registered in the Sender Profile is used)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx         |
+| unsubscribeAuthNo   | String  | X  | 080 opt-out authentication number (up to 10 characters; if none is entered, the opt-out information registered in the Sender Profile is used)<br>Cannot enter unsubscribeAuthNo without unsubscribeNo<br>Example: 1234        |
+| adult                | boolean | X  | Whether the message is for adults (default: false)                                                                                                                                                                                                                                                       |
+| carousel             | Object  | O  | Carousel                                                                                                                                                                                                                                                                           |
+| - head               | Object  | X  | Carousel intro                                                                                                                                                                                                                                                                       |
+| -- header            | String  | O  | Carousel intro header (up to 20 characters)                                                                                                                                                                                                                                            |
+| -- content           | String  | O  | Carousel intro content (up to 50 characters)                                                                                                                                                                                                                                            |
+| -- imageUrl          | String  | O  | Carousel intro image URL (must use an image uploaded as a Carousel Commerce type image; the image ratio must match that of the carousel images)                                                                                                                                                                                                                    |
+| -- linkMo            | String  | X  | Mobile web link (required if any of linkMo, linkPc, schemeAndroid, or schemeIos is used), up to 1,000 characters                                                                                                                                                                                    |
+| -- linkPc            | String  | X  | PC web link, up to 1,000 characters                                                                                                                                                                                                                                           |
+| -- schemeAndroid     | String  | X  | Android app link, up to 1,000 characters                                                                                                                                                                                                                                         |
+| -- schemeIos         | String  | X  | iOS app link, up to 1,000 characters                                                                                                                                                                                                                                           |
+| - list               | List    | O  | Carousel list (minimum 1, maximum 5 if head exists; otherwise minimum 2, maximum 6)                                                                                                                                                                                                                      |
+| -- additionalContent | String  | X  | Additional information (up to 34 characters), available only for Carousel Commerce type                                                                                                                                                                                                                                              |
+| -- imageUrl          | String  | O  | Image URL (must use an image uploaded as a Carousel Commerce type image)                                                                                                                                                                                                                                           |
+| -- imageLink         | String  | X  | Image link, up to 1,000 characters                                                                                                                                                                                                                                              |
+| -- commerce          | Object  | O  | Commerce (available only for CAROUSEL_COMMERCE type)                                                                                                                                                                                                                                           |
+| --- title            | String  | O  | Product title (up to 30 characters, line breaks not allowed)                                                                                                                                                                                                                                                       |
+| --- regularPrice     | Integer | O  | Regular price (0–99,999,999)                                                                                                                                                                                                                                                        |
+| --- discountPrice    | Integer | X  | Discounted price (0–99,999,999)                                                                                                                                                                                                                                                          |
+| --- discountRate     | Integer | X  | Discount rate (0–100); if a discounted price exists, either the discount rate or the fixed discount price is required                                                                                                                                                                                                                                   |
+| --- discountFixed    | Integer | X  | Fixed discount price (0–999,999); if a discounted price exists, either the discount rate or the fixed discount price is required                                                                                                                                                                                                                            |
+| -- buttons           | List    | O  | Carousel list button list: minimum 1, maximum 2                                                                                                                                                                                                                                                    |
+| --- name             | String  | O  | Button title<br>- Up to 14 characters for TEXT and IMAGE types<br>- Up to 8 characters for all other types                                                                                                                                                                                                                    |
+| --- type             | String  | O  | Button type (WL: Web Link, AL: App Link, BK: Bot Keyword, MD: Message Delivery, AC: Add Channel, BT: Chatbot Transfer, BF: Business Form)<br>- The BT type is available only for channels that use a chatbot from Kakao Open Builder<br>- The BF type can only be used as the first button, and only the following three phrases are allowed for name:<br>  - 톡에서 예약하기<br>  - 톡에서 설문하기<br>  - 톡에서 응모하기 |
+| --- linkMo           | String  | X  | Mobile web link (required for the WL type), up to 1,000 characters                                                                                                                                                                                                                                         |
+| --- linkPc           | String  | X  | PC web link (optional for the WL type), 1,000-character limit                                                                                                                                                                                                                                                          |
+| --- schemeAndroid    | String  | X  | Android app link (required for the AL type), 1,000-character limit                                                                                                                                                                                                                                                       |
+| --- schemeIos        | String  | X  | iOS app link (required for the AL type), 1,000-character limit                                                                                                                                                                                                                                                         |
+| --- chatExtra        | String  | X  | Metadata to pass for BT type buttons                                                                                                                                                                                                                                                                         |
+| --- chatEvent        | String  | X  | Bot event name to connect for BT type buttons                                                                                                                                                                                                                                                                       |
+| --- bizFormKey       | String  | X  | Biz form key for BF type buttons                                                                                                                                                                                                                                                                                            |
+| -- coupon            | Object  | X  | Coupon element                                                                                                                                                                                                                                                                                         |
+| --- title            | String  | O  | For title, you are limited to five types:<br>- "${number}KRW off coupon" with a number greater than or equal to 1 and less than or equal to 99,999,999<br>- "${number}% off coupon" with a number greater than or equal to 1 and less than or equal to 100<br>- "Shipping discount coupon"<br>- "${7 characters} Free coupon"<br>- "${7 characters} UP coupon"                                                                                                            |
+| --- description      | String  | O  | Coupon detail description<br>- For WIDE, WIDE_ITEM_LIST, and PREMIUM_VIDEO types: up to 18 characters, line breaks not allowed<br>- For all other types: up to 12 characters, line breaks not allowed                                                                                                                                                                      |
+| --- linkMo           | String  | X  | Mobile web link (required for the WL type), 1,000-character limit<br>If the linkMo field is entered for a coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional.                                                                                   |
+| --- linkPc           | String  | X  | PC web link (optional for the WL type), 1,000-character limit                                                                                                                                                                                                                                                          |
+| --- schemeAndroid    | String  | X  | Android app link (required for the AL type), 1,000-character limit<br>If the linkMo field is entered for a coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional.                                                                                 |
+| --- schemeIos        | String  | X  | iOS app link (required for the AL type), 1,000-character limit<br>If the linkMo field is entered for a coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional.                                                                                   |
+| - tail               | Object  | X  | View More button information                                                                                                                                                                                                                                                                                     |
+| -- linkMo            | String  | O  | Mobile web link, 1,000-character limit                                                                                                                                                                                                                                                                           |
+| -- linkPc            | String  | X  | PC web link, 1,000-character limit                                                                                                                                                                                                                                                                            |
+| -- schemeAndroid     | String  | X  | Android app link, 1,000-character limit                                                                                                                                                                                                                                                                         |
+| -- schemeIos         | String  | X  | iOS app link, 1,000-character limit                                                                                                                                                                                                                                                                           |
+| recipientList        | List    | O  | List of recipients (up to 1,000)                                                                                                                                                                                                                                                                             |
+| - recipientNo        | String  | O  | Recipient number                                                                                                                                                                                                                                                                                         |
+| - resendParameter    | Object  | X  | Alternative delivery information                                                                                                                                                                                                                                                                                      |
+| -- isResend          | boolean | X  | Whether to send as an SMS alternative if delivery fails<br>If alternative delivery is configured in the console, it is sent as an alternative by default.                                                                                                                                                                                                                       |
+| -- resendType        | String  | X  | Alternative delivery type (SMS, LMS)<br>Categorized by the length of template body, if value is unavailable.                                                                                                                                                                                                                       |
+| -- resendTitle       | String  | X  | Title for LMS alternative delivery<br>(resent with PlusFriend ID if value is unavailable.)                                                                                                                                                                                                                               |
+| -- resendContent     | String  | X  | Alternative delivery content<br>(If value is unavailable, the [message body] is used for alternative delivery.)                                                                                                                                                                                                                                  |
+| -- resendSendNo      | String  | X  | Sender number for alternative delivery<br><span style="color:red">(Fallback may fail, if the sender number is not registered on the SMS service.)</span>                                                                                                                                                                                 |
+| - targeting         | String  | X  | Type of message target (M: users who agreed to receive marketing messages, N: users who agreed to receive marketing messages but are not friends, I: users who are friends)                                                                |
+| - unsubscribeNo       | String  | X  | 080 opt-out phone number (if none is entered, the opt-out information registered in the Sender Profile is used)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx         |
+| - unsubscribeAuthNo   | String  | X  | 080 opt-out authentication number (up to 10 characters; if none is entered, the opt-out information registered in the Sender Profile is used)<br>Cannot enter unsubscribeAuthNo without unsubscribeNo<br>Example: 1234        |
+| - recipientGroupingKey | String  | X  | Recipient grouping key (you can specify a grouping key per recipient, up to 100 characters)                                                                                                                                                                                                                   |
+| senderGroupingKey    | String  | X  | Sender grouping key (you can specify a grouping key per sender, up to 100 characters)                                                                                                                                                                                                                   |
+| resellerCode          | String  | X  | Reseller code (used when a reseller sends messages)                                                                                                                                                                                                                                                                       |
+| createUser           | String  | X  | Registrant (saved as the user UUID when sending from the console)                                                                                                                                                                                                                                                   |
+| statsId              | String  | 	X | Statistics ID (not included in the delivery search conditions, up to 8 characters)                                                                                                                                                                                                                                            |
 
 <a id="response-3"></a>
 
@@ -1273,61 +1274,61 @@ Allow unique placeholder values for each item in a carousel-type template.
 }
 ```
 
-| Name| Type| Not Null| Description|
-|:----------|:----------|:----------|:----------|
-| header| Object| O| Response header info|
-| \- isSuccessful| boolean| O| Successful API call status|
-| \- resultCode| Integer| O| API call result code (success: 0, error code for failure)|
-| \- resultMessage| String| O| API call result message ("success" or a related success message on success, detailed message on failure, cause on failure)|
-| message| Object| X| message sending result information (exists only if there is a send request)|
-| \- requestId| String| X| Sending request ID (an ID that uniquely identifies each sending request)|
-| \- sendResults| Array| O| List of sending results by recipient|
-| \-- recipientSeq| Integer| O| Number in the recipient list|
-| \-- recipientNo| String| X| Recipient’s phone number|
-| \-- resultCode| Integer| O| Recipient-specific sending result code (success and various failure codes may exist)|
-| \-- resultMessage| String| O| Recipient-specific sending result message ("success" or a related message on success, detailed message on failure, cause on failure)|
+| Name               | Type      | Not Null | Description                                                           |
+|:-----------------|:--------|:---------|:-------------------------------------------------------------|
+| header           | Object  | O        | Response header information                                                     |
+| - isSuccessful   | boolean | O        | Whether the API call was successful                                                 |
+| - resultCode     | Integer | O        | API call result code (0 on success, error code on failure)                           |
+| - resultMessage  | String  | O        | API call result message ("success" or a related success message on success, detailed failure message on failure)  |
+| message          | Object  | X        | Message delivery result information (exists only when a delivery request is made)                             |
+| - requestId      | String  | X        | Delivery request ID (a unique ID that identifies each delivery request)                             |
+| - sendResults    | Array   | O        | List of delivery results per recipient                                                |
+| -- recipientSeq  | Integer | O        | Sequence number in the recipient list                                                   |
+| -- recipientNo   | String  | X        | Recipient phone number                                                     |
+| -- resultCode    | Integer | O        | Delivery result code per recipient (may include success and various failure codes)                     |
+| -- resultMessage | String  | O        | Delivery result message per recipient ("success" or a related message on success, detailed failure message on failure) |
 
 <a id="request-to-send-basic-message"></a>
 
-## Request to send basic message
+## Send Basic Message Request
 
-* A sending using a template.
+* This delivery uses a template.
 * Marketing consent-based sending can be used.
-   * You can specify the type of message target by specifying the targeting field.
-       * M: Users who agree to receive advertising information from the client company (KakaoTalk message consent)
-       * N: Users who agree to receive advertising information from the client company - Channel friend
-       * I: Target of customer sending request ∩ Channel friend
-* You can use all 8 message types of the existing FriendTalk.
-* You cannot use BT button types.
-* You can use Add Channel (AC) button.
-* When using the BF button, you can upload the Business Form ID issued by Kakao and receive and use a BizForm key.
-* Fallback can be set with resendParameter for each recipient.
-  * When using fallback, you need to register the SMS Appkey and set its send with the fallback management API.
-* **Nighttime delivery restrictions(8:50 PM - 8:00 AM the next day)**
+    * You can specify the message target type by setting the targeting field.
+        * M: Users who have consented to receive advertising information from the customer company (KakaoTalk consent)
+        * N: Users who have consented to receive advertising information from the customer company (KakaoTalk consent) — channel friends
+        * I: Intersection of the customer company's requested delivery targets ∩ channel friends
+* All 8 message types from the existing FriendTalk can be used.
+* The BT button type cannot be used.
+* The AC (Add Channel) button can be used.
+* When using the BF button, you can upload the business form ID issued by Kakao to receive a BizForm key and use it.
+* Alternative delivery can be configured per recipient using resendParameter.
+    * To use alternative delivery, you must register an SMS AppKey and configure delivery settings via the Alternative Delivery Management API.
+* **Delivery restricted during night (20:50~08:00 on the following day)**
 
 <a id="cautions-for-use"></a>
 
-### Cautions for use
+### Notes on Usage
 
-- unsubscribeNo and unsubscribeAuthNo are the 080 toll-free opt-out phone number and verification number. If either one is not entered, the message will be sent using the toll-free opt-out information registered in the outgoing profile.
-- If you enter unsubscribeNo or unsubscribeAuthNo between deliveries, the message will be sent using the entered values, not the toll-free opt-out information registered in the outgoing profile.
-- If you do not enter unsubscribeNo or unsubscribeAuthNo between deliveries, the message will be sent using the toll-free opt-out information registered in the outgoing profile.
-- unsubscribeNo, unsubscribeAuthNo can be entered by recipient. When entering both common fields and recipient-specific fields, the common fields take precedence.
+- `unsubscribeNo` and `unsubscribeAuthNo` are the 080 toll-free opt-out phone number and authentication number. If either one is not entered, the message will be sent using the opt-out information registered in the Sender Profile.
+- If you enter `unsubscribeNo` and `unsubscribeAuthNo` when sending, the message will be sent using the entered values instead of the opt-out information registered in the Sender Profile.
+- If you do not enter `unsubscribeNo` and `unsubscribeAuthNo` when sending, the message will be sent using the opt-out information registered in the Sender Profile.
+- `unsubscribeNo` and `unsubscribeAuthNo` can be entered per recipient. If both the common field and the per-recipient field are entered, the common field takes priority.
 
-\[URL]
+[URL]
 
 ```
 POST  /brand-message/v1.0/appkeys/{appkey}/basic-messages
 Content-Type: application/json;charset=UTF-8
 ```
 
-\[Path parameter]
+[Path Parameter]
 
-| Name| Type| Description|
-|----------|----------|----------|
-| appkey| String| Unique appkey|
+| Name | Type | Description |
+|--------|--------|--------|
+| appkey | String | Unique app key |
 
-\[Header]
+[Header]
 
 ```
 {
@@ -1335,13 +1336,13 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| X-Secret-Key| String| O| Available to create from the console.|
+| Name | Type | Required | Description |
+|--------------|--------|----|------------------|
+| X-Secret-Key | String | O | Can be created in the console. |
 
 <a id="requested-4"></a>
 
-#### Requested
+#### Delivery Request
 
 ```
 {
@@ -1378,34 +1379,37 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|--------------------------------------------------------------------------------------------------------------------|
-| senderKey| String| O| Outgoing key (40 characters), group outgoing key unavailable|
-| templateCode| String| O| Template code to use|
-| pushAlarm| boolean| X| Sending status for message push notifications (defaults: true)|
-| requestDate| String| X| Requested date (yyyy-MM-dd HH:mm)<br>(send immediately if not entered)<br>Available to schedule up to 60 days in advance|
-| unsubscribeNo| String| X| 080 toll-free opt-out phone number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx                                                                                 |
-| unsubscribeAuthNo| String| X| 080 toll-free opt-out verification number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>unsubscribeAuthNo cannot be entered without unsubscribeNo<br>ex) 1234                                                                                 |
-| recipientList| List| O| Recipient list (up to 1,000)|
-| \- recipientNo| String| O| Incoming number|
-| \- targeting| String| O| Type of message target (M: User with marketing consent, N: only users that agreed to marketing consent and are not friends, I: users who are friends)|
-| \- templateParameter| Object| X| Template parameter (required if including variables to be replaced in the template)<br>- carousel type: Use `key@$.carousel.list[Index]` to apply unique placeholder values per item (e.g., `productName@$.carousel.list[0]`)<br>- If a head is present, it occupies list[0]; actual items start from list[1]<br>- `@` character is prohibited in placeholder keys<br>- Max 1,300 characters each for key and value|
-| \- imageParameters| List| X| Dynamic parameters that can change the template image field value, carousel type is currently not supported (only JSON list with the same size as the number of images in the template can be used. If used, images that do not want to be changed must be entered as an empty JSON object)                                                 |
-| \-- imageUrl| String| O| Image URL |
-| \-- imageLink| String| X| Image link|
-| \- resendParameter| Object| X| Fallback Information|
-| \-- isResend| boolean| X| Fallback text status if sending fails<br>When setting up fallbacks in the console, fallbacks will be sent by default.|
-| \-- resendType| String| X| Fallback type (SMS, LMS)<br>If no value exists, types are distinguished according to the length of the template body.|
-| \-- resendTitle| String| X| LMS fallback title<br>(if no value exists, it will be replaced with PlusFriend ID.)|
-| \-- resendContent| String| X| Fallback title<br>(if no value exists, it will be replaced with [message body].)|
-| \-- resendSendNo| String| X| Fallback number<br><span style="color:red">(if the outgoing number is not registered with the SMS service, the fallback may fail.)</span>|
-| \- unsubscribeNo| String| X| 080 toll-free opt-out phone number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx                                                                                   |
-| \- unsubscribeAuthNo| String| X| 080 toll-free opt-out verification number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>unsubscribeAuthNo cannot be entered without unsubscribeNo<br>ex) 1234                                                                                   |
-| \- recipientGroupingKey| String| X| Recipient grouping key (you can specify grouping keys by recipient. Up 100 characters)|
-| senderGroupingKey| String| X| Sender grouping key (you can specify grouping keys by sender. Up 100 characters)|
-| resellerCode| String| X| Reseller code (used by resellers when sending)|
-| createUser| String| X| Registrant (stored as user UUID when sent from console)|
-| statsId| String| X| Statistics ID (not included in the outgoing search conditions, up to 8 characters)|
+| Name | Type | Required | Description |
+|------------------------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| senderKey              | String  | O  | Sender key (40 characters); group sender keys are not allowed |
+| templateCode           | String  | O  | Template code to use |
+| pushAlarm              | boolean | X  | Whether to send a message push notification (default: true) |
+| requestDate            | String  | X  | Date and time of request (yyyy-MM-dd HH:mm)<br>(to be sent immediately if not entered)<br>Can be scheduled up to 60 days in advance |
+| unsubscribeNo          | String  | X  | 080 free opt-out phone number (if all fields are left blank, the opt-out information registered in the Sender Profile is used for delivery)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx |
+| unsubscribeAuthNo      | String  | X  | 080 free opt-out authentication number (up to 10 characters; if all fields are left blank, the opt-out information registered in the Sender Profile is used for delivery)<br>Cannot enter unsubscribeAuthNo without unsubscribeNo<br>Example: 1234 |
+| recipientList          | List    | O  | List of recipients (up to 1,000) |
+| - recipientNo          | String  | O  | Recipient number |
+| - targeting            | String  | O  | Type of message target (M: users who agreed to receive marketing messages, N: users who are not friends but agreed to receive marketing messages only, I: users who are friends) |
+| - templateParameter    | Object  | X  | Template parameter (required if the template contains variables to replace)<br>- Carousel type: use the format `key@$.carousel.list[index]` to apply different replacement values per item (e.g., `productName@$.carousel.list[0]`)<br>- If a head exists, head occupies list[0] and actual items start from list[1]<br>- The `@` character cannot be used in replacement variable keys<br>- Up to 1,300 characters each for key and value |
+| - imageParameters      | List    | X  | Dynamic parameters for changing template image field values (only a JSON list of the same size as the number of images in the template can be used; if used, an empty JSON object must be entered for images that are not to be changed) |
+| -- imageUrl            | String  | O  | Image URL |
+| -- imageLink           | String  | X  | Image link |
+| - videoParameter       | Object  | X  | Dynamic parameters for changing template video field values |
+| -- videoUrl            | String  | O  | KakaoTV video URL |
+| -- thumbnailUrl        | String  | X  | Image URL for video thumbnail |
+| - resendParameter      | Object  | X  | Alternative delivery information |
+| -- isResend            | boolean | X  | Whether to send the message as an alternative delivery if sending fails<br>If alternative delivery is configured in the console, it is sent as alternative delivery by default. |
+| -- resendType          | String  | X  | Alternative delivery type (SMS, LMS)<br>Categorized by the length of template body, if value is unavailable. |
+| -- resendTitle         | String  | X  | LMS alternative delivery title<br>(resent with PlusFriend ID if value is unavailable.) |
+| -- resendContent       | String  | X  | Alternative delivery content<br>(If value is unavailable, the [message body] is used for alternative delivery.) |
+| -- resendSendNo        | String  | X  | Sender number for alternative delivery<br><span style="color:red">(Fallback may fail, if the sender number is not registered on the SMS service.)</span> |
+| - unsubscribeNo        | String  | X  | 080 free opt-out phone number (if all fields are left blank, the opt-out information registered in the Sender Profile is used for delivery)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx |
+| - unsubscribeAuthNo    | String  | X  | 080 free opt-out authentication number (up to 10 characters; if all fields are left blank, the opt-out information registered in the Sender Profile is used for delivery)<br>Cannot enter unsubscribeAuthNo without unsubscribeNo<br>Example: 1234 |
+| - recipientGroupingKey | String  | X  | Recipient grouping key (a grouping key can be specified per recipient; up to 100 characters) |
+| senderGroupingKey      | String  | X  | Sender grouping key (a grouping key can be specified per sender; up to 100 characters) |
+| resellerCode           | String  | X  | Reseller code (used when a reseller sends a message) |
+| createUser             | String  | X  | Registrant (saved as user UUID when sending from console) |
+| statsId                | String  | X  | Statistics ID (not included in the delivery search conditions, up to 8 characters) |
 
 <a id="response-4"></a>
 
@@ -1432,42 +1436,42 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Not Null| Description|
-|:----------|:----------|:----------|:----------|
-| header| Object| O| Response header info|
-| \- isSuccessful| boolean| O| Successful API call status|
-| \- resultCode| Integer| O| API call result code (success: 200, error code for failure)|
-| \- resultMessage| String| O| API call result message ("success" or a related success message on success, detailed message on failure, cause on failure)|
-| message| Object| X| Message sending result information (exists only if there is a sending request)|
-| \- requestId| String| X| Sending request ID (an ID that uniquely identifies each sending request)|
-| \- sendResults| Array| O| List of sending results by recipient|
-| \-- recipientSeq| Integer| O| Number in the recipient list|
-| \-- recipientNo| String| X| Recipient’s phone number|
-| \-- resultCode| Integer| O| Recipient-specific sending result code (success and various failure codes may exist)|
-| \-- resultMessage| String| O| Recipient-specific sending result message ("success" or a related message on success, detailed message on failure, cause on failure)|
+| Name               | Type      | Not Null | Description                                                                                                             |
+|:-----------------|:--------|:---------|:-------------------------------------------------------------|
+| header           | Object  | O        | Response header information                                                                                             |
+| - isSuccessful   | boolean | O        | Whether the API call was successful                                                                                     |
+| - resultCode     | Integer | O        | API call result code (success: 0, error code on failure)                                                                |
+| - resultMessage  | String  | O        | API call result message ("success" or a related success message on success, detailed failure reason on failure)         |
+| message          | Object  | X        | Message delivery result information (present only if a delivery request was made)                                       |
+| - requestId      | String  | X        | Delivery request ID (a unique identifier for each delivery request)                                                     |
+| - sendResults    | Array   | O        | List of delivery results per recipient                                                                                  |
+| -- recipientSeq  | Integer | O        | Sequence number in the recipient list                                                                                   |
+| -- recipientNo   | String  | X        | Recipient phone number                                                                                                  |
+| -- resultCode    | Integer | O        | Delivery result code per recipient (may include success and various failure codes)                                      |
+| -- resultMessage | String  | O        | Delivery result message per recipient ("success" or a related message on success, detailed failure reason on failure)   |
 
 <a id="view-sending-list"></a>
 
-## View sending list
+## List Deliveries
 
 <a id="requested-5"></a>
 
-#### Requested
+#### Request
 
-\[URL]
+[URL]
 
 ```
 GET  /brand-message/v1.0/appkeys/{appkey}/messages
 Content-Type: application/json;charset=UTF-8
 ```
 
-\[Path parameter]
+[Path parameter]
 
-| Name| Type| Description|
-|----------|----------|----------|
-| appkey| String| Unique appkey|
+| Name   | Type   | Description    |
+|--------|--------|----------------|
+| appkey | String | Unique app key |
 
-\[Header]
+[Header]
 
 ```
 {
@@ -1475,26 +1479,26 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| X-Secret-Key| String| O| Available to create from the console.|
+| Name         | Type   | Required | Description                          |
+|--------------|--------|----------|--------------------------------------|
+| X-Secret-Key | String | O        | Can be created in the console. |
 
-[Query parameter] Condition 1 or 2 required
+[Query parameter] No.1 or No.2 is conditionally required
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| requestId| String| Condition required (1)| Request ID|
-| startRequestDate| String| Condition required (2)| Start value of the sending request date (yyyy-MM-dd HH:mm)|
-| endRequestDate| String| Condition required (2)| End value of the sending request date (yyyy-MM-dd HH:mm)|
-| senderKey| String| X| Outgoing Key|
-| templateCode| String| X| Template Code|
-| recipientNo| String| X| Incoming number|
-| messageStatus| String| X| Request status (COMPLETED: success, FAILED: failure)|
-| resultCode| String| X| Sending result (MRC01: Success MRC02: failure )|
-| senderGroupingKey| String| X| Outgoing grouping key|
-| recipientGroupingKey| String| X| Recipient grouping key|
-| pageNum| String| X| Page number (default: 1\)|
-| pageSize| String| X| Number of views (default: 15, Max: 1,000)|
+| Name                 | Type   | Required              | Description                                                  |
+|----------------------|--------|-----------------------|--------------------------------------------------------------|
+| requestId            | String | Conditionally required (No.1) | Request ID                                                   |
+| startRequestDate     | String | Conditionally required (No.2) | Start date of delivery request (yyyy-MM-dd HH:mm)            |
+| endRequestDate       | String | Conditionally required (No.2) | End date of delivery request (yyyy-MM-dd HH:mm)              |
+| senderKey            | String | X                     | Sender Key                                                   |
+| templateCode         | String | X                     | Template Code                                                |
+| recipientNo          | String | X                     | Recipient number                                             |
+| messageStatus        | String | X                     | Request status (COMPLETED: success, FAILED: failure)         |
+| resultCode           | String | X                     | Delivery result (MRC01: success, MRC02: failure)             |
+| senderGroupingKey    | String | X                     | Sender grouping key                                          |
+| recipientGroupingKey | String | X                     | Recipient grouping key                                       |
+| pageNum              | String | X                     | Page number (Default: 1)                                     |
+| pageSize             | String | X                     | Number of results (Default: 15, Max: 1000)                   |
 
 <a id="response-5"></a>
 
@@ -1540,63 +1544,63 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Not Null| Description|
-|:----------|:----------|:----------|:----------|
-| header| Object| O| Header zone|
-| \- resultCode| Integer| O| Result code|
-| \- resultMessage| String| O| Result message|
-| \- isSuccessful| boolean| O| Success status|
-| messageSearchResultResponse| Object| X| Body area|
-| \- messages| Array| O| Message list|
-| \-- requestId| String| O| Request ID|
-| \-- recipientSeq| Integer| O| Recipient sequence number|
-| \-- plusFriendId| String| O| Outgoing profile ID|
-| \-- senderKey| String| O| Outgoing Key|
-| \-- templateCode| String| X| Template Code|
-| \-- recipientNo| String| O| Incoming number|
-| \-- targeting| String| O| Type of message target (M: User with marketing consent, N: only users that agreed to marketing consent and are not friends, I: users who are friends)|
-| \-- requestDate| String| O| Requested date (yyyy-MM-dd HH:mm)<br>(send immediately if not entered)<br>Available to schedule up to 60 days in advance|
-| \-- createDate| String| O| Registered on|
-| \-- receiveDate| String| X| Received on|
-| \-- chatBubbleType| String| O| Message type|
-| \-- pushAlarm| boolean| O| Push notification status|
-| \-- messageStatus| String| O| Request status (COMPLETED: success, FAILED: failure)|
-| \-- resendStatusCode| String| X| Fallback status code|
-| \-- resendStatusName| String| X| Fallback status name|
-| \-- resendResultCode| String| X| Fallback result code|
-| \-- resendRequestId| String| X| Fallback request ID|
-| \-- isAddedChannel| boolean| O| Channel friend status|
-| \-- resultCode| String| X| Received result code|
-| \-- resultCodeName| String| X| Received result code name|
-| \-- createUser| String| X| Registrant (stored as user UUID when sent from console)|
-| \-- senderGroupingKey| String| X| Outgoing grouping key|
-| \-- recipientGroupingKey| String| X| Recipient grouping key|
-| \- totalCount| Integer| O| Total|
+| Name                        | Type    | Not Null | Description                                                                                                                  |
+|:----------------------------|:--------|:---------|:-----------------------------------------------------------------------------------------------------------------------------|
+| header                      | Object  | O        | Header area                                                                                                                  |
+| - resultCode                | Integer | O        | Result code                                                                                                                  |
+| - resultMessage             | String  | O        | Result message                                                                                                               |
+| - isSuccessful              | boolean | O        | Success                                                                                                                      |
+| messageSearchResultResponse | Object  | X        | Body area                                                                                                                    |
+| - messages                  | Array   | O        | Message list                                                                                                                 |
+| -- requestId                | String  | O        | Request ID                                                                                                                   |
+| -- recipientSeq             | Integer | O        | Recipient sequence number                                                                                                    |
+| -- plusFriendId             | String  | O        | Sender Profile ID                                                                                                            |
+| -- senderKey                | String  | O        | Sender Key                                                                                                                   |
+| -- templateCode             | String  | X        | Template Code                                                                                                                |
+| -- recipientNo              | String  | O        | Recipient number                                                                                                             |
+| -- targeting                | String  | O        | Target type of message (M: users who agreed to receive marketing messages, N: users who are not friends but agreed to receive marketing messages, I: users who are friends) |
+| -- requestDate              | String  | O        | Date and time of request (yyyy-MM-dd HH:mm)<br>(to be sent immediately if not entered)<br>Can be scheduled up to 60 days in advance |
+| -- createDate               | String  | O        | Date and time of registration                                                                                                |
+| -- receiveDate              | String  | X        | Date and time of receipt                                                                                                     |
+| -- chatBubbleType           | String  | O        | Message type                                                                                                                 |
+| -- pushAlarm                | boolean | O        | Whether push alarm is used                                                                                                   |
+| -- messageStatus            | String  | O        | Request status (COMPLETED: success, FAILED: failure)                                                                         |
+| -- resendStatusCode         | String  | X        | Alternative delivery status code                                                                                             |
+| -- resendStatusName         | String  | X        | Alternative delivery status name                                                                                             |
+| -- resendResultCode         | String  | X        | Alternative delivery result code                                                                                             |
+| -- resendRequestId          | String  | X        | Alternative delivery request ID                                                                                              |
+| -- isAddedChannel           | boolean | O        | Whether the user is a channel friend                                                                                         |
+| -- resultCode               | String  | X        | Receipt result code                                                                                                          |
+| -- resultCodeName           | String  | X        | Receipt result code name                                                                                                     |
+| -- createUser               | String  | X        | Registrant (saved as user UUID when sending from console)                                                                    |
+| -- senderGroupingKey        | String  | X        | Sender grouping key                                                                                                          |
+| -- recipientGroupingKey     | String  | X        | Recipient grouping key                                                                                                       |
+| - totalCount                | Integer | O        | Total count                                                                                                                  |
 
 <a id="view-single-sending"></a>
 
-## View single sending
+## Get Delivery
 
 <a id="requested-6"></a>
 
-#### Requested
+#### Request
 
-\[URL]
+[URL]
 
 ```
 GET  /brand-message/v1.0/appkeys/{appkey}/messages/{requestId}/{recipientSeq}
 Content-Type: application/json;charset=UTF-8
 ```
 
-\[Path parameter]
+[Path parameter]
 
-| Name| Type| Description|
-|----------|----------|----------|
-| appkey| String| Unique appkey|
-| requestId| String| Request ID|
-| recipientSeq| Integer| Recipient sequence number|
+| Name           | Type      | Description              |
+|--------------|---------|------------|
+| appkey       | String  | Unique app key     |
+| requestId    | String  | Request ID      |
+| recipientSeq | Integer | Recipient sequence number |
 
-\[Header]
+[Header]
 
 ```
 {
@@ -1604,9 +1608,9 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| X-Secret-Key| String| O| Available to create from the console.|
+| Name           | Type     | Required | Description               |
+|--------------|--------|----|------------------|
+| X-Secret-Key | String | O  | Can be created in the console. |
 
 <a id="response-6"></a>
 
@@ -1754,163 +1758,144 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Not Null| Description|
-|:----------|:----------|:----------|:----------|
-| header| Object| O| Header zone|
-| \- resultCode| Integer| O| Result code|
-| \- resultMessage| String| O| Result message|
-| \- isSuccessful| boolean| O| Success status|
-| message| Object| X| Message body area (May not be present when the message fails)|
-| \- requestId| String| O| Request ID (Not Null if message object exists)|
-| \- recipientSeq| Integer| O| Recipient sequence number (Not Null if message object exists)|
-| \- plusFriendId| String| O| Outgoing profile ID (Not Null if message object exists)|
-| \- senderKey| String| O| Outgoing key (Not Null if message object exists)|
-| \- templateCode| String| X| Template Code|
-| \- recipientNo| String| O| Incoming number (Not Null if message object exists)|
-| \- targeting| String| O| Type of message target (M: User with marketing consent, N: only users that agreed to marketing consent and are not friends, I: users who are friends) (Not Null if message object exists)|
-| \- requestDate| String| O| Requested date (yyyy-MM-dd HH:mm)<br>(send immediately if not entered)<br>Available to schedule up to 60 days in advance (Not Null if message object exists)|
-| \- createDate| String| O| Registered on (Not Null if message object exists)|
-| \- receiveDate| String| X| Received on|
-| \- chatBubbleType| String| O| Message type (Not Null if message object exists)|
-| \- content| String| X| Message Content|
-| \- adult| boolean| O| Message status for adults (Not Null if message object exists)|
-| \- header| String| X| Header (within message)|
-| \- additionalContent| String| X| Additional info (within message)|
-| \- image| Object| X| Image elements|
-| \-- imageUrl| String| O| Image URL (Not Null if image object exists)|
-| \-- imageLink| String| X| Image link|
-| \- buttons| Array| X| Button list|
-| \-- name| String| O| Button title (Not Null if button array item exists)|
-| \-- type| String| O| Button type (Not Null if button array item exists)|
-| \-- linkMo| String| X| Mobile web link|
-| \-- linkPc| String| X| PC web link|
-| \-- schemeIos| String| X| iOS app link|
-| \-- schemeAndroid| String| X| Android app link|
-| \-- chatExtra| String| X| Meta information to send when the button is BT type|
-| \-- chatEvent| String| X| Bot event name to connect when the button is BT type|
-| \-- bizFormKey| String| X| BizForm key when the button is BF type|
-| \- item| Object| X| Wide list elements|
-| \-- list| Array| X| Wide list (Nullable if item object exists)|
-| \--- title| String| X| Item title|
-| \--- imageUrl| String| O| Item image URL (Not Null if item.list item exists)|
-| \--- linkMo| String| O| Mobile web link (Not Null if item.list item exists)|
-| \--- linkPc| String| X| PC web link|
-| \--- schemeIos| String| X| iOS app link|
-| \--- schemeAndroid| String| X| Android app link|
-| \- coupon| Object| X| Coupon elements|
-| \-- title| String| O| Coupon title (Not Null if coupon object exists)|
-| \-- description| String| O| Coupon details (Not Null if coupon object exists)|
-| \-- linkMo| String| X| Mobile web link|
-| \-- linkPc| String| X| PC web link|
-| \-- schemeAndroid| String| X| Android app link|
-| \-- schemeIos| String| X| iOS app link|
-| \- commerce| Object| X| Commerce elements|
-| \-- title| String| O| Product title (Not Null if commerce object exists)|
-| \-- regularPrice| Integer| X| Regular price|
-| \-- discountPrice| Integer| X| Discount price|
-| \-- discountRate| Integer| X| Discount rate|
-| \-- discountFixed| Integer| X| Fixed discount price|
-| \- video| Object| X| Video elements|
-| \-- videoUrl| String| O| KakaoTV video URL (Not Null if video item exists)|
-| \-- thumbnailUrl| String| X| Image URL for video thumbnail|
-| \- carousel| Object| X| Carousel|
-| \-- head| Object| X| Carousel intro (Nullable if carousel object exists)|
-| \--- header| String| O| Carousel intro header (Not Null if head object exists)|
-| \--- content| String| O| Carousel intro content (Not Null if head object exists)|
-| \--- imageUrl| String| O| Carousel intro image address (Not Null if header object exists)|
-| \--- linkMo| String| X| Mobile web link|
-| \--- linkPc| String| X| PC web link|
-| \--- schemeIos| String| X| iOS app link|
-| \--- schemeAndroid| String| X| Android app link|
-| \-- list| Array| O| Carousel list (Not Null if carousel object exists)|
-| \--- header| String| X| Carousel item header|
-| \--- message| String| O| Carousel item message (Not Null if list item exists)|
-| \--- additionalContent| String| X| Additional Info|
-| \--- imageUrl| String| X| Image URL|
-| \--- imageLink| String| X| Image link|
-| \--- commerce| Object| X| Commerce (within carousel)|
-| \---- title| String| O| Product title (Not Null if carousel.list.commerce exists)|
-| \---- regularPrice| Integer| X| Regular price|
-| \---- discountPrice| Integer| X| Discount price|
-| \---- discountRate| Integer| X| Discount rate|
-| \---- discountFixed| Integer| X| Fixed discount price|
-| \--- buttons| Array| X| Button list (within carousel)|
-| \---- name| String| O| Button title (Not Null if carousel.list.buttons item exists)|
-| \---- type| String| O| Button type (Not Null if carousel.list.buttons item exists)|
-| \---- linkMo| String| X| Mobile web link|
-| \---- linkPc| String| X| PC web link|
-| \---- schemeAndroid| String| X| Android app link|
-| \---- schemeIos| String| X| iOS app link|
-| \---- chatExtra| String| X| Meta information to send when the button is BT type|
-| \---- chatEvent| String| X| Bot event name to connect when the button is BT type|
-| \---- bizFormKey| String| X| BizForm key when the button is BF type|
-| \--- coupon| Object| X| Coupon (within carousel)|
-| \---- title| String| O| Coupon title (Not Null if carousel.list.coupon exists)|
-| \---- description| String| O| Coupon details (Not Null if carousel.list.coupon exists)|
-| \---- linkMo| String| X| Mobile web link|
-| \---- linkPc| String| X| PC web link|
-| \---- schemeAndroid| String| X| Android app link|
-| \---- schemeIos| String| X| iOS app link|
-| \-- tail| Object| X| More button information (Nullable if carousel object exists)|
-| \--- linkMo| String| O| Mobile web link (Not Null if tail object exists)|
-| \--- linkPc| String| X| PC web link|
-| \--- schemeAndroid| String| X| Android app link|
-| \--- schemeIos| String| X| iOS app link|
-| \- templateParameter| String| X| Template parameter|
-| \- pushAlarm| boolean| O| Push alarm status (Not Null if message object exists)|
-| \- messageStatus| String| O| Request status (COMPLETED: success, FAILED: failure) (Not Null if message object exists)|
-| \- isAddedChannel| boolean| O| Channel friend status (Not Null if message object exists)|
-| \- resultCode| String| X| Received result code (within message)|
-| \- resultCodeName| String| X| Received result code name (within message)|
-| \- resendStatusCode| String| X| Fallback status code|
-| \- resendStatusName| String| X| Fallback status code name|
-| \- resendResultCode| String| X| Fallback result code|
-| \- resendRequestId| String| X| Fallback request ID|
-| \- createUser| String| X| Registrant (stored as user UUID when sent from console)|
-| \- senderGroupingKey| String| X| Outgoing grouping key|
-| \- recipientGroupingKey| String| X| Recipient grouping key|
+| Name                    | Type      | Not Null | Description                                                                                               |
+|:----------------------|:--------|:---------|:-------------------------------------------------------------------------------------------------|
+| header                | Object  | O        | Header area                                                                                            |
+| - resultCode          | Integer | O        | Result code                                                                                            |
+| - resultMessage       | String  | O        | Result message                                                                                           |
+| - isSuccessful        | boolean | O        | Success                                                                                            |
+| message               | Object  | X        | Message body area (may not exist if the message fails)                                                                     |
+| - requestId           | String  | O        | Request ID (Not Null if the message object exists)                                                                 |
+| - recipientSeq        | Integer | O        | Recipient sequence number (Not Null if the message object exists)                                                            |
+| - plusFriendId        | String  | O        | Sender Profile ID (Not Null if the message object exists)                                                             |
+| - senderKey           | String  | O        | Sender Key (Not Null if the message object exists)                                                                  |
+| - templateCode        | String  | X        | Template Code                                                                                           |
+| - recipientNo         | String  | O        | Recipient number (Not Null if the message object exists)                                                                 |
+| - targeting           | String  | O        | Type of message target (M: users who have agreed to receive marketing messages, N: only users who are not friends but have agreed to receive marketing messages, I: users who are friends) (Not Null if the message object exists) |
+| - requestDate         | String  | O        | Date and time of request (yyyy-MM-dd HH:mm)<br>(send immediately, if it is left blank)<br>Can be scheduled up to 60 days in advance (Not Null if the message object exists)                                                                 |
+| - createDate          | String  | O        | Registration date and time (Not Null if the message object exists)                                                                 |
+| - receiveDate         | String  | X        | Date and time of receipt                                                                                            |
+| - chatBubbleType      | String  | O        | Message type (Not Null if the message object exists)                                                                |
+| - content             | String  | X        | Message content                                                                                           |
+| - adult               | boolean | O        | Whether the message is for adults (Not Null if the message object exists)                                                            |
+| - header              | String  | X        | Header (in message)                                                                                       |
+| - additionalContent   | String  | X        | Additional information (in message)                                                                                    |
+| - image               | Object  | X        | Image element                                                                                           |
+| -- imageUrl           | String  | O        | Image URL (Not Null if the image object exists)                                                                 |
+| -- imageLink          | String  | X        | Image link                                                                                           |
+| - buttons             | Array   | X        | Button list                                                                                            |
+| -- name               | String  | O        | Button title (Not Null if the buttons array item exists)                                                              |
+| -- type               | String  | O        | Button type (Not Null if the buttons array item exists)                                                              |
+| -- linkMo             | String  | X        | Mobile web link                                                                                         |
+| -- linkPc             | String  | X        | PC web link                                                                                          |
+| -- schemeIos          | String  | X        | iOS app link                                                                                         |
+| -- schemeAndroid      | String  | X        | Android app link                                                                                       |
+| -- chatExtra          | String  | X        | Meta information to be delivered for BT type button                                                                      |
+| -- chatEvent          | String  | X        | Bot event name to connect for BT type button                                                                          |
+| -- bizFormKey         | String  | X        | Biz form key for BF type button                                                                               |
+| - item                | Object  | X        | Wide list element                                                                                       |
+| -- list               | Array   | X        | Wide list (Nullable if the item object exists)                                                                  |
+| --- title             | String  | X        | Item title                                                                                           |
+| --- imageUrl          | String  | O        | Item image URL (Not Null if the item.list item exists)                                                         |
+| --- linkMo            | String  | O        | Mobile web link (Not Null if the item.list item exists)                                                            |
+| --- linkPc            | String  | X        | PC web link                                                                                          |
+| --- schemeIos         | String  | X        | iOS app link                                                                                         |
+| --- schemeAndroid     | String  | X        | Android app link                                                                                       |
+| - coupon              | Object  | X        | Coupon element                                                                                            |
+| -- title              | String  | O        | Coupon title (Not Null if the coupon object exists)                                                                  |
+| -- description        | String  | O        | Coupon detailed description (Not Null if the coupon object exists)                                                               |
+| -- linkMo             | String  | X        | Mobile web link                                                                                         |
+| -- linkPc             | String  | X        | PC web link                                                                                          |
+| -- schemeAndroid      | String  | X        | Android app link                                                                                       |
+| -- schemeIos          | String  | X        | iOS app link                                                                                         |
+| - commerce            | Object  | X        | Commerce element                                                                                           |
+| -- title              | String  | O        | Product title (Not Null if the commerce object exists)                                                                |
+| -- regularPrice       | Integer | X        | Regular price                                                                                            |
+| -- discountPrice      | Integer | X        | Discounted price                                                                                             |
+| -- discountRate       | Integer | X        | Discount rate                                                                                              |
+| -- discountFixed      | Integer | X        | Fixed discount price                                                                                           |
+| - video               | Object  | X        | Video element                                                                                           |
+| -- videoUrl           | String  | O        | KakaoTV video URL (Not Null if the video object exists)                                                           |
+| -- thumbnailUrl       | String  | X        | Image URL for video thumbnail                                                                                 |
+| - carousel            | Object  | X        | Carousel                                                                                              |
+| -- head               | Object  | X        | Carousel intro (Nullable if the carousel object exists)                                                              |
+| --- header            | String  | O        | Carousel intro header (Not Null if the head object exists)                                                               |
+| --- content           | String  | O        | Carousel intro content (Not Null if the head object exists)                                                               |
+| --- imageUrl          | String  | O        | Carousel intro image URL (Not Null if the head object exists)                                                           |
+| --- linkMo            | String  | X        | Mobile web link                                                                                         |
+| --- linkPc            | String  | X        | PC web link                                                                                          |
+| --- schemeIos         | String  | X        | iOS app link                                                                                         |
+| --- schemeAndroid     | String  | X        | Android app link                                                                                       |
+| -- list               | Array   | O        | Carousel list (Not Null if carousel object exists)                                                              |
+| --- header            | String  | X        | Carousel item header                                                                                       |
+| --- message           | String  | O        | Carousel item message (Not Null if list item exists)                                                              |
+| --- additionalContent | String  | X        | Additional information                                                                                            |
+| --- imageUrl          | String  | X        | Image URL                                                                                          |
+| --- imageLink         | String  | X        | Image link                                                                                           |
+| --- commerce          | Object  | X        | Commerce (in carousel)                                                                                      |
+| ---- title            | String  | O        | Product title (Not Null if carousel.list.commerce exists)                                                     |
+| ---- regularPrice     | Integer | X        | Regular price                                                                                            |
+| ---- discountPrice    | Integer | X        | Discounted price                                                                                             |
+| ---- discountRate     | Integer | X        | Discount rate                                                                                              |
+| ---- discountFixed    | Integer | X        | Fixed discount price                                                                                           |
+| --- buttons           | Array   | X        | Button list (in carousel)                                                                                    |
+| ---- name             | String  | O        | Button title (Not Null if carousel.list.buttons item exists)                                                   |
+| ---- type             | String  | O        | Button type (Not Null if carousel.list.buttons item exists)                                                   |
+| ---- linkMo           | String  | X        | Mobile web link                                                                                         |
+| ---- linkPc           | String  | X        | PC web link                                                                                          |
+| ---- schemeAndroid    | String  | X        | Android app link                                                                                       |
+| ---- schemeIos        | String  | X        | iOS app link                                                                                         |
+| ---- chatExtra        | String  | X        | Meta information to be delivered for BT type button                                                                      |
+| ---- chatEvent        | String  | X        | Bot event name to connect for BT type button                                                                          |
+| ---- bizFormKey       | String  | X        | Biz form key for BF type button                                                                               |
+| --- coupon            | Object  | X        | Coupon (in carousel)                                                                                       |
+| ---- title            | String  | O        | Coupon title (Not Null if carousel.list.coupon exists)                                                       |
+| ---- description      | String  | O        | Coupon detailed description (Not Null if carousel.list.coupon exists)                                                    |
+| ---- linkMo           | String  | X        | Mobile web link                                                                                         |
+| ---- linkPc           | String  | X        | PC web link                                                                                          |
+| ---- schemeAndroid    | String  | X        | Android app link                                                                                       |
+| ---- schemeIos        | String  | X        | iOS app link                                                                                         |
+| -- tail               | Object  | X        | More button information (Nullable if carousel object exists)                                                            |
+| --- linkMo            | String  | O        | Mobile web link (Not Null if tail object exists)                                                                 |
+| --- linkPc            | String  | X        | PC web link                                                                                          |
+| --- schemeAndroid     | String  | X        | Android app link                                                                                       |
+| --- schemeIos         | String  | X        | iOS app link                                                                                         |
+| - templateParameter   | String  | X        | Template parameter                                                                                         |
+| - pushAlarm           | boolean | O        | Whether push alarm is enabled (Not Null if message object exists)                                                              |
+| - messageStatus       | String  | O        | Request status (COMPLETED: successful, FAILED: failed) (Not Null if message object exists)                                     |
+| - isAddedChannel      | boolean | O        | Whether channel friend is added (Not Null if message object exists)                                                              |
+| - resultCode          | String  | X        | Received result code (in message)                                                                                 |
+| - resultCodeName      | String  | X        | Received result code name (in message)                                                                                |
+| - resendStatusCode    | String  | X        | Alternative delivery status code                                                                                      |
+| - resendStatusName    | String  | X        | Alternative delivery status code name                                                                                     |
+| - resendResultCode    | String  | X        | Alternative delivery result code                                                                                      |
+| - resendRequestId     | String  | X        | Alternative delivery request ID                                                                                      |
+| - createUser          | String  | X        | Registrant (saved as user UUID when sending from console)                                                                      |
+| - senderGroupingKey   | String  | X        | Sender grouping key                                                 |
+| - recipientGroupingKey | String  | X        | Recipient grouping key                                           |
 
 <a id="message-results"></a>
 
-## Query Updated Message Results
-
-<!-- TODO: translate body -->
+## Query Message Result Updates
 
 <a id="requested-25"></a>
 
 #### Request
 
-<!-- TODO: translate body -->
-
-<a id="response-25"></a>
-
-#### Response
-
-<!-- TODO: translate body -->
-
-<a id="cancel-message-sending"></a>
-
-## Cancel message sending
-
-<a id="requested-7"></a>
-
-#### Requested
-
-\[URL]
+[URL]
 
 ```
-DELETE  /brand-message/v1.0/appkeys/{appkey}/messages/{requestId}
+GET  /brand-message/v1.0/appkeys/{appKey}/message-results
 Content-Type: application/json;charset=UTF-8
 ```
 
-\[Path parameter]
+[Path parameter]
 
-| Name| Type| Description|
-|----------|----------|----------|
-| appkey| String| Unique appkey|
-| requestId| String| Request ID|
+| Name   | Type   | Description    |
+|--------|--------|----------------|
+| appKey | String | Unique app key |
 
-\[Header]
+[Header]
 
 ```
 {
@@ -1918,15 +1903,127 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| X-Secret-Key| String| O| Available to create from the console.|
+| Name         | Type   | Required | Description                          |
+|--------------|--------|----------|--------------------------------------|
+| X-Secret-Key | String | O        | Can be created in the console. |
 
-\[Query parameter]
+[Query parameter]
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| recipientSeq| String| X| Recipient sequence number<br>(If you do not enter any information, all requests for that request ID will be canceled)|
+| Name            | Type    | Required | Description                                                                                                                              |
+|-----------------|---------|----------|------------------------------------------------------------------------------------------------------------------------------------------|
+| startUpdateDate | String  | O        | Start time of querying result updates (yyyy-MM-dd HH:mm)                                                                                 |
+| endUpdateDate   | String  | O        | End time of querying result updates (yyyy-MM-dd HH:mm)                                                                                   |
+| targeting       | String  | X        | Type of message target (M: users who agreed to receive marketing, N: users who agreed to receive marketing but are not friends, I: friend users) |
+| pageNum         | Integer | X        | Page number (default: 1)                                                                                                                 |
+| pageSize        | Integer | X        | Number of results to retrieve (default: 15)                                                                                              |
+
+!!! tip "Note"
+    The queryable period is within the last 90 days, and the maximum range per query is 31 days.
+
+<a id="response-25"></a>
+
+#### Response
+
+```
+{
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
+  },
+  "messageSearchResultResponse": {
+    "messages": [
+      {
+        "requestId": String,
+        "recipientSeq": Integer,
+        "plusFriendId": String,
+        "recipientNo": String,
+        "targeting": String,
+        "requestDate": String,
+        "messageStatus": String,
+        "isAddedChannel": boolean,
+        "resendStatus": String,
+        "resendStatusName": String,
+        "resultCode": String,
+        "resultCodeName": String,
+        "senderGroupingKey": String,
+        "recipientGroupingKey": String
+      }
+    ],
+    "totalCount": Integer
+  }
+}
+```
+
+| Name                        | Type    | Not Null | Description                                                                                                                              |
+|:----------------------------|:--------|:---------|:-----------------------------------------------------------------------------------------------------------------------------------------|
+| header                      | Object  | O        | Header area                                                                                                                              |
+| - resultCode                | Integer | O        | Result code                                                                                                                              |
+| - resultMessage             | String  | O        | Result message                                                                                                                           |
+| - isSuccessful              | Boolean | O        | Success                                                                                                                                  |
+| messageSearchResultResponse | Object  | X        | Body area                                                                                                                                |
+| - messages                  | Array   | X        | Message list                                                                                                                             |
+| -- requestId                | String  | O        | Request ID                                                                                                                               |
+| -- recipientSeq             | Integer | O        | Recipient sequence number                                                                                                                |
+| -- plusFriendId             | String  | O        | Sender Profile ID                                                                                                                        |
+| -- recipientNo              | String  | O        | Recipient number                                                                                                                         |
+| -- targeting                | String  | O        | Type of message target (M: users who agreed to receive marketing, N: users who agreed to receive marketing but are not friends, I: friend users) |
+| -- requestDate              | String  | O        | Request date and time                                                                                                                    |
+| -- messageStatus            | String  | O        | Request status (COMPLETED: successful, FAILED: failed, CANCEL: canceled)                                                                 |
+| -- isAddedChannel           | Boolean | O        | Whether the channel is a friend                                                                                                          |
+| -- resendStatus             | String  | X        | Alternative delivery status code                                                                                                         |
+| -- resendStatusName         | String  | X        | Alternative delivery status code name                                                                                                    |
+| -- resultCode               | String  | X        | Receipt result code                                                                                                                      |
+| -- resultCodeName           | String  | X        | Receipt result code name                                                                                                                 |
+| -- senderGroupingKey        | String  | X        | Sender grouping key                                                                                                                      |
+| -- recipientGroupingKey     | String  | X        | Recipient grouping key                                                                                                                   |
+| - totalCount                | Integer | X        | Total count                                                                                                                              |
+
+[Example]
+
+```
+curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appKey}/message-results?startUpdateDate=2026-06-01%2000:00&endUpdateDate=2026-06-30%2023:59"
+```
+
+<a id="cancel-message-sending"></a>
+
+## Cancel Message Delivery
+
+<a id="requested-7"></a>
+
+#### Request
+
+[URL]
+
+```
+DELETE  /brand-message/v1.0/appkeys/{appkey}/messages/{requestId}
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| Name        | 	Type     | 	Description     |
+|-----------|---------|---------|
+| appkey    | 	String | 	Unique app key |
+| requestId | String  | Request ID   |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| Name           | 	Type     | 	Required | 	Description              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | Can be created in the console. |
+
+[Query parameter]
+
+| Name           | 	Type     | 	Required | 	Description                                         |
+|--------------|---------|-----|---------------------------------------------|
+| recipientSeq | 	String | 	X  | Recipient sequence number<br>(to cancel all deliveries of request ID, if the value is left blank) |
 
 <a id="response-7"></a>
 
@@ -1942,46 +2039,45 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Not Null| Description|
-|----------|----------|:----------:|----------|
-| header| Object| X| Header zone|
-| \- resultCode| Integer| X| Result code|
-| \- resultMessage| String| X| Result message|
-| \- isSuccessful| Boolean| X| Success status|
+| Name              | Type      | Not Null | Description     |
+|-----------------|---------|:--------:|--------|
+| header          | Object  |    X     | Header area  |
+| - resultCode    | Integer |    X     | Result code  |
+| - resultMessage | String  |    X     | Result message |
+| - isSuccessful  | Boolean |    X     | Success |
 
-\[Example]
-
+[Example]
 ```
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
 ```
 
 <a id="manage-templates"></a>
 
-## Manage Templates
+## Template Management
 
 <a id="view-template-list"></a>
 
-### View template list
+### List Templates
 
 <a id="requested-8"></a>
 
-#### Requested
+#### Request
 
-\[URL]
+[URL]
 
 ```
 GET  /brand-message/v1.0/appkeys/{appkey}/senders/{senderKey}/templates
 Content-Type: application/json;charset=UTF-8
 ```
 
-\[Path parameter]
+[Path parameter]
 
-| Name| Type| Description|
-|----------|----------|----------|
-| appkey| String| Unique appkey|
-| senderKey| String| Outgoing Key|
+| Name      | Type   | Description    |
+|-----------|--------|----------------|
+| appkey    | String | Unique app key |
+| senderKey | String | Sender Key     |
 
-\[Header]
+[Header]
 
 ```
 {
@@ -1989,19 +2085,19 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| X-Secret-Key| String| O| Available to create from the console.|
+| Name         | Type   | Required | Description                        |
+|--------------|--------|----------|------------------------------------|
+| X-Secret-Key | String | O        | Can be created in the console. |
 
-\[Query parameter]
+[Query parameter]
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| templateCode| String| X| Template Code|
-| templateName| String| X| Template Name|
-| status| String| X| Template status code|
-| pageNum| Integer| X| Page number (Default: 1\)|
-| pageSize| Integer| X| Number of views (default: 15, Max: 1,000)|
+| Name         | Type    | Required | Description                                  |
+|--------------|---------|----------|----------------------------------------------|
+| templateCode | String  | X        | Template Code                                |
+| templateName | String  | X        | Template name                                |
+| status       | String  | X        | Template Status code                         |
+| pageNum      | Integer | X        | Page number (Default: 1)                     |
+| pageSize     | Integer | X        | Number of results (Default: 15, Max: 1,000)  |
 
 <a id="response-8"></a>
 
@@ -2134,124 +2230,124 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Not Null| Description|
-|:----------|:----------|:----------|:----------|
-| header| Object| O| Header zone|
-| \- resultCode| Integer| O| Result code|
-| \- resultMessage| String| O| Result message|
-| \- isSuccessful| boolean| O| Success status|
-| templateListResponse| Object| O| Body area|
-| \- templates| Array| O| Template list|
-| \-- plusFriendId| String| O| Outgoing profile ID|
-| \-- plusFriendType| String| O| Outgoing profile type|
-| \-- templateCode| String| O| Template Code|
-| \-- templateName| String| O| Template name|
-| \-- chatBubbleType| String| O| Message type|
-| \-- content| String| X| Message Content|
-| \-- header| String| X| Header|
-| \-- additionalContent| String| X| (refer to the description table)|
-| \-- adult| boolean| O| Message status for adults|
-| \-- image| Object| X| Image Information|
-| \--- imageUrl| String| O| Image URL|
-| \--- imageLink| String| X| Image link|
-| \-- buttons| Array| X| Button list|
-| \--- name| String| O| Button title|
-| \--- type| String| O| Button type|
-| \--- linkMo| String| X| Mobile web link|
-| \--- linkPc| String| X| PC web link|
-| \--- schemeIos| String| X| iOS app link|
-| \--- schemeAndroid| String| X| Android app link|
-| \--- bizFormId| Integer| X| BizForm ID (JSON based)|
-| \-- item| Object| X| Wide list elements|
-| \--- list| Array| X| Wide list|
-| \---- title| String| X| Item title|
-| \---- imageUrl| String| O| Item image URL|
-| \---- linkMo| String| O| Mobile web link|
-| \---- linkPc| String| X| PC web link|
-| \---- schemeAndroid| String| X| Android app link|
-| \---- schemeIos| String| X| iOS app link|
-| \-- coupon| Object| X| Coupon elements|
-| \--- title| String| O| Coupon title|
-| \--- description| String| O| Coupon details|
-| \--- linkMo| String| X| Mobile web link|
-| \--- linkPc| String| X| PC web link|
-| \--- schemeAndroid| String| X| Android app link|
-| \--- schemeIos| String| X| iOS app link|
-| \-- commerce| Object| X| Commerce elements|
-| \--- title| String| O| Product title|
-| \--- regularPrice| Integer| X| Regular price|
-| \--- discountPrice| Integer| X| Discount price|
-| \--- discountRate| Integer| X| Discount rate|
-| \--- discountFixed| Integer| X| Fixed discount price|
-| \-- video| Object| X| Video elements|
-| \--- videoUrl| String| O| KakaoTV video URL|
-| \--- thumbnailUrl| String| X| Image URL for video thumbnail|
-| \-- carousel| Object| X| Carousel|
-| \--- head| Object| X| Carousel intro|
-| \---- header| String| O| Carousel intro header|
-| \---- content| String| O| Carousel intro content|
-| \---- imageUrl| String| O| Carousel intro image address|
-| \---- linkMo| String| X| Mobile web link|
-| \---- linkPc| String| X| PC web link|
-| \----- schemeAndroid| String| X| Android app link|
-| \----- schemeIos| String| X| iOS app link|
-| \---- list| Array| O| Carousel list|
-| \----- header| String| O| Carousel item header|
-| \----- message| String| O| Carousel item message (content mapping of Not Null list)|
-| \----- additionalContent| String| X| Additional Info|
-| \----- imageUrl| String| O| Image URL (within carousel items)|
-| \----- imageLink| String| X| Image link (within carousel items)|
-| \----- commerce| Object| O| Commerce (within carousel items)|
-| \------ title| String| O| Product title|
-| \------ regularPrice| Integer| X| Regular price|
-| \------ discountPrice| Integer| X| Discount price|
-| \------ discountRate| Integer| X| Discount rate|
-| \------ discountFixed| Integer| X| Fixed discount price|
-| \----- buttons| Array| O| Carousel list button list|
-| \------ name| String| O| Button title|
-| \------ type| String| O| Button type|
-| \------ linkMo| String| X| Mobile web link|
-| \------ linkPc| String| X| PC web link|
-| \------ schemeIos| String| X| iOS app link|
-| \------ schemeAndroid| String| X| Android app link|
-| \------ bizFormId| Integer| X| BizForm ID (JSON based)|
-| \----- coupon| Object| X| Coupon elements (within carousel items)|
-| \------ title| String| X| Coupon title|
-| \------ description| String| X| Coupon details|
-| \------ linkMo| String| X| Mobile web link|
-| \------ linkPc| String| X| PC web link|
-| \------ schemeAndroid| String| X| Android app link|
-| \------ schemeIos| String| X| iOS app link|
-| \---- tail| Object| X| More button information|
-| \----- linkMo| String| O| Mobile web link|
-| \----- linkPc| String| X| PC web link|
-| \----- schemeAndroid| String| X| Android app link|
-| \----- schemeIos| String| X| iOS app link|
-| \--- status| String| O| Template status (A: registered, S: blocked)|
-| \--- createDate| String| O| Registered on|
-| \--- updateDate| String| X| Modified on|
-| \- totalCount| Integer| O| Total|
+| Name                    | Type    | Not Null | Description                                          |
+|:------------------------|:--------|:---------|:-----------------------------------------------------|
+| header                  | Object  | O        | Header area                                          |
+| - resultCode            | Integer | O        | Result code                                          |
+| - resultMessage         | String  | O        | Result message                                       |
+| - isSuccessful          | boolean | O        | Success                                              |
+| templateListResponse    | Object  | O        | Body area                                            |
+| - templates             | Array   | O        | Template list                                        |
+| -- plusFriendId         | String  | O        | Sender Profile ID                                    |
+| -- plusFriendType       | String  | O        | Sender Profile type                                  |
+| -- templateCode         | String  | O        | Template Code                                        |
+| -- templateName         | String  | O        | Template name                                        |
+| -- chatBubbleType       | String  | O        | Message type                                         |
+| -- content              | String  | X        | Message content                                      |
+| -- header               | String  | X        | Header                                               |
+| -- additionalContent    | String  | X        | (See description table)                              |
+| -- adult                | boolean | O        | Whether the message is for adults only               |
+| -- image                | Object  | X        | Image information                                    |
+| --- imageUrl            | String  | O        | Image URL                                            |
+| --- imageLink           | String  | X        | Image link                                           |
+| -- buttons              | Array   | X        | Button list                                          |
+| --- name                | String  | O        | Button title                                         |
+| --- type                | String  | O        | Button type                                          |
+| --- linkMo              | String  | X        | Mobile web link                                      |
+| --- linkPc              | String  | X        | PC web link                                          |
+| --- schemeIos           | String  | X        | iOS app link                                         |
+| --- schemeAndroid       | String  | X        | Android app link                                     |
+| --- bizFormId           | Integer | X        | Biz form ID (based on JSON)                          |
+| -- item                 | Object  | X        | Wide list element                                    |
+| --- list                | Array   | X        | Wide list                                            |
+| ---- title              | String  | X        | Item title                                           |
+| ---- imageUrl           | String  | O        | Item image URL                                       |
+| ---- linkMo             | String  | O        | Mobile web link                                      |
+| ---- linkPc             | String  | X        | PC web link                                          |
+| ---- schemeAndroid      | String  | X        | Android app link                                     |
+| ---- schemeIos          | String  | X        | iOS app link                                         |
+| -- coupon               | Object  | X        | Coupon element                                       |
+| --- title               | String  | O        | Coupon title                                         |
+| --- description         | String  | O        | Coupon detailed description                          |
+| --- linkMo              | String  | X        | Mobile web link                                      |
+| --- linkPc              | String  | X        | PC web link                                          |
+| --- schemeAndroid       | String  | X        | Android app link                                     |
+| --- schemeIos           | String  | X        | iOS app link                                         |
+| -- commerce             | Object  | X        | Commerce element                                     |
+| --- title               | String  | O        | Product title                                        |
+| --- regularPrice        | Integer | X        | Regular price                                        |
+| --- discountPrice       | Integer | X        | Discounted price                                     |
+| --- discountRate        | Integer | X        | Discount rate                                        |
+| --- discountFixed       | Integer | X        | Fixed discount price                                 |
+| -- video                | Object  | X        | Video element                                        |
+| --- videoUrl            | String  | O        | KakaoTV video URL                                    |
+| --- thumbnailUrl        | String  | X        | Image URL for video thumbnail                        |
+| -- carousel             | Object  | X        | Carousel                                             |
+| --- head                | Object  | X        | Carousel intro                                       |
+| ---- header             | String  | O        | Carousel intro header                                |
+| ---- content            | String  | O        | Carousel intro content                               |
+| ---- imageUrl           | String  | O        | Carousel intro image URL                             |
+| ---- linkMo             | String  | X        | Mobile web link                                      |
+| ---- linkPc             | String  | X        | PC web link                                          |
+| ----- schemeAndroid     | String  | X        | Android app link                                     |
+| ----- schemeIos         | String  | X        | iOS app link                                         |
+| ---- list               | Array   | O        | Carousel list                                        |
+| ----- header            | String  | O        | Carousel item header                                 |
+| ----- message           | String  | O        | Carousel item message (maps to content in Not Null list) |
+| ----- additionalContent | String  | X        | Additional information                               |
+| ----- imageUrl          | String  | O        | Image URL (within carousel item)                     |
+| ----- imageLink         | String  | X        | Image link (within carousel item)                    |
+| ----- commerce          | Object  | O        | Commerce (within carousel item)                      |
+| ------ title            | String  | O        | Product title                                        |
+| ------ regularPrice     | Integer | X        | Regular price                                        |
+| ------ discountPrice    | Integer | X        | Discounted price                                     |
+| ------ discountRate     | Integer | X        | Discount rate                                        |
+| ------ discountFixed    | Integer | X        | Fixed discount price                                 |
+| ----- buttons           | Array   | O        | Carousel list button list                            |
+| ------ name             | String  | O        | Button title                                         |
+| ------ type             | String  | O        | Button type                                          |
+| ------ linkMo           | String  | X        | Mobile web link                                      |
+| ------ linkPc           | String  | X        | PC web link                                          |
+| ------ schemeIos        | String  | X        | iOS app link                                         |
+| ------ schemeAndroid    | String  | X        | Android app link                                     |
+| ------ bizFormId        | Integer | X        | Biz form ID (based on JSON)                          |
+| ----- coupon            | Object  | X        | Coupon element (within carousel item)                |
+| ------ title            | String  | X        | Coupon title                                         |
+| ------ description      | String  | X        | Coupon detailed description                          |
+| ------ linkMo           | String  | X        | Mobile web link                                      |
+| ------ linkPc           | String  | X        | PC web link                                          |
+| ------ schemeAndroid    | String  | X        | Android app link                                     |
+| ------ schemeIos        | String  | X        | iOS app link                                         |
+| ---- tail               | Object  | X        | View More button information                         |
+| ----- linkMo            | String  | O        | Mobile web link                                      |
+| ----- linkPc            | String  | X        | PC web link                                          |
+| ----- schemeAndroid     | String  | X        | Android app link                                     |
+| ----- schemeIos         | String  | X        | iOS app link                                         |
+| --- status              | String  | O        | Template status (A: registered, S: blocked)          |
+| --- createDate          | String  | O        | Registration date and time                           |
+| --- updateDate          | String  | X        | Modification date and time                           |
+| - totalCount            | Integer | O        | Total count                                          |
 
 <a id="view-single-template"></a>
 
-### View single template
+### Get a Template
 
-\[URL]
+[URL]
 
 ```
 GET  /brand-message/v1.0/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}
 Content-Type: application/json;charset=UTF-8
 ```
 
-\[Path parameter]
+[Path parameter]
 
-| Name| Type| Description|
-|----------|----------|----------|
-| appkey| String| Unique appkey|
-| senderKey| String| Outgoing Key|
-| templateCode| String| Template Code|
+| Name         | Type   | Description    |
+|--------------|--------|----------------|
+| appkey       | String | Unique app key |
+| senderKey    | String | Sender Key     |
+| templateCode | String | Template Code  |
 
-\[Header]
+[Header]
 
 ```
 {
@@ -2259,10 +2355,10 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| X-Secret-Key| String| O| Available to create from the console.|
-| X-NC-API-IDEMPOTENCY-KEY | String | X | Key used as the basis for duplicate message delivery request detection<br>If a request is made with the same key within 10 minutes, the request will be treated as failed. |
+| Name                        | Type   | Required | Description                                                                                                                              |
+|-----------------------------|--------|----------|------------------------------------------------------------------------------------------------------------------------------------------|
+| X-Secret-Key                | String | O        | Can be created in the console.                                                                                                           |
+| X-NC-API-IDEMPOTENCY-KEY    | String | X        | Key used as the reference for duplicate message sending requests.<br>If a request is made with the same key for 10 minutes, the request will be failed. |
 
 <a id="response-9"></a>
 
@@ -2390,126 +2486,126 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Not Null| Description|
-|:----------|:----------|:----------|:----------|
-| header| Object| O| Header zone|
-| \- resultCode| Integer| O| Result code|
-| \- resultMessage| String| O| Result message|
-| \- isSuccessful| boolean| O| Success status|
-| template| Object| O| Template body area|
-| \- plusFriendId| String| O| Outgoing profile ID|
-| \- plusFriendType| String| O| Outgoing profile type|
-| \- templateCode| String| O| Template Code|
-| \- templateName| String| O| Template name|
-| \- chatBubbleType| String| O| Message type|
-| \- pushAlarm| boolean| X| Push alarm status|
-| \- content| String| X| Message Content|
-| \- adult| boolean| O| Message status for adults|
-| \- header| String| X| Header (within template)|
-| \- additionalContent| String| X| Additional info (within template)|
-| \- image| Object| X| Image Information|
-| \-- imageUrl| String| O| Image URL|
-| \-- imageLink| String| X| Image link|
-| \- buttons| Array| X| Button list|
-| \-- name| String| O| Button title|
-| \-- type| String| O| Button type|
-| \-- linkMo| String| X| Mobile web link|
-| \-- linkPc| String| X| PC web link|
-| \-- schemeIos| String| X| iOS app link|
-| \-- schemeAndroid| String| X| Android app link|
-| \-- bizFormId| Integer| X| BizForm ID (JSON based)|
-| \- item| Object| X| Wide list elements|
-| \-- list| Array| X| Wide list|
-| \--- title| String| X| Item title|
-| \--- imageUrl| String| O| Item image URL|
-| \--- linkMo| String| O| Mobile web link|
-| \--- linkPc| String| X| PC web link|
-| \--- schemeIos| String| X| iOS app link|
-| \--- schemeAndroid| String| X| Android app link|
-| \- coupon| Object| X| Coupon elements|
-| \-- title| String| O| Coupon title|
-| \-- description| String| O| Coupon details|
-| \-- linkMo| String| X| Mobile web link|
-| \-- linkPc| String| X| PC web link|
-| \-- schemeIos| String| X| iOS app link|
-| \-- schemeAndroid| String| X| Android app link|
-| \- commerce| Object| X| Commerce elements|
-| \-- title| String| O| Product title|
-| \-- regularPrice| Integer| X| Regular price|
-| \-- discountPrice| Integer| X| Discount price|
-| \-- discountRate| Integer| X| Discount rate|
-| \-- discountFixed| Integer| X| Fixed discount price|
-| \- video| Object| X| Video elements|
-| \-- videoUrl| String| O| KakaoTV video URL|
-| \-- thumbnailUrl| String| X| Image URL for video thumbnail|
-| \- carousel| Object| X| Carousel|
-| \-- head| Object| X| Carousel intro|
-| \--- header| String| O| Carousel intro header|
-| \--- content| String| O| Carousel intro content|
-| \--- imageUrl| String| O| Carousel intro image address|
-| \--- linkMo| String| X| Mobile web link|
-| \--- linkPc| String| X| PC web link|
-| \--- schemeIos| String| X| iOS app link|
-| \--- schemeAndroid| String| X| Android app link|
-| \-- list| Array| O| Carousel list|
-| \--- header| String| O| Carousel item header|
-| \--- message| String| O| Carousel item message|
-| \--- additionalContent| String| X| Additional Info (within carousel items)|
-| \--- imageUrl| String| O| Image URL (within carousel items)|
-| \--- imageLink| String| X| Image link (within carousel items)|
-| \--- commerce| Object| O| Commerce (within carousel items)|
-| \---- title| String| O| Product title|
-| \---- regularPrice| Integer| X| Regular price|
-| \---- discountPrice| Integer| X| Discount price|
-| \---- discountRate| Integer| X| Discount rate|
-| \---- discountFixed| Integer| X| Fixed discount price|
-| \--- buttons| Array| O| Carousel list button list|
-| \---- name| String| O| Button title|
-| \---- type| String| O| Button type|
-| \---- linkMo| String| X| Mobile web link|
-| \---- linkPc| String| X| PC web link|
-| \---- schemeIos| String| X| iOS app link|
-| \---- schemeAndroid| String| X| Android app link|
-| \---- bizFormId| Integer| X| BizForm ID (JSON based)|
-| \--- coupon| Object| X| Coupon elements (within carousel items)|
-| \---- title| String| X| Coupon title|
-| \---- description| String| X| Coupon details|
-| \---- linkMo| String| X| Mobile web link|
-| \---- linkPc| String| X| PC web link|
-| \---- schemeIos| String| X| iOS app link|
-| \---- schemeAndroid| String| X| Android app link|
-| \-- tail| Object| X| More button information|
-| \--- linkMo| String| O| Mobile web link|
-| \--- linkPc| String| X| PC web link|
-| \--- schemeIos| String| X| iOS app link|
-| \--- schemeAndroid| String| X| Android app link|
-| \- status| String| O| Template status (A: registered, S: blocked)|
-| \- createDate| String| O| Registered on|
-| \- updateDate| String| X| Modified on|
+| Name                  | Type    | Not Null | Description                              |
+|:----------------------|:--------|:---------|:-----------------------------------------|
+| header                | Object  | O        | Header area                              |
+| - resultCode          | Integer | O        | Result code                              |
+| - resultMessage       | String  | O        | Result message                           |
+| - isSuccessful        | boolean | O        | Success                                  |
+| template              | Object  | O        | Template body area                       |
+| - plusFriendId        | String  | O        | Sender Profile ID                        |
+| - plusFriendType      | String  | O        | Sender Profile type                      |
+| - templateCode        | String  | O        | Template Code                            |
+| - templateName        | String  | O        | Template name                            |
+| - chatBubbleType      | String  | O        | Message Type                             |
+| - pushAlarm           | boolean | X        | Whether push alarm is enabled            |
+| - content             | String  | X        | Message content                          |
+| - adult               | boolean | O        | Whether the message is for adults        |
+| - header              | String  | X        | Header (within template)                 |
+| - additionalContent   | String  | X        | Additional information (within template) |
+| - image               | Object  | X        | Image information                        |
+| -- imageUrl           | String  | O        | Image URL                                |
+| -- imageLink          | String  | X        | Image link                               |
+| - buttons             | Array   | X        | Button list                              |
+| -- name               | String  | O        | Button title                             |
+| -- type               | String  | O        | Button type                              |
+| -- linkMo             | String  | X        | Mobile web link                          |
+| -- linkPc             | String  | X        | PC web link                              |
+| -- schemeIos          | String  | X        | iOS app link                             |
+| -- schemeAndroid      | String  | X        | Android app link                         |
+| -- bizFormId          | Integer | X        | Biz form ID (based on JSON)              |
+| - item                | Object  | X        | Wide list element                        |
+| -- list               | Array   | X        | Wide list                                |
+| --- title             | String  | X        | Item title                               |
+| --- imageUrl          | String  | O        | Item image URL                           |
+| --- linkMo            | String  | O        | Mobile web link                          |
+| --- linkPc            | String  | X        | PC web link                              |
+| --- schemeIos         | String  | X        | iOS app link                             |
+| --- schemeAndroid     | String  | X        | Android app link                         |
+| - coupon              | Object  | X        | Coupon element                           |
+| -- title              | String  | O        | Coupon title                             |
+| -- description        | String  | O        | Coupon detail description                |
+| -- linkMo             | String  | X        | Mobile web link                          |
+| -- linkPc             | String  | X        | PC web link                              |
+| -- schemeIos          | String  | X        | iOS app link                             |
+| -- schemeAndroid      | String  | X        | Android app link                         |
+| - commerce            | Object  | X        | Commerce element                         |
+| -- title              | String  | O        | Product title                            |
+| -- regularPrice       | Integer | X        | Regular price                            |
+| -- discountPrice      | Integer | X        | Discount price                           |
+| -- discountRate       | Integer | X        | Discount rate                            |
+| -- discountFixed      | Integer | X        | Fixed discount price                     |
+| - video               | Object  | X        | Video element                            |
+| -- videoUrl           | String  | O        | KakaoTV video URL                        |
+| -- thumbnailUrl       | String  | X        | Image URL for video thumbnail            |
+| - carousel            | Object  | X        | Carousel                                 |
+| -- head               | Object  | X        | Carousel intro                           |
+| --- header            | String  | O        | Carousel intro header                    |
+| --- content           | String  | O        | Carousel intro content                   |
+| --- imageUrl          | String  | O        | Carousel intro image URL                 |
+| --- linkMo            | String  | X        | Mobile web link                          |
+| --- linkPc            | String  | X        | PC web link                              |
+| --- schemeIos         | String  | X        | iOS app link                             |
+| --- schemeAndroid     | String  | X        | Android app link                         |
+| -- list               | Array   | O        | Carousel list                            |
+| --- header            | String  | O        | Carousel item header                     |
+| --- message           | String  | O        | Carousel item message                    |
+| --- additionalContent | String  | X        | Additional information (within carousel item) |
+| --- imageUrl          | String  | O        | Image URL (within carousel item)         |
+| --- imageLink         | String  | X        | Image link (within carousel item)        |
+| --- commerce          | Object  | O        | Commerce (within carousel item)          |
+| ---- title            | String  | O        | Product title                            |
+| ---- regularPrice     | Integer | X        | Regular price                            |
+| ---- discountPrice    | Integer | X        | Discount price                           |
+| ---- discountRate     | Integer | X        | Discount rate                            |
+| ---- discountFixed    | Integer | X        | Fixed discount price                     |
+| --- buttons           | Array   | O        | Carousel list button list                |
+| ---- name             | String  | O        | Button title                             |
+| ---- type             | String  | O        | Button type                              |
+| ---- linkMo           | String  | X        | Mobile web link                          |
+| ---- linkPc           | String  | X        | PC web link                              |
+| ---- schemeIos        | String  | X        | iOS app link                             |
+| ---- schemeAndroid    | String  | X        | Android app link                         |
+| ---- bizFormId        | Integer | X        | Biz form ID (based on JSON)              |
+| --- coupon            | Object  | X        | Coupon element (within carousel item)    |
+| ---- title            | String  | X        | Coupon title                             |
+| ---- description      | String  | X        | Coupon detail description                |
+| ---- linkMo           | String  | X        | Mobile web link                          |
+| ---- linkPc           | String  | X        | PC web link                              |
+| ---- schemeIos        | String  | X        | iOS app link                             |
+| ---- schemeAndroid    | String  | X        | Android app link                         |
+| -- tail               | Object  | X        | View More button information             |
+| --- linkMo            | String  | O        | Mobile web link                          |
+| --- linkPc            | String  | X        | PC web link                              |
+| --- schemeIos         | String  | X        | iOS app link                             |
+| --- schemeAndroid     | String  | X        | Android app link                         |
+| - status              | String  | O        | Template Status (A: registered, S: blocked) |
+| - createDate          | String  | O        | Registration date and time               |
+| - updateDate          | String  | X        | Modification date and time               |
 
 <a id="register-template"></a>
 
-### Register Template
+### Template Registration
 
 <a id="requested-10"></a>
 
-#### Requested
+#### Request
 
-\[URL]
+[URL]
 
 ```
 POST  /brand-message/v1.0/appkeys/{appkey}/senders/{senderKey}/templates
 Content-Type: application/json;charset=UTF-8
 ```
 
-\[Path parameter]
+[Path Parameter]
 
-| Name| Type| Description|
-|----------|----------|----------|
-| appkey| String| Unique appkey|
-| senderKey| String| Outgoing Key|
+| Name      | Type   | Description        |
+|-----------|--------|--------------------|
+| appkey    | String | Unique app key     |
+| senderKey | String | Sender key         |
 
-\[Header]
+[Header]
 
 ```
 {
@@ -2517,36 +2613,36 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| X-Secret-Key| String| O| Available to create from the console.|
+| Name         | Type   | Required | Description                        |
+|--------------|--------|----------|------------------------------------|
+| X-Secret-Key | String | O        | Can be created in the console. |
 
 <a id="note"></a>
 
-#### Note
+#### Notes
 
-* If applying placeholders to coupon titles, you must use the following fixed placeholders:
+* When applying replacement variables to a coupon title, you must use the following fixed replacement variables.
 
 ```
-- #{discount price} won discount coupon (#{discount price} scope is 1 ~ 99,999,999)
-- #{discount rate}% discount coupon (#{discount rate} scope is 1 ~ 100)
-- Delivery fee discount coupon
-- #{product name} free coupon (#{product name} is up to 7 characters)
-- #{product name} UP coupon (#{product name} is up to 7 characters)
+- #{Discount amount} KRW off coupon (#{Discount amount} range: 1 to 99,999,999)
+- #{Discount rate}% off coupon (#{Discount rate} range: 1 to 100)
+- Shipping discount coupon
+- #{Product name} Free coupon (#{Product name} is up to 7 characters)
+- #{Product name} UP coupon (#{Product name} is up to 7 characters)
 ```
 
-* In commerce, users cannot specify placeholders for the regularPrice, discountPrice, discountRate, and discountFixed fields, except for the product title.
-  * If you leave all fields except product title blank, the fixed placeholders will be automatically filled in and saved.
-  * regularPrice -> #{regular price}
-  * discountPrice -> #{discount price}
-  * discountRate -> #{discount rate}
-  * discountFixed -> #{fixed discount price}
+* In Commerce, users cannot specify replacement variables for the regularPrice, discountPrice, discountRate, and discountFixed fields, excluding the product title.
+    * If you leave all fields other than the product title empty, they are automatically populated with fixed replacement variables and saved.
+    * regularPrice -> #{Regular price}
+    * discountPrice -> #{Discounted price}
+    * discountRate -> #{Discount rate}
+    * discountFixed -> #{Discount fixed amount}
 
 <a id="request-to-register-text-type-template"></a>
 
-#### Request to register text type template
+#### Register Text Type Template Request
 
-\[Request body]
+[Request body]
 
 ```
 {
@@ -2576,33 +2672,33 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| templateName| String| O| Template name (up 200 characters)|
-| chatBubbleType| String| O| Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)|
-| adult| boolean| X| Message status for adults (defaults: false)|
-| content| String| O| \- For TEXT type, up to 1,300 characters (linebreak: up to 99, URL type available)<br>- For IMAGE type, up to 1,300 characters (linebreak: up to 99, URL type available)<br>- For WIDE type, up to 76 characters (linebreak: up to 5)<br>- For PREMIUM_VIDEO type, the field can be used optionally, 76 characters (linebreak: up to 5)<br>- For other types, the field is unavailable.|
-| buttons| List| X| Button list<br>- For TEXT, IMAGE type, up to 4 when applying a coupon; for others, up to 5<br>- For WIDE, WIDE_ITEM_LIST type, up to 2<br>- For PREMIUM_VIDEO type, up to 1<br>- For COMMERCE type, minimum 1 and up to 2|
-| \- name| String| O| Button title<br>- For TEXT, IMAGE type, up to 14 characters<br>- For other types, up to 8 characters<br>No placeholders available|
-| \- type| String| O| Button type (WL: web link, AL: app link, BK: bot keyword, MD: forward message, AC: add channel, BT: chatbot conversion, BF: business form)<br>- AC type must be registered as the first button for TEXT and IMAGE, and as the last button for other message types|
-| \- linkMo| String| X| Mobile web link (required for WL type), limited to 500 characters|
-| \- linkPc| String| X| PC web link (optional for WL type), limited to 500 characters|
-| \- schemeAndroid| String| X| Android app link (required for AL type), limited to 500 characters|
-| \- schemeIos| String| X| iOS app link (required for AL type), limited to 500 characters|
-| \- bizFormKey| String| X| BizForm key when the button is BF type<br>No placeholders available|
-| coupon| Object| X| Coupon elements|
-| \- title| String| O| Limited to 5 formats for titles<br>- "${number} won discount coupon" number is 1 or greater and 99,999,999 or less<br>- "${number}% discount coupon" number is 1 or greater and 100 or less<br>- "Shipping discount coupon"<br>- "${within 7 characters} free coupon"<br>- "${within 7 characters} UP coupon"|
-| \- description| String| O| Coupon details<br>- For WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO type, up to 18, linebreak: unavailable<br>- For other types, up to 12 characters, linebreak: unavailable|
-| \- linkMo| String| X| Mobile web link (required for WL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \- linkPc| String| X| PC web link (optional for WL type), limited to 500 characters|
-| \- schemeAndroid| String| X| Android app link (required for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \- schemeIos| String| X| iOS app link (required field for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
+| Name            | Type    | Required | Description                                                                                                                                                                                                                                                                                                                                                 |
+|-----------------|---------|----|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| templateName    | String  | O  | Template name (up to 200 characters)                                                                                                                                                                                                                                                                                                                        |
+| chatBubbleType  | String  | O  | Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)                                                                                                                                                                                                                                                 |
+| adult           | boolean | X  | Whether the message is for adults (default: false)                                                                                                                                                                                                                                                                                                          |
+| content         | String  | O  | - For the TEXT type: up to 1,300 characters (line breaks: up to 99, URL format allowed)<br>- For the IMAGE type: up to 1,300 characters (line breaks: up to 99, URL format allowed)<br>- For the WIDE type: up to 76 characters (line breaks: up to 5)<br>- For the PREMIUM_VIDEO type: this field is optional, up to 76 characters (line breaks: up to 5)<br>- For all other types: this field is not used |
+| buttons         | List    | X  | List of buttons<br>- For the TEXT and IMAGE types: up to 4 buttons when a coupon is applied, up to 5 buttons otherwise<br>- For the WIDE and WIDE_ITEM_LIST types: up to 2 buttons<br>- For the PREMIUM_VIDEO type: up to 1 button<br>- For the COMMERCE type: at least 1 and up to 2 buttons                                                               |
+| - name          | String  | O  | Button title<br>- For the TEXT and IMAGE types: up to 14 characters<br>- For all other types: up to 8 characters<br>Replacement variables cannot be used                                                                                                                                                                                                    |
+| - type          | String  | O  | Button type (WL: Web Link, AL: App Link, BK: Bot Keyword, MD: Message Delivery, AC: Add Channel, BT: Bot Transfer, BF: Business Form)<br>- The AC type must be registered as the first button for TEXT and IMAGE types, and as the last button for all other message types                                                                                   |
+| - linkMo        | String  | X  | Mobile web link (required for the WL type), for up to 500 characters                                                                                                                                                                                                                                                                                       |
+| - linkPc        | String  | X  | PC web link (optional for the WL type), for up to 500 characters                                                                                                                                                                                                                                                                                           |
+| - schemeAndroid | String  | X  | Android app link (required for the AL type), for up to 500 characters                                                                                                                                                                                                                                                                                      |
+| - schemeIos     | String  | X  | iOS app link (required for the AL type), for up to 500 characters                                                                                                                                                                                                                                                                                          |
+| - bizFormKey    | String  | X  | Business form key for the BF type button<br>Replacement variables cannot be used                                                                                                                                                                                                                                                                            |
+| coupon          | Object  | X  | Coupon element                                                                                                                                                                                                                                                                                                                                              |
+| - title         | String  | O  | For title, you are limited to five types:<br>- "${number}KRW off coupon" with a number greater than or equal to 1 and less than or equal to 99,999,999<br>- "${number}% off coupon" with a number greater than or equal to 1 and less than or equal to 100<br>- "Shipping discount coupon"<br>- "${7 characters} Free coupon"<br>- "${7 characters} UP coupon" |
+| - description   | String  | O  | Coupon detailed description<br>- For the WIDE, WIDE_ITEM_LIST, and PREMIUM_VIDEO types: up to 18 characters, no line breaks allowed<br>- For all other types: up to 12 characters, no line breaks allowed                                                                                                                                                   |
+| - linkMo        | String  | X  | Mobile web link (required for the WL type), for up to 500 characters<br>If the linkMo field is entered for a coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional.                                               |
+| - linkPc        | String  | X  | PC web link (optional for the WL type), for up to 500 characters                                                                                                                                                                                                                                                                                           |
+| - schemeAndroid | String  | X  | Android app link (required for the AL type), for up to 500 characters<br>If the linkMo field is entered for a coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional.                                              |
+| - schemeIos     | String  | X  | iOS app link (required for the AL type), for up to 500 characters<br>If the linkMo field is entered for a coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional.                                                  |
 
 <a id="request-to-register-image-type-template"></a>
 
-#### Request to register image type template
+#### Request to Register Image Type Template
 
-\[Request body]
+[Request body]
 
 ```
 {
@@ -2636,36 +2732,36 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required | Description|
-|----------|----------|----------|----------|
-| templateName| String| O        | Template name (up 200 characters)|
-| chatBubbleType| String| O        | Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)|
-| adult| boolean| X        | Message status for adults (defaults: false)|
-| content| String| O        | \- For TEXT type, up to 1,300 characters (linebreak: up to 99, URL type available)<br>- For IMAGE type, up to 1,300 characters (linebreak: up to 99, URL type available)<br>- For WIDE type, up to 76 characters (linebreak: up to 5)<br>- For PREMIUM_VIDEO type, the field can be used optionally, 76 characters (linebreak: up to 5)<br>- For other types, the field is unavailable.|
-| image| Object| O        | Image elements<br>- Required fields for IMAGE, WIDE, COMMERCE types|
-| \- imageUrl| String| O        | Image URL, use an image URL uploaded as a general image<br>No placeholders available|
-| \- imageLink| String| X        | URL to go to when the image is clicked, limited to 500 characters<br>If not set, use the image viewer in KakaoTalk<br>No placeholders available|
-| buttons| List| X        | Button list<br>- For TEXT, IMAGE type, up to 4 when applying a coupon; for others, up to 5<br>- For WIDE, WIDE_ITEM_LIST type, up to 2<br>- For PREMIUM_VIDEO type, up to 1<br>- For COMMERCE type, minimum 1 and up to 2|
-| \- name| String| O        | Button title<br>- For TEXT, IMAGE type, up to 14 characters<br>- For other types, up to 8 characters<br>No placeholders available|
-| \- type| String| O        | Button type (WL: web link, AL: app link, BK: bot keyword, MD: forward message, AC: add channel, BT: chatbot conversion, BF: business form)<br>- AC type must be registered as the first button for TEXT and IMAGE, and as the last button for other message types|
-| \- linkMo| String| X        | Mobile web link (required for WL type), limited to 500 characters|
-| \- linkPc| String| X        | PC web link (optional for WL type), limited to 500 characters|
-| \- schemeAndroid| String| X        | Android app link (required for AL type), limited to 500 characters|
-| \- schemeIos| String| X        | iOS app link (required for AL type), limited to 500 characters|
-| \- bizFormKey| String| X        | BizForm key when the button is BF type|
-| coupon| Object| X        | Coupon elements|
-| \- title| String| O        | Limited to 5 formats for titles<br>- "${number} won discount coupon" number is 1 or greater and 99,999,999 or less<br>- "${number}% discount coupon" number is 1 or greater and 100 or less<br>- "Shipping discount coupon"<br>- "${within 7 characters} free coupon"<br>- "${within 7 characters} UP coupon"|
-| \- description| String| O        | Coupon details<br>- For WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO type, up to 18, linebreak: unavailable<br>- For other types, up to 12 characters, linebreak: unavailable|
-| \- linkMo| String| X        | Mobile web link (required for WL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \- linkPc| String| X        | PC web link (optional for WL type), limited to 500 characters|
-| \- schemeAndroid| String| X        | Android app link (required for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \- schemeIos| String| X        | iOS app link (required field for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
+| Name            | Type    | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                    |
+|-----------------|---------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| templateName    | String  | O        | Template name (up to 200 characters)                                                                                                                                                                                                                                                                                                                                                                           |
+| chatBubbleType  | String  | O        | Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)                                                                                                                                                                                                                                                                                                    |
+| adult           | boolean | X        | Whether the message is for adults (default: false)                                                                                                                                                                                                                                                                                                                                                             |
+| content         | String  | O        | - For the TEXT type: up to 1,300 characters (line breaks: up to 99, URL format input allowed)<br>- For the IMAGE type: up to 1,300 characters (line breaks: up to 99, URL format input allowed)<br>- For the WIDE type: up to 76 characters (line breaks: up to 5)<br>- For the PREMIUM_VIDEO type: this field is optional, up to 76 characters (line breaks: up to 5)<br>- For all other types: this field is not used |
+| image           | Object  | O        | Image element<br>- Required for the IMAGE, WIDE, and COMMERCE types                                                                                                                                                                                                                                                                                                                                            |
+| - imageUrl      | String  | O        | Image URL; use the URL of an image uploaded as a general image<br>Replacement variables cannot be used                                                                                                                                                                                                                                                                                                         |
+| - imageLink     | String  | X        | URL to navigate to when the image is clicked; limited to 500 characters<br>If not set, the KakaoTalk in-app image viewer is used<br>Replacement variables cannot be used                                                                                                                                                                                                                                       |
+| buttons         | List    | X        | Button list<br>- For the TEXT and IMAGE types: up to 4 buttons when a coupon is applied, otherwise up to 5<br>- For the WIDE and WIDE_ITEM_LIST types: up to 2 buttons<br>- For the PREMIUM_VIDEO type: up to 1 button<br>- For the COMMERCE type: at least 1 and up to 2 buttons                                                                                                                               |
+| - name          | String  | O        | Button title<br>- For the TEXT and IMAGE types: up to 14 characters<br>- For all other types: up to 8 characters<br>Replacement variables cannot be used                                                                                                                                                                                                                                                       |
+| - type          | String  | O        | Button type (WL: Web Link, AL: App Link, BK: Bot Keyword, MD: Message Delivery, AC: Add Channel, BT: Bot Transfer, BF: Business Form)<br>- The AC type must be registered as the first button for the TEXT and IMAGE types, and as the last button for all other message types                                                                                                                                  |
+| - linkMo        | String  | X        | Mobile web link (required for the WL type), limited to 500 characters                                                                                                                                                                                                                                                                                                                                         |
+| - linkPc        | String  | X        | PC web link (optional for the WL type), limited to 500 characters                                                                                                                                                                                                                                                                                                                                             |
+| - schemeAndroid | String  | X        | Android app link (required for the AL type), limited to 500 characters                                                                                                                                                                                                                                                                                                                                        |
+| - schemeIos     | String  | X        | iOS app link (required for the AL type), limited to 500 characters                                                                                                                                                                                                                                                                                                                                            |
+| - bizFormKey    | String  | X        | Business form key for the BF type button                                                                                                                                                                                                                                                                                                                                                                       |
+| coupon          | Object  | X        | Coupon element                                                                                                                                                                                                                                                                                                                                                                                                 |
+| - title         | String  | O        | For title, you are limited to five formats:<br>- "${number}KRW off coupon" with a number greater than or equal to 1 and less than or equal to 99,999,999<br>- "${number}% off coupon" with a number greater than or equal to 1 and less than or equal to 100<br>- "Shipping discount coupon"<br>- "${7 characters} Free coupon"<br>- "${7 characters} UP coupon"                                                |
+| - description   | String  | O        | Coupon detailed description<br>- For the WIDE, WIDE_ITEM_LIST, and PREMIUM_VIDEO types: up to 18 characters, no line breaks allowed<br>- For all other types: up to 12 characters, no line breaks allowed                                                                                                                                                                                                      |
+| - linkMo        | String  | X        | Mobile web link (required for the WL type), limited to 500 characters<br>If the linkMo field is entered for the coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional.                                                                                                |
+| - linkPc        | String  | X        | PC web link (optional for the WL type), limited to 500 characters                                                                                                                                                                                                                                                                                                                                             |
+| - schemeAndroid | String  | X        | Android app link (required for the AL type), limited to 500 characters<br>If the linkMo field is entered for the coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional.                                                                                               |
+| - schemeIos     | String  | X        | iOS app link (required for the AL type), limited to 500 characters<br>If the linkMo field is entered for the coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional.                                                                                                   |
 
 <a id="request-to-register-wide-image-type-template"></a>
 
-#### Request to register wide image type template
+#### Request to Register Wide Image Type Template
 
-\[Request body]
+[Request body]
 
 ```
 {
@@ -2699,36 +2795,36 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required | Description|
-|----------|----------|----------|----------|
-| templateName| String| O        | Template name (up 200 characters)|
-| chatBubbleType| String| O        | Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)|
-| adult| boolean| X        | Message status for adults (defaults: false)|
-| content| String| O        | \- For TEXT type, up to 1,300 characters (linebreak: up to 99, URL type available)<br>- For IMAGE type, up to 1,300 characters (linebreak: up to 99, URL type available)<br>- For WIDE type, up to 76 characters (linebreak: up to 5)<br>- For PREMIUM_VIDEO type, the field can be used optionally, 76 characters (linebreak: up to 5)<br>- For other types, the field is unavailable.|
-| image| Object| O        | Image elements<br>- Required fields for IMAGE, WIDE, COMMERCE types|
-| \- imageUrl| String| O        | Image URL, use an image URL uploaded as a wide image<br>No placeholders available|
-| \- imageLink| String| X        | URL to go to when the image is clicked, limited to 500 characters<br>If not set, use the image viewer in KakaoTalk<br>No placeholders available|
-| buttons| List| X        | Button list<br>- For TEXT, IMAGE type, up to 4 when applying a coupon; for others, up to 5<br>- For WIDE, WIDE_ITEM_LIST type, up to 2<br>- For PREMIUM_VIDEO type, up to 1<br>- For COMMERCE type, minimum 1 and up to 2|
-| \- name| String| O        | Button title<br>- For TEXT, IMAGE type, up to 14 characters<br>- For other types, up to 8 characters<br>No placeholders available|
-| \- type| String| O        | Button type (WL: web link, AL: app link, BK: bot keyword, MD: forward message, AC: add channel, BT: chatbot conversion, BF: business form)<br>- AC type must be registered as the first button for TEXT and IMAGE, and as the last button for other message types|
-| \- linkMo| String| X        | Mobile web link (required for WL type), limited to 500 characters|
-| \- linkPc| String| X        | PC web link (optional for WL type), limited to 500 characters|
-| \- schemeAndroid| String| X        | Android app link (required for AL type), limited to 500 characters|
-| \- schemeIos| String| X        | iOS app link (required for AL type), limited to 500 characters|
-| \- bizFormKey| String| X        | BizForm key when the button is BF type|
-| coupon| Object| X        | Coupon elements|
-| \- title| String| O        | Limited to 5 formats for titles<br>- "${number} won discount coupon" number is 1 or greater and 99,999,999 or less<br>- "${number}% discount coupon" number is 1 or greater and 100 or less<br>- "Shipping discount coupon"<br>- "${within 7 characters} free coupon"<br>- "${within 7 characters} UP coupon"|
-| \- description| String| O        | Coupon details<br>- For WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO type, up to 18, linebreak: unavailable<br>- For other types, up to 12 characters, linebreak: unavailable|
-| \- linkMo| String| X        | Mobile web link (required for WL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \- linkPc| String| X        | PC web link (optional for WL type), limited to 500 characters|
-| \- schemeAndroid| String| X        | Android app link (required for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \- schemeIos| String| X        | iOS app link (required field for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
+| Name            | Type    | Required | Description                                                                                                                                                                                                                                                                                                                                                                                          |
+|-----------------|---------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| templateName    | String  | O        | Template name (up to 200 characters)                                                                                                                                                                                                                                                                                                                                                                 |
+| chatBubbleType  | String  | O        | Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)                                                                                                                                                                                                                                                                                          |
+| adult           | boolean | X        | Whether the message is for adults (default: false)                                                                                                                                                                                                                                                                                                                                                   |
+| content         | String  | O        | - For the TEXT type: up to 1,300 characters (line breaks: up to 99, URL format input allowed)<br>- For the IMAGE type: up to 1,300 characters (line breaks: up to 99, URL format input allowed)<br>- For the WIDE type: up to 76 characters (line breaks: up to 5)<br>- For the PREMIUM_VIDEO type: this field is optional, up to 76 characters (line breaks: up to 5)<br>- For all other types: this field is not used |
+| image           | Object  | O        | Image element<br>- Required field for the IMAGE, WIDE, and COMMERCE types                                                                                                                                                                                                                                                                                                                            |
+| - imageUrl      | String  | O        | Image URL; use the image URL uploaded as a wide image<br>Replacement variables are not allowed                                                                                                                                                                                                                                                                                                       |
+| - imageLink     | String  | X        | URL to navigate to when the image is clicked; limited to 500 characters<br>If not set, the KakaoTalk in-app image viewer is used<br>Replacement variables are not allowed                                                                                                                                                                                                                            |
+| buttons         | List    | X        | Button list<br>- For the TEXT and IMAGE types: up to 4 buttons when a coupon is applied, otherwise up to 5<br>- For the WIDE and WIDE_ITEM_LIST types: up to 2 buttons<br>- For the PREMIUM_VIDEO type: up to 1 button<br>- For the COMMERCE type: at least 1 and up to 2 buttons                                                                                                                    |
+| - name          | String  | O        | Button title<br>- For the TEXT and IMAGE types: up to 14 characters<br>- For all other types: up to 8 characters<br>Replacement variables are not allowed                                                                                                                                                                                                                                            |
+| - type          | String  | O        | Button type (WL: Web Link, AL: App Link, BK: Bot Keyword, MD: Message Delivery, AC: Add Channel, BT: Bot Transfer, BF: Business Form)<br>- The AC type must be registered as the first button for TEXT and IMAGE types, and as the last button for all other message types                                                                                                                           |
+| - linkMo        | String  | X        | Mobile web link (required for the WL type), limited to 500 characters                                                                                                                                                                                                                                                                                                                               |
+| - linkPc        | String  | X        | PC web link (optional for the WL type), limited to 500 characters                                                                                                                                                                                                                                                                                                                                   |
+| - schemeAndroid | String  | X        | Android app link (required for the AL type), limited to 500 characters                                                                                                                                                                                                                                                                                                                               |
+| - schemeIos     | String  | X        | iOS app link (required for the AL type), limited to 500 characters                                                                                                                                                                                                                                                                                                                                   |
+| - bizFormKey    | String  | X        | Business form key for the BF type button                                                                                                                                                                                                                                                                                                                                                             |
+| coupon          | Object  | X        | Coupon element                                                                                                                                                                                                                                                                                                                                                                                       |
+| - title         | String  | O        | For title, you are limited to five types:<br>- "${number}KRW off coupon" with a number greater than or equal to 1 and less than or equal to 99,999,999<br>- "${number}% off coupon" with a number greater than or equal to 1 and less than or equal to 100<br>- "Shipping discount coupon"<br>- "${7 characters} Free coupon"<br>- "${7 characters} UP coupon"                                        |
+| - description   | String  | O        | Detailed coupon description<br>- For the WIDE, WIDE_ITEM_LIST, and PREMIUM_VIDEO types: up to 18 characters, line breaks not allowed<br>- For all other types: up to 12 characters, line breaks not allowed                                                                                                                                                                                          |
+| - linkMo        | String  | X        | Mobile web link (required for the WL type), limited to 500 characters<br>If the linkMo field is entered for the coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional.                                                                                     |
+| - linkPc        | String  | X        | PC web link (optional for the WL type), limited to 500 characters                                                                                                                                                                                                                                                                                                                                   |
+| - schemeAndroid | String  | X        | Android app link (required for the AL type), limited to 500 characters<br>If the linkMo field is entered for the coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional.                                                                                    |
+| - schemeIos     | String  | X        | iOS app link (required for the AL type), limited to 500 characters<br>If the linkMo field is entered for the coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional.                                                                                        |
 
 <a id="request-to-register-wide-item-list-type-template"></a>
 
-#### Request to register wide item list type template
+#### Register Wide Item List Type Template Request
 
-\[Request body]
+[Request body]
 
 ```
 {
@@ -2786,41 +2882,41 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| templateName| String| O| Template name (up to 200 characters)|
-| chatBubbleType| String| O| Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)|
-| adult| boolean| X| Message status for adults (defaults: false)|
-| header| String| O| Header<br>- Required field for WIDE_ITEM_LIST type, up to 20 characters (linebreak: unavailable)<br>- Optional field for WIDE_ITEM_LIST type, up to 20 characters (linebreak: unavailable)|
-| item| Object| O| Wide list item (available only for WIDE_ITEM_LIST type)|
-| \- list| List| O| Wide list (minimum: 3, maximum 4)|
-| \-- title| String| O| Item title<br>- The first item is limited to up to 25 characters (linebreak: up to 1; for the first item, title is not required)<br>- For the first item, title field is not required<br>- 2 to 4th items are limited to up to 30 characters (linebreak: up 1 item)|
-| \-- imageUrl| String| O| Item image URL<br>- The first item uses the image URL uploaded as the first wide item list image.<br>- 2 to 4th items use the image URL uploaded as a general wide item list image<br>Placeholders unavailable|
-| \-- linkMo| String| O| Mobile web link, limited to 500 characters|
-| \-- linkPc| String| X| PC web link, limited to 500 characters|
-| \-- schemeAndroid| String| X| Android app link, limited to 500 characters|
-| \-- schemeIos| String| X| iOS app link, limited to 500 characters|
-| buttons| List| X| Button list<br>- For TEXT, IMAGE type, up to 4 when applying a coupon; for others, up to 5<br>- For WIDE, WIDE_ITEM_LIST type, up to 2<br>- For PREMIUM_VIDEO type, up to 1<br>- For COMMERCE type, minimum 1 and up to 2|
-| \- name| String| O| Button title<br>- For TEXT, IMAGE type, up to 14 characters<br>- For other types, up to 8 characters<br>No placeholders available|
-| \- type| String| O| Button type (WL: web link, AL: app link, BK: bot keyword, MD: forward message, AC: add channel, BT: chatbot conversion, BF: business form)<br>- AC type must be registered as the first button for TEXT and IMAGE, and as the last button for other message types|
-| \- linkMo| String| X| Mobile web link (required for WL type), limited to 500 characters|
-| \- linkPc| String| X| PC web link (optional for WL type), limited to 500 characters|
-| \- schemeAndroid| String| X| Android app link (required for AL type), limited to 500 characters|
-| \- schemeIos| String| X| iOS app link (required for AL type), limited to 500 characters|
-| \- bizFormKey| String| X| BizForm key when the button is BF type|
-| coupon| Object| X| Coupon elements|
-| \- title| String| O| Limited to 5 formats for titles<br>- "${number} won discount coupon" number is 1 or greater and 99,999,999 or less<br>- "${number}% discount coupon" number is 1 or greater and 100 or less<br>- "Shipping discount coupon"<br>- "${within 7 characters} free coupon"<br>- "${within 7 characters} UP coupon"|
-| \- description| String| O| Coupon details<br>- For WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO type, up to 18, linebreak: unavailable<br>- For other types, up to 12 characters, linebreak: unavailable|
-| \- linkMo| String| X| Mobile web link (required for WL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \- linkPc| String| X| PC web link (optional for WL type), limited to 500 characters|
-| \- schemeAndroid| String| X| Android app link (required for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \- schemeIos| String| X| iOS app link (required field for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
+| Name | Type | Required | Description |
+|------------------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| templateName | String | O | Template name (up to 200 characters) |
+| chatBubbleType | String | O | Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE) |
+| adult | boolean | X | Whether the message is for adults (default: false) |
+| header | String | O | Header<br>- Required for the WIDE_ITEM_LIST type, up to 20 characters (line breaks: not allowed)<br>- Optional for the PREMIUM_VIDEO type, up to 20 characters (line breaks: not allowed) |
+| item | Object | O | Wide list element (available only for the WIDE_ITEM_LIST type) |
+| - list | List | O | Wide list (minimum: 3, maximum: 4) |
+| -- title | String | O | Item title<br>- Up to 25 characters for the first item (line breaks: up to 1; title is not required for the first item)<br>- title is not a required field for the first item<br>- Up to 30 characters for items 2–4 (line breaks: up to 1) |
+| -- imageUrl | String | O | Item image URL<br>- For the first item, use the image URL uploaded as the first wide item list image<br>- For items 2–4, use the image URL uploaded as a general wide item list image<br>Replacement variables cannot be used |
+| -- linkMo | String | O | Mobile web link, up to 500 characters |
+| -- linkPc | String | X | PC web link, up to 500 characters |
+| -- schemeAndroid | String | X | Android app link, up to 500 characters |
+| -- schemeIos | String | X | iOS app link, up to 500 characters |
+| buttons | List | X | Button list<br>- Up to 4 buttons when a coupon is applied for the TEXT or IMAGE type; otherwise up to 5<br>- Up to 2 buttons for the WIDE or WIDE_ITEM_LIST type<br>- Up to 1 button for the PREMIUM_VIDEO type<br>- At least 1 and up to 2 buttons for the COMMERCE type |
+| - name | String | O | Button title<br>- Up to 14 characters for the TEXT or IMAGE type<br>- Up to 8 characters for all other types<br>Replacement variables cannot be used |
+| - type | String | O | Button type (WL: Web Link, AL: App Link, BK: Bot Keyword, MD: Message Delivery, AC: Add Channel, BT: Bot Transfer, BF: Business Form)<br>- The AC type must be registered as the first button for the TEXT and IMAGE types, and as the last button for all other message types |
+| - linkMo | String | X | Mobile web link (required for the WL type), up to 500 characters |
+| - linkPc | String | X | PC web link (optional for the WL type), up to 500 characters |
+| - schemeAndroid | String | X | Android app link (required for the AL type), up to 500 characters |
+| - schemeIos | String | X | iOS app link (required for the AL type), up to 500 characters |
+| - bizFormKey | String | X | Business form key for the BF type button |
+| coupon | Object | X | Coupon element |
+| - title | String | O | For title, you are limited to five types:<br>- "${number}KRW off coupon" with a number greater than or equal to 1 and less than or equal to 99,999,999<br>- "${number}% off coupon" with a number greater than or equal to 1 and less than or equal to 100<br>- "Shipping discount coupon"<br>- "${7 characters} Free coupon"<br>- "${7 characters} UP coupon" |
+| - description | String | O | Coupon detailed description<br>- Up to 18 characters for the WIDE, WIDE_ITEM_LIST, or PREMIUM_VIDEO type (line breaks: not allowed)<br>- Up to 12 characters for all other types (line breaks: not allowed) |
+| - linkMo | String | X | Mobile web link (required for the WL type), up to 500 characters<br>If the linkMo field is entered for a coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional. |
+| - linkPc | String | X | PC web link (optional for the WL type), up to 500 characters |
+| - schemeAndroid | String | X | Android app link (required for the AL type), up to 500 characters<br>If the linkMo field is entered for a coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional. |
+| - schemeIos | String | X | iOS app link (required for the AL type), up to 500 characters<br>If the linkMo field is entered for a coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional. |
 
 <a id="request-to-register-premium-video-type-template"></a>
 
-#### Request to register premium video type template
+#### Register Premium Video Type Template
 
-\[Request body]
+[Request body]
 
 ```
 {
@@ -2855,37 +2951,37 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| templateName| String| O| Template name (up 200 characters)|
-| chatBubbleType| String| O| Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)|
-| adult| boolean| X| Message status for adults (defaults: false)|
-| content| String| X| \- For TEXT type, up to 1,300 characters (linebreak: up to 99, URL type available)<br>- For IMAGE type, up to 1,300 characters (linebreak: up to 99, URL type available)<br>- For WIDE type, up to 76 characters (linebreak: up to 5)<br>- For PREMIUM_VIDEO type, the field can be used optionally, 76 characters (linebreak: up to 5)<br>- For other types, the field is unavailable.|
-| header| String| X| Header<br>- Required field for WIDE_ITEM_LIST type, up to 20 characters (linebreak: unavailable)<br>- Optional field for WIDE_ITEM_LIST type, up to 20 characters (linebreak: unavailable)|
-| video| Object| O| Video elements (only PREMIUM_VIDEO type available)|
-| \- videoUrl| String| O| KakaoTV video URL (only video addresses uploaded on KakaoTV available), limited to up to 500 characters<br>Placeholders unavailable|
-| \- thumbnailUrl| String| X| Image URL for video thumbnail. Only URLs uploaded as general images available (if none is available, the default KakaoTV video thumbnail is used). Limited to up to 500 characters<br>Placeholders unavailable|
-| buttons| List| X| Button list<br>- For TEXT, IMAGE type, up to 4 when applying a coupon; for others, up to 5<br>- For WIDE, WIDE_ITEM_LIST type, up to 2<br>- For PREMIUM_VIDEO type, up to 1<br>- For COMMERCE type, minimum 1 and up to 2|
-| \- name| String| O| Button title<br>- For TEXT, IMAGE type, up to 14 characters<br>- For other types, up to 8 characters<br>No placeholders available|
-| \- type| String| O| Button type (WL: web link, AL: app link, BK: bot keyword, MD: forward message, AC: add channel, BT: chatbot conversion, BF: business form)<br>- AC type must be registered as the first button for TEXT and IMAGE, and as the last button for other message types|
-| \- linkMo| String| X| Mobile web link (required for WL type), limited to 500 characters|
-| \- linkPc| String| X| PC web link (optional for WL type), limited to 500 characters|
-| \- schemeAndroid| String| X| Android app link (required for AL type), limited to 500 characters|
-| \- schemeIos| String| X| iOS app link (required for AL type), limited to 500 characters|
-| \- bizFormKey| String| X| BizForm key when the button is BF type|
-| coupon| Object| X| Coupon elements|
-| \- title| String| O| Limited to 5 formats for titles<br>- "${number} won discount coupon" number is 1 or greater and 99,999,999 or less<br>- "${number}% discount coupon" number is 1 or greater and 100 or less<br>- "Shipping discount coupon"<br>- "${within 7 characters} free coupon"<br>- "${within 7 characters} UP coupon"|
-| \- description| String| O| Coupon details<br>- For WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO type, up to 18, linebreak: unavailable<br>- For other types, up to 12 characters, linebreak: unavailable|
-| \- linkMo| String| X| Mobile web link (required for WL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \- linkPc| String| X| PC web link (optional for WL type), limited to 500 characters|
-| \- schemeAndroid| String| X| Android app link (required for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \- schemeIos| String| X| iOS app link (required field for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
+| Name | Type | Required | Description |
+|-----------------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| templateName | String | O | Template name (up to 200 characters) |
+| chatBubbleType | String | O | Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE) |
+| adult | boolean | X | Whether the message is for adults (default: false) |
+| content | String | X | - For the TEXT type: up to 1,300 characters (line breaks: up to 99, URL format allowed)<br>- For the IMAGE type: up to 1,300 characters (line breaks: up to 99, URL format allowed)<br>- For the WIDE type: up to 76 characters (line breaks: up to 5)<br>- For the PREMIUM_VIDEO type: this field is optional, up to 76 characters (line breaks: up to 5)<br>- For all other types: this field is not used |
+| header | String | X | Header<br>- For the WIDE_ITEM_LIST type: required field, up to 20 characters (line breaks: not allowed)<br>- For the PREMIUM_VIDEO type: optional field, up to 20 characters (line breaks: not allowed) |
+| video | Object | O | Video element (available for the PREMIUM_VIDEO type only) |
+| - videoUrl | String | O | KakaoTV video URL (only URLs of videos uploaded to KakaoTV are allowed), up to 500 characters<br>Replacement variables cannot be used |
+| - thumbnailUrl | String | X | Image URL for the video thumbnail. Only URLs uploaded as general images are allowed (if not provided, the default KakaoTV video thumbnail is used), up to 500 characters<br>Replacement variables cannot be used |
+| buttons | List | X | Button list<br>- For the TEXT and IMAGE types: up to 4 buttons when a coupon is applied, otherwise up to 5<br>- For the WIDE and WIDE_ITEM_LIST types: up to 2 buttons<br>- For the PREMIUM_VIDEO type: up to 1 button<br>- For the COMMERCE type: minimum 1 button, maximum 2 buttons |
+| - name | String | O | Button title<br>- For the TEXT and IMAGE types: up to 14 characters<br>- For all other types: up to 8 characters<br>Replacement variables cannot be used |
+| - type | String | O | Button type (WL: Web Link, AL: App Link, BK: Bot Keyword, MD: Message Delivery, AC: Add Channel, BT: Bot Transfer, BF: Business Form)<br>- The AC type must be registered as the first button for TEXT and IMAGE types, and as the last button for all other message types |
+| - linkMo | String | X | Mobile web link (required for the WL type), up to 500 characters |
+| - linkPc | String | X | PC web link (optional for the WL type), up to 500 characters |
+| - schemeAndroid | String | X | Android app link (required for the AL type), up to 1,000 characters |
+| - schemeIos | String | X | iOS app link (required for the AL type), up to 500 characters |
+| - bizFormKey | String | X | Biz form key for the BF type button |
+| coupon | Object | X | Coupon element |
+| - title | String | O | For title, you are limited to five types:<br>- "${number}KRW off coupon" with a number greater than or equal to 1 and less than or equal to 99,999,999<br>- "${number}% off coupon" with a number greater than or equal to 1 and less than or equal to 100<br>- "Shipping discount coupon"<br>- "${7 characters} Free coupon"<br>- "${7 characters} UP coupon" |
+| - description | String | O | Coupon detailed description<br>- For the WIDE, WIDE_ITEM_LIST, and PREMIUM_VIDEO types: up to 18 characters, line breaks not allowed<br>- For all other types: up to 12 characters, line breaks not allowed |
+| - linkMo | String | X | Mobile web link (required for the WL type), up to 500 characters<br>If the linkMo field is entered for a coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional. |
+| - linkPc | String | X | PC web link (optional for the WL type), up to 500 characters |
+| - schemeAndroid | String | X | Android app link (required for the AL type), up to 500 characters<br>If the linkMo field is entered for a coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional. |
+| - schemeIos | String | X | iOS app link (required for the AL type), up to 500 characters<br>If the linkMo field is entered for a coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional. |
 
 <a id="request-to-register-commerce-type-template"></a>
 
-#### Request to register commerce type template
+#### Register Commerce Type Template Request
 
-\[Request body]
+[Request body]
 
 ```
 {
@@ -2927,42 +3023,42 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required | Description|
-|----------|----------|----------|----------|
-| templateName| String| O        | Template name (up to 200 characters)|
-| chatBubbleType| String| O        | Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)|
-| adult| boolean| X        | Message status for adults (defaults: false)|
-| additionalContent| String| X        | Additional information (up to 34 characters, linebreak: up to 1), available only for commerce type|
-| image| Object| O        | Image elements<br>- Required fields for IMAGE, WIDE, COMMERCE types|
-| \- imageUrl| String| O        | Image URL, use an image URL uploaded as a general image<br>No placeholders available|
-| \- imageLink| String| X        | URL to go to when the image is clicked, limited to 500 characters<br>If not set, use the image viewer in KakaoTalk<br>No placeholders available|
-| commerce| Object| O        | Commerce (available only for COMMERCE type)|
-| title| String| O        | Product title (up to 30 characters, linebreak: unavailable)|
-| regularPrice| Integer| O        | Regular price (0 to 99,999,999)<br>Cannot customize placeholders, stored as a fixed placeholder `#{regular price}` if the value is left blank|
-| discountPrice| Integer| X        | Discount price (0 to 99,999,999)<br>Cannot customize placeholders, stored as a fixed placeholder `#{discount price}` if the value is left blank|
-| discountRate| Integer| X        | Discount rate (0 to 100), discount rate when a discount price exists, one of the fixed discount prices required<br>Cannot customize placeholders, stored as a fixed placeholder `#{discount rate}` if the value is left blank|
-| discountFixed| Integer| X        | Fixed discount rate (0 to 999,999), discount rate when a discount price exists, one of the fixed discount prices required<br>Cannot customize placeholders, stored as a fixed placeholder `#{fixed discount price}` if the value is left blank|
-| buttons| List| O        | Button list<br>- For TEXT, IMAGE type, up to 4 when applying a coupon; for others, up to 5<br>- For WIDE, WIDE_ITEM_LIST type, up to 2<br>- For PREMIUM_VIDEO type, up to 1<br>- For COMMERCE type, minimum 1 and up to 2|
-| \- name| String| O        | Button title<br>- For TEXT, IMAGE type, up to 14 characters<br>- For other types, up to 8 characters<br>No placeholders available|
-| \- type| String| O        | Button type (WL: web link, AL: app link, BK: bot keyword, MD: forward message, AC: add channel, BT: chatbot conversion, BF: business form)<br>- AC type must be registered as the first button for TEXT and IMAGE, and as the last button for other message types|
-| \- linkMo| String| X        | Mobile web link (required for WL type), limited to 500 characters|
-| \- linkPc| String| X        | PC web link (optional for WL type), limited to 500 characters|
-| \- schemeAndroid| String| X        | Android app link (required for AL type), limited to 1,000 characters|
-| \- schemeIos| String| X        | iOS app link (required for AL type), limited to 500 characters|
-| \- bizFormKey| String| X        | BizForm key when the button is BF type|
-| coupon| Object| X        | Coupon elements|
-| \- title| String| O        | Limited to 5 formats for titles<br>- "${number} won discount coupon" number is 1 or greater and 99,999,999 or less<br>- "${number}% discount coupon" number is 1 or greater and 100 or less<br>- "Shipping discount coupon"<br>- "${within 7 characters} free coupon"<br>- "${within 7 characters} UP coupon"|
-| \- description| String| O        | Coupon details<br>- For WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO type, up to 18, linebreak: unavailable<br>- For other types, up to 12 characters, linebreak: unavailable|
-| \- linkMo| String| X        | Mobile web link (required for WL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \- linkPc| String| X        | PC web link (optional for WL type), limited to 500 characters|
-| \- schemeAndroid| String| X        | Android app link (required for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \- schemeIos| String| X        | iOS app link (required field for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
+| Name | Type | Required | Description |
+|-------------------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| templateName | String | O | Template name (up to 200 characters) |
+| chatBubbleType | String | O | Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE) |
+| adult | boolean | X | Whether the message is for adults (default: false) |
+| additionalContent | String | X | Additional information (up to 34 characters, line breaks: up to 1), available for the Commerce type only |
+| image | Object | O | Image element<br>- Required for the IMAGE, WIDE, or COMMERCE type |
+| - imageUrl | String | O | Image URL; use the URL of an image uploaded as a general image<br>Replacement variables cannot be used |
+| - imageLink | String | X | URL to navigate to when the image is clicked, limited to 500 characters<br>If not set, the KakaoTalk in-app image viewer is used<br>Replacement variables cannot be used |
+| commerce | Object | O | Commerce (available for the COMMERCE type only) |
+| title | String | O | Product title (up to 30 characters, line breaks: not allowed) |
+| regularPrice | Integer | O | Regular price (0–99,999,999)<br>Replacement variable customization is not available; if left empty, it is saved as the fixed replacement variable `#{정상가격}` |
+| discountPrice | Integer | X | Discount price (0–99,999,999)<br>Replacement variable customization is not available; if left empty, it is saved as the fixed replacement variable `#{할인가격}` |
+| discountRate | Integer | X | Discount rate (0–100); when a discount price exists, either the discount rate or the fixed discount price is required<br>Replacement variable customization is not available; if left empty, it is saved as the fixed replacement variable `#{할인율}` |
+| discountFixed | Integer | X | Fixed discount price (0–999,999); when a discount price exists, either the discount rate or the fixed discount price is required<br>Replacement variable customization is not available; if left empty, it is saved as the fixed replacement variable `#{정액할인가격}` |
+| buttons | List | O | Button list<br>- For the TEXT or IMAGE type, up to 4 buttons when a coupon is applied, otherwise up to 5<br>- For the WIDE or WIDE_ITEM_LIST type, up to 2 buttons<br>- For the PREMIUM_VIDEO type, up to 1 button<br>- For the COMMERCE type, at least 1 and up to 2 buttons |
+| - name | String | O | Button title<br>- For the TEXT or IMAGE type, up to 14 characters<br>- For other types, up to 8 characters<br>Replacement variables cannot be used |
+| - type | String | O | Button type (WL: Web Link, AL: App Link, BK: Bot Keyword, MD: Message Delivery, AC: Add Channel, BT: Bot Transfer, BF: Business Form)<br>- The AC type must be registered as the first button for TEXT and IMAGE, and as the last button for all other message types |
+| - linkMo | String | X | Mobile web link (required for the WL type), limited to 500 characters |
+| - linkPc | String | X | PC web link (optional for the WL type), limited to 500 characters |
+| - schemeAndroid | String | X | Android app link (required for the AL type), limited to 500 characters |
+| - schemeIos | String | X | iOS app link (required for the AL type), limited to 500 characters |
+| - bizFormKey | String | X | Business form key for the BF type button |
+| coupon | Object | X | Coupon element |
+| - title | String | O | For title, you are limited to five types:<br>- "${number}KRW off coupon" with a number greater than or equal to 1 and less than or equal to 99,999,999<br>- "${number}% off coupon" with a number greater than or equal to 1 and less than or equal to 100<br>- "Shipping discount coupon"<br>- "${7 characters} Free coupon"<br>- "${7 characters} UP coupon" |
+| - description | String | O | Coupon detailed description<br>- For the WIDE, WIDE_ITEM_LIST, or PREMIUM_VIDEO type, up to 18 characters, line breaks: not allowed<br>- For other types, up to 12 characters, line breaks: not allowed |
+| - linkMo | String | X | Mobile web link (required for the WL type), limited to 500 characters<br>If the linkMo field is entered for the coupon, the remaining fields become optional;<br>if a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional. |
+| - linkPc | String | X | PC web link (optional for the WL type), limited to 500 characters |
+| - schemeAndroid | String | X | Android app link (required for the AL type), limited to 500 characters<br>If the linkMo field is entered for the coupon, the remaining fields become optional;<br>if a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional. |
+| - schemeIos | String | X | iOS app link (required for the AL type), limited to 500 characters<br>If the linkMo field is entered for the coupon, the remaining fields become optional;<br>if a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional. |
 
 <a id="request-to-register-carousel-feed-type-template"></a>
 
-#### Request to register carousel feed type template
+#### Register Carousel Feed Template
 
-\[Request body]
+[Request Body]
 
 ```
 {
@@ -3034,47 +3130,47 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required | Description|
-|----------|----------|----------|----------|
-| templateName| String| O        | Template name (up to 200 characters)|
-| chatBubbleType| String| O        | Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)|
-| pushAlarm| boolean| X        | Sending status for message push notifications (defaults: true)|
-| adult| boolean| X        | Message status for adults (defaults: false)|
-| carousel| Object| O        | Carousel|
-| \- list| List| O        | Carousel list (minimum 2, maximum 6)|
-| \-- header| String| O        | Carousel item title (up to 20 characters), available only for carousel feed type|
-| \-- message| String| O        | Carousel item title (up to 20 characters), carousel item message (up to 180 characters), available only for carousel feed type|
-| \-- imageUrl| String| O        | Image URL (use an image uploaded as a carousel feed type image<br>No placeholders available|
-| \-- imageLink| String| X        | Image link, limited to 500 characters<br>No placeholders available|
-| \-- buttons| List| O        | Carousel list button list, minimum 1, maximum 2|
-| \--- name| String| O        | Button title<br>- For TEXT, IMAGE type, up to 14 characters<br>- For other types, up to 8 characters<br>No placeholders available|
-| \--- type| String| O        | Button type (WL: web link, AL: app link, BK: bot keyword, MD: forward message, AC: add channel, BT: chatbot conversion, BF: business form)<br>- AC type must be registered as the first button for TEXT and IMAGE, and as the last button for other message types|
-| \--- linkMo| String| X        | Mobile web link (required for WL type), limited to 500 characters|
-| \--- linkPc| String| X        | PC web link (optional for WL type), limited to 500 characters|
-| \--- schemeAndroid| String| X        | Android app link (required for AL type), limited to 500 characters|
-| \--- schemeIos| String| X        | iOS app link (required for AL type), limited to 500 characters|
-| \--- bizFormKey| String| X        | BizForm key when the button is BF type|
-| \-- coupon| Object| X        | Coupon elements|
-| \--- title| String| O        | Limited to 5 formats for titles<br>- "${number} won discount coupon" number is 1 or greater and 99,999,999 or less<br>- "${number}% discount coupon" number is 1 or greater and 100 or less<br>- "Shipping discount coupon"<br>- "${within 7 characters} free coupon"<br>- "${within 7 characters} UP coupon"|
-| \--- description| String| O        | Coupon details<br>- For WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO type, up to 18, linebreak: unavailable<br>- For other types, up to 12 characters, linebreak: unavailable|
-| \--- linkMo| String| X        | Mobile web link (required for WL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \--- linkPc| String| X        | PC web link (optional for WL type), limited to 500 characters|
-| \--- schemeAndroid| String| X        | Android app link (required for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \--- schemeIos| String| X        | iOS app link (required field for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \- tail| Object| X        | More button information|
-| \-- linkMo| String| O        | Mobile web link, limited to 500 characters<br>No placeholders available|
-| \-- linkPc| String| X        | PC web link, limited to 500 characters<br>No placeholders available|
-| \-- schemeAndroid| String| X        | Android app link, limited to 500 characters<br>No placeholders available|
-| \-- schemeIos| String| X        | iOS app link, limited to 500 characters<br>No placeholders available|
-| recipientList| List| O        | Recipient list (up to 1,000)|
-| \- recipientNo| String| O        | Incoming number|
-| createUser| String| X        | Registrant (stored as user UUID when sent from console)|
+| Name                | Type      | Required | Description                                                                                                                                                                                                                                                                                                                                    |
+|-------------------|---------|----|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| templateName      | String  | O  | Template name (up to 200 characters)                                                                                                                                                                                                                                                                                                                           |
+| chatBubbleType    | String  | O  | Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)                                                                                                                                                                                                                                                    |
+| pushAlarm         | boolean | X  | Whether to send push alarm for message (default: true)                                                                                                                                                                                                                                                                                                         |
+| adult             | boolean | X  | Whether the message is for adults only (default: false)                                                                                                                                                                                                                                                                                                        |
+| carousel          | Object  | O  | Carousel                                                                                                                                                                                                                                                                                                                                                       |
+| - list            | List    | O  | Carousel list (minimum 2, maximum 6)                                                                                                                                                                                                                                                                                                                           |
+| -- header         | String  | O  | Carousel item title (up to 20 characters), only available in carousel feeds                                                                                                                                                                                                                                                                                    |
+| -- message        | String  | O  | Carousel item title (up to 20 characters), carousel item message (up to 180 characters), only available in carousel feeds                                                                                                                                                                                                                                      |
+| -- imageUrl       | String  | O  | Image URL (only images uploaded as carousel feed images can be used)<br>Replacement variables cannot be used                                                                                                                                                                                                                                                   |
+| -- imageLink      | String  | X  | Image link, limited to 500 characters<br>Replacement variables cannot be used                                                                                                                                                                                                                                                                                  |
+| -- buttons        | List    | O  | Carousel list button list, minimum 1, maximum 2                                                                                                                                                                                                                                                                                                                |
+| --- name          | String  | O  | Button title<br>- Up to 14 characters for TEXT and IMAGE types<br>- Up to 8 characters for other types<br>Replacement variables cannot be used                                                                                                                                                                                                                 |
+| --- type          | String  | O  | Button type (WL: Web Link, AL: App Link, BK: Bot Keyword, MD: Message Delivery, AC: Add Channel, BT: Bot Transfer, BF: Business Form)<br>- The AC type must be registered as the first button for TEXT and IMAGE types, and as the last button for other message types |
+| --- linkMo        | String  | X  | Mobile web link (required for the WL type), limited to 500 characters                                                                                                                                                                                                                                                                                         |
+| --- linkPc        | String  | X  | PC web link (optional for the WL type), limited to 500 characters                                                                                                                                                                                                                                                                                             |
+| --- schemeAndroid | String  | X  | Android app link (required for the AL type), limited to 500 characters                                                                                                                                                                                                                                                                                        |
+| --- schemeIos     | String  | X  | iOS app link (required for the AL type), limited to 500 characters                                                                                                                                                                                                                                                                                            |
+| --- bizFormKey    | String  | X  | Business form key for BF type buttons                                                                                                                                                                                                                                                                                                                          |
+| -- coupon         | Object  | X  | Coupon element                                                                                                                                                                                                                                                                                                                                                 |
+| --- title         | String  | O  | For title, you are limited to five types:<br>- "${number}KRW off coupon" with a number greater than or equal to 1 and less than or equal to 99,999,999<br>- "${number}% off coupon" with a number greater than or equal to 1 and less than or equal to 100<br>- "Shipping discount coupon"<br>- "${7 characters} Free coupon"<br>- "${7 characters} UP coupon" |
+| --- description   | String  | O  | Coupon detailed description<br>- Up to 18 characters for WIDE, WIDE_ITEM_LIST, and PREMIUM_VIDEO types; line breaks not allowed<br>- Up to 12 characters for other types; line breaks not allowed                                                                                                                                                              |
+| --- linkMo        | String  | X  | Mobile web link (required for the WL type), limited to 500 characters<br>If the linkMo field is entered for the coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional.                                               |
+| --- linkPc        | String  | X  | PC web link (optional for the WL type), limited to 500 characters                                                                                                                                                                                                                                                                                             |
+| --- schemeAndroid | String  | X  | Android app link (required for the AL type), limited to 500 characters<br>If the linkMo field is entered for the coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional.                                              |
+| --- schemeIos     | String  | X  | iOS app link (required for the AL type), limited to 500 characters<br>If the linkMo field is entered for the coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional.                                                  |
+| - tail            | Object  | X  | View More button information                                                                                                                                                                                                                                                                                                                                   |
+| -- linkMo         | String  | O  | Mobile web link, limited to 500 characters<br>Replacement variables cannot be used                                                                                                                                                                                                                                                                            |
+| -- linkPc         | String  | X  | PC web link, limited to 500 characters<br>Replacement variables cannot be used                                                                                                                                                                                                                                                                                |
+| -- schemeAndroid  | String  | X  | Android app link, limited to 500 characters<br>Replacement variables cannot be used                                                                                                                                                                                                                                                                           |
+| -- schemeIos      | String  | X  | iOS app link, limited to 500 characters<br>Replacement variables cannot be used                                                                                                                                                                                                                                                                               |
+| recipientList     | List    | O  | Recipient list (up to 1,000)                                                                                                                                                                                                                                                                                                                                   |
+| - recipientNo     | String  | O  | Recipient number                                                                                                                                                                                                                                                                                                                                               |
+| createUser        | String  | X  | Registrant (saved as user UUID when sending from the console)                                                                                                                                                                                                                                                                                                  |
 
 <a id="request-to-register-carousel-commerce-type-template"></a>
 
-#### Request to register carousel commerce type template
+#### Register Template Request for Carousel Commerce Type
 
-\[Request body]
+[Request Body]
 
 ```
 {
@@ -3134,51 +3230,51 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required | Description|
-|----------|----------|----------|----------|
-| templateName| String| O        | Template name (up to 200 characters)|
-| chatBubbleType| String| O        | Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)|
-| pushAlarm| boolean| X        | Sending status for message push notifications (defaults: true)|
-| adult| boolean| X        | Message status for adults (defaults: false)|
-| carousel| Object| O        | Carousel|
-| \- head| Object| X        | Carousel intro|
-| \-- header| String| O        | Carousel intro header (up to 20 characters)|
-| \-- content| String| O        | Carousel intro content (up to 50 characters)|
-| \-- imageUrl| String| O        | Carousel intro image address (use an image uploaded as a carousel commerce type image; the used image should have the same image and ratio of the carousel.)<br>No placeholders available|
-| \-- linkMo| String| X        | Mobile web link (linkMo is required if one of the linkMo, linkPc, schemeAndroid, schemeIos will be used), limited to up to 500 characters|
-| \-- linkPc| String| X        | PC web link, limited to 500 characters|
-| \-- schemeAndroid| String| X        | Android app link, limited to 500 characters|
-| \-- schemeIos| String| X        | iOS app link, limited to 500 characters|
-| \- list| List| O        | Carousel list (If head exists, minimum 1, maximum 5 / otherwise minimum 2, maximum 6)|
-| \-- additionalContent| String| X        | Additional info (up to 34 characters), available only for carousel commerce|
-| \-- imageUrl| String| O        | Image URL(use an image uploaded as a carousel commerce type image<br>No placeholders available|
-| \-- imageLink| String| X        | Image link, limited to 500 characters<br>No placeholders available|
-| \-- commerce| Object| O        | Commerce (available only for CAROUSEL_COMMERCE type)|
-| \--- title| String| O        | Product title (up to 30 characters, linebreak: unavailable)|
-| \--- regularPrice| Integer| O        | Regular price (0 to 99,999,999)<br>Cannot customize placeholders, stored as a fixed placeholder `#{regular price}` if the value is left blank|
-| \--- discountPrice| Integer| X        | Discount price (0 to 99,999,999)<br>Cannot customize placeholders, stored as a fixed placeholder `#{discount price}` if the value is left blank|
-| \--- discountRate| Integer| X        | Discount rate (0 to 100), discount rate when a discount price exists, one of the fixed discount prices required<br>Cannot customize placeholders, stored as a fixed placeholder `#{discount rate}` if the value is left blank|
-| \--- discountFixed| Integer| X        | Fixed discount rate (0 to 999,999), discount rate when a discount price exists, one of the fixed discount prices required<br>Cannot customize placeholders, stored as a fixed placeholder `#{fixed discount price}` if the value is left blank|
-| \-- buttons| List| O        | Carousel list button list, minimum 1, maximum 2|
-| \--- name| String| O        | Button title<br>- For TEXT, IMAGE type, up to 14 characters<br>- For other types, up to 8 characters<br>No placeholders available|
-| \--- type| String| O        | Button type (WL: web link, AL: app link, BK: bot keyword, MD: forward message, AC: add channel, BT: chatbot conversion, BF: business form)<br>- AC type must be registered as the first button for TEXT and IMAGE, and as the last button for other message types|
-| \--- linkMo| String| X        | Mobile web link (required for WL type), limited to 500 characters|
-| \--- linkPc| String| X        | PC web link (optional for WL type), limited to 500 characters|
-| \--- schemeAndroid| String| X        | Android app link (required for AL type), limited to 500 characters|
-| \--- schemeIos| String| X        | iOS app link (required for AL type), limited to 500 characters|
-| \--- bizFormKey| String| X        | BizForm key when the button is BF type|
-| \-- coupon| Object| X        | Coupon elements|
-| \--- title| String| O        | Limited to 5 formats for titles<br>- "${number} won discount coupon" number is 1 or greater and 99,999,999 or less<br>- "${number}% discount coupon" number is 1 or greater and 100 or less<br>- "Shipping discount coupon"<br>- "${within 7 characters} free coupon"<br>- "${within 7 characters} UP coupon"|
-| \--- description| String| O        | Coupon details<br>- For WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO type, up to 18, linebreak: unavailable<br>- For other types, up to 12 characters, linebreak: unavailable|
-| \--- linkMo| String| X        | Mobile web link (required for WL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \--- linkPc| String| X        | PC web link (optional for WL type), limited to 500 characters|
-| \--- schemeAndroid| String| X        | Android app link (required for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \--- schemeIos| String| X        | iOS app link (required field for AL type), limited to 500 characters<br>If entering linkMo field in the coupon, the remaining fields become optional.<br>If entering the channel coupon URL (format: alimtalk=coupon://) in the scheme_android or scheme_ios field, the remaining fields become optional.|
-| \- tail| Object| X        | More button information|
-| \-- linkMo| String| O        | Mobile web link, limited to 500 characters<br>No placeholders available|
-| \-- linkPc| String| X        | PC web link, limited to 500 characters<br>No placeholders available|
-| \-- schemeAndroid| String| X        | Android app link, limited to 500 characters<br>No placeholders available|
-| \-- schemeIos| String| X        | iOS app link, limited to 500 characters<br>No placeholders available|
+| Name | Type | Required | Description |
+|----------------------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| templateName | String | O | Template name (maximum 200 characters) |
+| chatBubbleType | String | O | Message type (TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE) |
+| pushAlarm | boolean | X | Whether to send a push notification for the message (default: true) |
+| adult | boolean | X | Whether the message is for adults only (default: false) |
+| carousel | Object | O | Carousel |
+| - head | Object | X | Carousel intro |
+| -- header | String | O | Carousel intro header (maximum 20 characters) |
+| -- content | String | O | Carousel intro content (maximum 50 characters) |
+| -- imageUrl | String | O | Carousel intro image URL (use an image uploaded as a Carousel Commerce type image; the image must have the same aspect ratio as the carousel images)<br>Replacement variables cannot be used |
+| -- linkMo | String | X | Mobile web link (required if you intend to use any of linkMo, linkPc, schemeAndroid, or schemeIos), up to 500 characters |
+| -- linkPc | String | X | PC web link, up to 500 characters |
+| -- schemeAndroid | String | X | Android app link, up to 500 characters |
+| -- schemeIos | String | X | iOS app link, up to 500 characters |
+| - list | List | O | Carousel list (minimum 1, maximum 5 items if head exists; otherwise minimum 2, maximum 6 items) |
+| -- additionalContent | String | X | Additional information (maximum 34 characters); available only for the Carousel Commerce type |
+| -- imageUrl | String | O | Image URL (use an image uploaded as a Carousel Commerce type image)<br>Replacement variables cannot be used |
+| -- imageLink | String | X | Image link, up to 500 characters<br>Replacement variables cannot be used |
+| -- commerce | Object | O | Commerce (available only for the CAROUSEL_COMMERCE type) |
+| --- title | String | O | Product title (maximum 30 characters; line breaks not allowed) |
+| --- regularPrice | Integer | O | Regular price (0–99,999,999)<br>Custom replacement variables cannot be used; if left empty, the fixed replacement variable `#{정상가격}` is used |
+| --- discountPrice | Integer | X | Discount price (0–99,999,999)<br>Custom replacement variables cannot be used; if left empty, the fixed replacement variable `#{할인가격}` is used |
+| --- discountRate | Integer | X | Discount rate (0–100); when a discount price exists, either discount rate or fixed discount price is required<br>Custom replacement variables cannot be used; if left empty, the fixed replacement variable `#{할인율}` is used |
+| --- discountFixed | Integer | X | Fixed discount price (0–999,999); when a discount price exists, either discount rate or fixed discount price is required<br>Custom replacement variables cannot be used; if left empty, the fixed replacement variable `#{정액할인가격}` is used |
+| -- buttons | List | O | List of carousel buttons (minimum 1, maximum 2) |
+| --- name | String | O | Button title<br>- Maximum 14 characters for the TEXT or IMAGE type<br>- Maximum 8 characters for all other types<br>Replacement variables cannot be used |
+| --- type | String | O | Button type (WL: Web Link, AL: App Link, BK: Bot Keyword, MD: Message Delivery, AC: Channel Added, BT: Bot Transfer, BF: Business Form)<br>- The AC type must be registered as the first button for TEXT and IMAGE types, and as the last button for all other message types |
+| --- linkMo | String | X | Mobile web link (required for the WL type), up to 500 characters |
+| --- linkPc | String | X | PC web link (optional for the WL type), up to 500 characters |
+| --- schemeAndroid | String | X | Android app link (required for the AL type), up to 500 characters |
+| --- schemeIos | String | X | iOS app link (required for the AL type), up to 500 characters |
+| --- bizFormKey | String | X | Business form key for the BF type button |
+| -- coupon | Object | X | Coupon element |
+| --- title | String | O | For title, you are limited to five types:<br>- "${number}KRW off coupon" with a number greater than or equal to 1 and less than or equal to 99,999,999<br>- "${number}% off coupon" with a number greater than or equal to 1 and less than or equal to 100<br>- "Shipping discount coupon"<br>- "${7 characters} Free coupon"<br>- "${7 characters} UP coupon" |
+| --- description | String | O | Coupon detailed description<br>- Maximum 18 characters for the WIDE, WIDE_ITEM_LIST, or PREMIUM_VIDEO type; line breaks not allowed<br>- Maximum 12 characters for all other types; line breaks not allowed |
+| --- linkMo | String | X | Mobile web link (required for the WL type), up to 500 characters<br>If the linkMo field is entered for the coupon, the remaining fields become optional;<br>if a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional. |
+| --- linkPc           | String  | X  | PC web link (optional for the WL type), up to 500 characters                                                                                                                                                                                              |
+| --- schemeAndroid    | String  | X  | Android app link (required for the AL type), up to 500 characters<br>If the linkMo field is entered for a coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional.                                     |
+| --- schemeIos        | String  | X  | iOS app link (required for the AL type), up to 500 characters<br>If the linkMo field is entered for a coupon, the remaining fields become optional.<br>If a channel coupon URL (format: alimtalk=coupon://) is entered in the scheme_android or scheme_ios field, the remaining fields become optional.                                       |
+| - tail               | Object  | X  | More button information                                                                                                                                                                                                                         |
+| -- linkMo            | String  | O  | Mobile web link, up to 500 characters<br>Replacement variables cannot be used.                                                                                                                                                                                                 |
+| -- linkPc            | String  | X  | PC web link, up to 500 characters<br>Replacement variables cannot be used.                                                                                                                                                                                                  |
+| -- schemeAndroid     | String  | X  | Android app link, up to 500 characters<br>Replacement variables cannot be used.                                                                                                                                                                                               |
+| -- schemeIos         | String  | X  | iOS app link, up to 500 characters<br>Replacement variables cannot be used.                                                                                                                                                                                                 |
 
 <a id="response-10"></a>
 
@@ -3197,14 +3293,14 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Not Null| Description|
-|:----------|:----------|:----------|:----------|
-| header| Object| O| Header zone|
-| \- resultCode| Integer| O| Result code|
-| \- resultMessage| String| O| Result message|
-| \- isSuccessful| boolean| O| Success status|
-| template| Object| X| Template Info|
-| \- templateCode| String| O| Template Code|
+| Name            | Type    | Not Null | Description     |
+|:----------------|:--------|:---------|:----------------|
+| header          | Object  | O        | Header area     |
+| - resultCode    | Integer | O        | Result code     |
+| - resultMessage | String  | O        | Result message  |
+| - isSuccessful  | boolean | O        | Success         |
+| template        | Object  | X        | Template information |
+| - templateCode  | String  | O        | Template Code   |
 
 <a id="modify-template"></a>
 
@@ -3212,24 +3308,24 @@ Content-Type: application/json;charset=UTF-8
 
 <a id="requested-11"></a>
 
-#### Requested
+#### Request
 
-\[URL]
+[URL]
 
 ```
 PUT  /brand-message/v1.0/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}
 Content-Type: application/json;charset=UTF-8
 ```
 
-\[Path parameter]
+[Path parameter]
 
-| Name| Type| Description|
-|----------|----------|----------|
-| appkey| String| Unique appkey|
-| senderKey| String| Outgoing Key|
-| templateCode| String| Template Code|
+| Name         | Type   | Description      |
+|--------------|--------|------------------|
+| appkey       | String | Unique app key   |
+| senderKey    | String | Sender Key       |
+| templateCode | String | Template Code    |
 
-\[Header]
+[Header]
 
 ```
 {
@@ -3237,11 +3333,11 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| X-Secret-Key| String| O| Available to create from the console.|
+| Name         | Type   | Required | Description                          |
+|--------------|--------|----------|--------------------------------------|
+| X-Secret-Key | String | O        | Can be created in the console.       |
 
-\[Request Body]
+[Request Body]
 
 * Same specifications as template registration
 
@@ -3259,12 +3355,12 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Not Null| Description|
-|:----------|:----------|:----------|:----------|
-| header| Object| O| Header zone|
-| \- resultCode| Integer| O| Result code|
-| \- resultMessage| String| O| Result message|
-| \- isSuccessful| boolean| O| Success status|
+| Name            | Type    | Not Null | Description    |
+|:----------------|:--------|:---------|:---------------|
+| header          | Object  | O        | Header area    |
+| - resultCode    | Integer | O        | Result code    |
+| - resultMessage | String  | O        | Result message |
+| - isSuccessful  | boolean | O        | Success        |
 
 <a id="delete-template"></a>
 
@@ -3272,24 +3368,24 @@ Content-Type: application/json;charset=UTF-8
 
 <a id="requested-12"></a>
 
-#### Requested
+#### Request
 
-\[URL]
+[URL]
 
 ```
 DELETE  /brand-message/v1.0/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}
 Content-Type: application/json;charset=UTF-8
 ```
 
-\[Path parameter]
+[Path parameter]
 
-| Name| Type| Description|
-|----------|----------|----------|
-| appkey| String| Unique appkey|
-| senderKey| String| Outgoing Key|
-| templateCode| String| Template Code|
+| Name         | Type   | Description       |
+|--------------|--------|-------------------|
+| appkey       | String | Unique app key    |
+| senderKey    | String | Sender Key        |
+| templateCode | String | Template Code     |
 
-\[Header]
+[Header]
 
 ```
 {
@@ -3297,9 +3393,9 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| X-Secret-Key| String| O| Available to create from the console.|
+| Name         | Type   | Required | Description                        |
+|--------------|--------|----------|------------------------------------|
+| X-Secret-Key | String | O        | Can be created in the console.     |
 
 <a id="response-12"></a>
 
@@ -3315,39 +3411,39 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Not Null| Description|
-|:----------|:----------|:----------|:----------|
-| header| Object| O| Header zone|
-| \- resultCode| Integer| O| Result code|
-| \- resultMessage| String| O| Result message|
-| \- isSuccessful| boolean| O| Success status|
+| Name            | Type    | Not Null | Description    |
+|:----------------|:--------|:---------|:---------------|
+| header          | Object  | O        | Header area    |
+| - resultCode    | Integer | O        | Result code    |
+| - resultMessage | String  | O        | Result message |
+| - isSuccessful  | boolean | O        | Success        |
 
 <a id="manage-image"></a>
 
-## Manage Image
+## Image Management
 
 <a id="upload-image"></a>
 
-### Upload image
+### Upload Image
 
 <a id="requested-13"></a>
 
-#### Requested
+#### Request
 
-\[URL]
+[URL]
 
 ```
 POST  /brand-message/v1.0/appkeys/{appKey}/images
 Content-Type: multipart/form-data
 ```
 
-\[Path parameter]
+[Path parameter]
 
-| Name| Type| Description|
-|----------|----------|----------|
-| appkey| String| Unique appkey|
+| Name | Type | Description |
+|--------|--------|--------|
+| appkey | String | Unique appkey |
 
-\[Header]
+[Header]
 
 ```
 {
@@ -3355,16 +3451,16 @@ Content-Type: multipart/form-data
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| X-Secret-Key| String| O| Available to create from the console.|
+| Name | Type | Required | Description |
+|--------------|--------|----|------------------|
+| X-Secret-Key | String | O  | Can be created in the console. |
 
-\[Request parameter]
+[Request parameter]
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| image| File| O| Image|
-| imageType| String| O| Image type <br>(IMAGE, WIDE_IMAGE,MAIN_WIDE_ITEMLIST_IMAGE,NORMAL_WIDE_ITEMLIST_IMAGE,CAROUSEL_FEED_IMAGE,CAROUSEL_COMMERCE_IMAGE)|
+| Name | Type | Required | Description |
+|-----------|--------|----|--------------------------------------------------------------------------------------------------------------------------------|
+| image     | File   | O  | Image |
+| imageType | String | O  | Image type <br>(IMAGE, WIDE_IMAGE, MAIN_WIDE_ITEMLIST_IMAGE, NORMAL_WIDE_ITEMLIST_IMAGE, CAROUSEL_FEED_IMAGE, CAROUSEL_COMMERCE_IMAGE) |
 
 <a id="response-13"></a>
 
@@ -3385,53 +3481,54 @@ Content-Type: multipart/form-data
 }
 ```
 
-| Name| Type| Not Null| Description|
-|:----------|:----------|:----------|:----------|
-| header| Object| O| Header zone|
-| \- resultCode| Integer| O| Result code|
-| \- resultMessage| String| O| Result message|
-| \- isSuccessful| boolean| O| Success status|
-| image| Object| X| Image area|
-| \- imageSeq| Integer| O| Image sequence|
-| \- imageUrl| String| O| Image URL|
-| \- imageName| String| X| Image Name|
+| Name | Type | Not Null | Description |
+|:----------------|:--------|:---------|:--------|
+| header          | Object  | O        | Header area |
+| - resultCode    | Integer | O        | Result code |
+| - resultMessage | String  | O        | Result message |
+| - isSuccessful  | boolean | O        | Success |
+| image           | Object  | X        | Image area |
+| - imageSeq      | Integer | O        | Image sequence |
+| - imageUrl      | String  | O        | Image URL |
+| - imageName     | String  | X        | Image name |
 
 <a id="upload-image-specifications"></a>
 
 #### Upload Image Specifications
-| Image Type                 | Usage                                                                   | Upload Image Specifications                                                                                                                                                      |
-| :------------------------- | :---------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| IMAGE                      | Image-type image, Commerce-type image, Premium video-type thumbnail     | **Recommended size:** 800 × 400 px (width ≥ 500 px)<br/>**Aspect ratio:** 0.5 ≤ (height ÷ width) ≤ 1.333<br/>**File format & size limit:** JPG, PNG / up to 5 MB                 |
-| WIDE_IMAGE                 | Wide image-type image                                                   | **Recommended size:** 800 × 600 px (width ≥ 500 px)<br/>**Aspect ratio:** 0.5 ≤ (height ÷ width) ≤ 1<br/>**File format & size limit:** JPG, PNG / up to 5 MB                     |
-| MAIN_WIDE_ITEMLIST_IMAGE   | First item image in a wide item list                                    | **Minimum size:** width ≥ 500 px<br/>**Aspect ratio:** (height ÷ width) = 0.5<br/>**File format & size limit:** JPG, PNG / up to 5 MB                                            |
-| NORMAL_WIDE_ITEMLIST_IMAGE | Item images #2–#4 in a wide item list                                   | **Minimum size:** width ≥ 500 px<br/>**Aspect ratio:** (height ÷ width) = 1<br/>**File format & size limit:** JPG, PNG / up to 5 MB each                                         |
-| CAROUSEL_FEED_IMAGE        | Per-cell image in a carousel feed                                       | **Recommended size:** 800 × 600 px or 800 × 400 px (width ≥ 500 px)<br/>**Aspect ratio:** 0.5 ≤ (height ÷ width) ≤ 1.333<br/>**File format & size limit:** JPG, PNG / up to 5 MB |
-| CAROUSEL_COMMERCE_IMAGE    | Intro image for carousel commerce, per-cell image for carousel commerce | **Recommended size:** 800 × 600 px or 800 × 400 px (width ≥ 500 px)<br/>**Aspect ratio:** 0.5 ≤ (height ÷ width) ≤ 1.333<br/>**File format & size limit:** JPG, PNG / up to 5 MB |
 
-* When updating a template, if the image is changed to a different one, the existing image is deleted from the Kakao CDN and the URL becomes invalid. Other templates using the same image are also affected, so caution is required. Although image information is retained in the image retrieval API, the actual image cannot be accessed, so it is recommended to keep the original file separately on your own server.
+| Image Type | Usage | Upload Image Specifications |
+|:---------------------------|:--------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------|
+| IMAGE                      | Image type image, Commerce type image, Premium video type thumbnail | Recommended size: 800 x 400 px (width 500 px or more)<br/>Image ratio: 0.5 ≤ height ÷ width ≤ 1.333<br/>File format and size limit: jpg, png / up to 5 MB |
+| WIDE_IMAGE                 | Wide Image type image | Recommended size: 800 x 600 px (width 500 px or more)<br/>Image ratio: 0.5 ≤ height ÷ width ≤ 1<br>File format and size limit: jpg, png / up to 5 MB |
+| MAIN_WIDE_ITEMLIST_IMAGE   | First item image of Wide Item List type | Size limit: width 500 px or more<br/>Image ratio: height ÷ width = 0.5<br/>File format and size limit: jpg, png / up to 5 MB |
+| NORMAL_WIDE_ITEMLIST_IMAGE | 2nd–4th item images of Wide Item List type | Size limit: width 500 px or more<br/>Image ratio: height ÷ width = 1<br/>File format and size: jpg, png / up to 5 MB per file |
+| CAROUSEL_FEED_IMAGE        | Per-cell image of Carousel Feed type | Recommended size: 800 x 600 px or 800 x 400 px (width 500 px or more)<br/>Image ratio: 0.5 ≤ height ÷ width ≤ 1.333<br/>File format and size limit: jpg, png / up to 5 MB |
+| CAROUSEL_COMMERCE_IMAGE    | Intro image of Carousel Commerce type, per-cell image of Carousel Commerce type | Recommended size: 800 x 600 px or 800 x 400 px (width 500 px or more)<br/>Image ratio: 0.5 ≤ height ÷ width ≤ 1.333<br/>File format and size limit: jpg, png / up to 5 MB |
+
+* If all templates that reference an uploaded image are deleted or changed to a different image, the image is deleted from the Kakao CDN and the URL becomes invalid. Although image information is retained in the image retrieval API, the actual image cannot be accessed, so it is recommended to keep the original file separately on your own server.
 
 <a id="view-image"></a>
 
-### View image
+### View Image
 
 <a id="requested-14"></a>
 
-#### Requested
+#### Request
 
-\[URL]
+[URL]
 
 ```
 GET  /brand-message/v1.0/appkeys/{appKey}/images
 Content-Type: application/json;charset=UTF-8
 ```
 
-\[Path parameter]
+[Path parameter]
 
-| Name| Type| Description|
-|----------|----------|----------|
-| appkey| String| Unique appkey|
+| Name | Type | Description |
+|--------|--------|--------|
+| appkey | String | Unique appkey |
 
-\[Header]
+[Header]
 
 ```
 {
@@ -3439,17 +3536,17 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| X-Secret-Key| String| O| Available to create from the console.|
+| Name | Type | Required | Description |
+|--------------|--------|----|------------------|
+| X-Secret-Key | String | O  | Can be created in the console. |
 
-\[Request parameter]
+[Request parameter]
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| imageTypes| List| O| Image type <br>(IMAGE, WIDE_IMAGE,MAIN_WIDE_ITEMLIST_IMAGE,NORMAL_WIDE_ITEMLIST_IMAGE,CAROUSEL_FEED_IMAGE,CAROUSEL_COMMERCE_IMAGE)|
-| pageNum| String| X| Page number (default: 1\)|
-| pageSize| String| X| Number of views (default: 15\)|
+| Name | Type | Required | Description |
+|------------|--------|----|--------------------------------------------------------------------------------------------------------------------------------|
+| imageTypes | List   | O  | Image type <br>(IMAGE, WIDE_IMAGE, MAIN_WIDE_ITEMLIST_IMAGE, NORMAL_WIDE_ITEMLIST_IMAGE, CAROUSEL_FEED_IMAGE, CAROUSEL_COMMERCE_IMAGE) |
+| pageNum    | String | X  | Page number (default: 1) |
+| pageSize   | String | X  | Number of results (default: 15) |
 
 <a id="response-14"></a>
 
@@ -3470,16 +3567,16 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Not Null| Description|
-|:----------|:----------|:----------|:----------|
-| header| Object| O| Header zone|
-| \- resultCode| Integer| O| Result code|
-| \- resultMessage| String| O| Result message|
-| \- isSuccessful| boolean| O| Success status|
-| image| Object| X| Image area|
-| \- imageSeq| Integer| O| Image sequence|
-| \- imageUrl| String| O| Image URL|
-| \- imageName| String| X| Image Name|
+| Name | Type | Not Null | Description |
+|:----------------|:--------|:---------|:--------|
+| header          | Object  | O        | Header area |
+| - resultCode    | Integer | O        | Result code |
+| - resultMessage | String  | O        | Result message |
+| - isSuccessful  | boolean | O        | Success |
+| image           | Object  | X        | Image area |
+| - imageSeq      | Integer | O        | Image sequence |
+| - imageUrl      | String  | O        | Image URL |
+| - imageName     | String  | X        | Image name |
 
 <a id="delete-image"></a>
 
@@ -3487,22 +3584,22 @@ Content-Type: application/json;charset=UTF-8
 
 <a id="requested-15"></a>
 
-#### Requested
+#### Request
 
-\[URL]
+[URL]
 
 ```
 DELETE  /brand-message/v1.0/appkeys/{appKey}/images
 Content-Type: application/json;charset=UTF-8
 ```
 
-\[Path parameter]
+[Path parameter]
 
-| Name| Type| Description|
-|----------|----------|----------|
-| appkey| String| Unique appkey|
+| Name | Type | Description |
+|--------|--------|--------|
+| appkey | String | Unique appkey |
 
-\[Header]
+[Header]
 
 ```
 {
@@ -3510,15 +3607,15 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| X-Secret-Key| String| O| Available to create from the console.|
+| Name | Type | Required | Description |
+|--------------|--------|----|------------------|
+| X-Secret-Key | String | O  | Can be created in the console. |
 
-\[Query parameter]
+[Query parameter]
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| imageSeq| String| O| Image number|
+| Name | Type | Required | Description |
+|----------|--------|----|--------|
+| imageSeq | String | O  | Image number |
 
 <a id="response-15"></a>
 
@@ -3534,33 +3631,33 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Not Null| Description|
-|:----------|:----------|:----------|:----------|
-| header| Object| O| Header zone|
-| \- resultCode| Integer| O| Result code|
-| \- resultMessage| String| O| Result message|
-| \- isSuccessful| boolean| O| Success status|
+| Name | Type | Not Null | Description |
+|:----------------|:--------|:---------|:-------|
+| header          | Object  | O        | Header area |
+| - resultCode    | Integer | O        | Result code |
+| - resultMessage | String  | O        | Result message |
+| - isSuccessful  | boolean | O        | Success |
 
 <a id="manage-video"></a>
 
 ## Video Management
 
-An API for registering, retrieving, and deleting videos to be used in brand messages. Registered videos can be used for sending after encoding is complete in KakaoBizCenter. Only videos in `PUBLIC` status can be used for template registration and sending (`PRIVATE` status allows template registration only).
+This API is used to register, view, and delete videos for use in Brand Message. Registered videos can be used for sending after encoding by the Kakao Biz Center, and only videos with a status of `PUBLIC` can be used for template registration and sending (`PRIVATE` allows template registration only).
 
 <a id="video-upload-flow"></a>
 
 ### Video Upload Flow
 
-The video upload process consists of 2 steps.
+Video upload is a two-step process.
 
-1. **Register video upload** — Send video metadata (file name and file size) as JSON to this API (`POST /brand-message/v1.0/appkeys/{appKey}/videos`). The response includes `video` (registration information on the NHN Cloud side) and `uploadInfo` (Kakao upload URL and token).
-2. **Upload video file** — Directly upload the video file to `uploadInfo.uploadUrl` received in the response as `multipart/form-data`. For authentication, pass `uploadInfo.token` as the `x-kamp-upload-token` header.
+1. **Register video upload** — Send video metadata (file name and file size) as JSON to this API (`POST /brand-message/v1.0/appkeys/{appKey}/videos`). The response returns `video` (registration information on the NHN Cloud side) and `uploadInfo` (Kakao upload URL and token).
+2. **Upload the video file** — Upload the video file directly to `uploadInfo.uploadUrl` using `multipart/form-data`. For authentication, pass `uploadInfo.token` as the `x-kamp-upload-token` header.
 
-The video file is sent directly to Kakao's upload server without going through NHN Cloud servers. Therefore, the request body of this API sends only metadata as JSON, and the actual file is sent separately in step 2.
+The video file is sent directly to the Kakao upload server without passing through NHN Cloud servers. Therefore, the request body of this API contains only metadata in JSON format, and the actual file is sent separately in step 2.
 
 > **Caution**
-> * `uploadInfo.token` is valid for 5 minutes after issuance. If 5 minutes have elapsed, you must call step 1 registration again to obtain a new token.
-> * The `fileSize` in the step 1 request must exactly match the size of the file to be uploaded in step 2 (a mismatch will result in rejection by Kakao with errCode 109).
+> * `uploadInfo.token` is valid for 5 minutes after it is issued. If 5 minutes have elapsed, you must call the step 1 registration again to obtain a new token.
+> * The `fileSize` in the step 1 request must exactly match the size of the file that will be uploaded in step 2. If the sizes do not match, Kakao will reject the request with errCode 109.
 
 <a id="register-video-upload"></a>
 
@@ -3568,7 +3665,7 @@ The video file is sent directly to Kakao's upload server without going through N
 
 <a id="requested-16"></a>
 
-#### Requested
+#### Request
 
 [URL]
 
@@ -3579,9 +3676,9 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name | Type | Description |
+| Name     | Type     | Description     |
 |--------|--------|--------|
-| appKey | String | Unique appkey |
+| appKey | String | Unique app key |
 
 [Header]
 
@@ -3591,9 +3688,9 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name | Type | Required | Description |
+| Name           | Type     | Required | Description               |
 |--------------|--------|----|------------------|
-| X-Secret-Key | String | O | Can be created in the console. |
+| X-Secret-Key | String | O  | Can be created in the console. |
 
 [Request body]
 
@@ -3606,12 +3703,12 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name | Type | Required | Description |
+| Name         | Type     | Required | Description                                                                  |
 |------------|--------|----|---------------------------------------------------------------------|
-| senderKey | String | O | Sender profile key (40 characters) |
-| fileName | String | O | Video file name (including extension; one of MP4, MOV, or AVI; up to 250 characters) |
-| fileSize | Long | O | Video file size (in bytes; maximum 4 GB) |
-| createUser | String | X | Upload user identifier (up to 100 characters) |
+| senderKey  | String | O  | Sender Profile key (40 characters)                                                       |
+| fileName   | String | O  | Video file name (including extension; must be MP4, MOV, or AVI; up to 250 characters)                          |
+| fileSize   | Long   | O  | Video file size (bytes; up to 4 GB)                                              |
+| createUser | String | X  | Upload user identifier (up to 100 characters)                                                |
 
 <a id="response-16"></a>
 
@@ -3640,35 +3737,35 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name | Type | Not Null | Description |
+| Name              | Type      | Not Null | Description                                                                              |
 |:----------------|:--------|:---------|:--------------------------------------------------------------------------------|
-| header | Object | O | |
-| - resultCode | Integer | O | Result code |
-| - resultMessage | String | O | Result message |
-| - isSuccessful | boolean | O | Whether the request was successful |
-| video | Object | X | Video information registered on the NHN Cloud side (status = `REGISTERED`) |
-| - videoSeq | Long | O | Video sequence |
-| - vid | String | O | Kakao video ID |
-| - senderKey | String | O | Sender profile key |
-| - title | String | X | Video title (immediately after upload, the file name is used; synchronized with the value modified in KakaoBizCenter after encoding is complete) |
-| - fileName | String | O | Uploaded file name |
-| - fileSize | Long | O | File size (in bytes) |
-| - status | String | O | Video status (see [Video Status](#video-status)). Always `REGISTERED` in the upload registration response. |
-| uploadInfo | Object | O | Kakao upload information. Used in step 2. |
-| - uploadUrl | String | O | Kakao endpoint for directly uploading the video file |
-| - token | String | O | Upload authentication token. Pass as the `x-kamp-upload-token` header. |
+| header          | Object  | O        | Header area                                                                           |
+| - resultCode    | Integer | O        | Result code                                                                           |
+| - resultMessage | String  | O        | Result message                                                                          |
+| - isSuccessful  | boolean | O        | Success                                                                           |
+| video           | Object  | X        | Video information registered on the NHN Cloud side (status = `REGISTERED`)                                   |
+| - videoSeq      | Long    | O        | Video sequence                                                                         |
+| - vid           | String  | O        | Kakao video ID                                                                      |
+| - senderKey     | String  | O        | Sender Profile key                                                                         |
+| - title         | String  | X        | Video title (set to the file name immediately after upload; synchronized with the value edited in Kakao Biz Center after encoding is complete)                        |
+| - fileName      | String  | O        | Uploaded file name                                                                         |
+| - fileSize      | Long    | O        | File size (bytes)                                                                    |
+| - status        | String  | O        | Video status (see [Video Status](#동영상-상태)). Always `REGISTERED` in the upload registration response.                     |
+| uploadInfo      | Object  | O        | Kakao upload information. Used in step 2.                                                            |
+| - uploadUrl     | String  | O        | Kakao endpoint to which the video file is uploaded directly                                                     |
+| - token         | String  | O        | Upload authentication token. Passed via the `x-kamp-upload-token` header.                                          |
 
-> The `thumbnailUrl`, `videoUrl`, `playUrl`, and `updateDate` fields, which are populated after encoding is complete, can be obtained through the [Retrieve Video](#retrieve-video) API.
+> The `thumbnailUrl`, `videoUrl`, `playUrl`, and `updateDate` fields, which are populated after encoding is complete, can be retrieved using the [Get Video](#동영상-조회) API.
 
 <a id="video-file-upload-step-2"></a>
 
 ### Upload Video File (Step 2)
 
-Call `uploadInfo.uploadUrl` from the above response to directly upload the video file. This request is sent directly to Kakao's upload server, not to NHN Cloud servers.
+Call the video file directly to `uploadInfo.uploadUrl` from the response above. This request is sent directly to the Kakao upload server, not to the NHN Cloud server.
 
 <a id="requested-17"></a>
 
-#### Requested
+#### Request
 
 [URL]
 
@@ -3679,15 +3776,15 @@ Content-Type: multipart/form-data
 
 [Header]
 
-| Name | Type | Required | Description |
-|---------------------|--------|----|---------------------------------------------|
-| x-kamp-upload-token | String | O | Pass the `uploadInfo.token` value from the step 1 response as-is. |
+| Name                | Type   | Required | Description                                                        |
+|---------------------|--------|----------|--------------------------------------------------------------------|
+| x-kamp-upload-token | String | O        | Pass the `uploadInfo.token` value from the Step 1 response as-is  |
 
 [Request body (multipart)]
 
-| Name | Type | Required | Description |
-|------|------|----|-----------------------------------------------------|
-| file | File | O | Video file. Must exactly match the `fileSize` in the step 1 request. |
+| Name | Type | Required | Description                                                                    |
+|------|------|----------|--------------------------------------------------------------------------------|
+| file | File | O        | Video file. Must exactly match the `fileSize` specified in the Step 1 request  |
 
 <a id="response-17"></a>
 
@@ -3702,33 +3799,33 @@ Content-Type: multipart/form-data
 }
 ```
 
-* On success, returns `vid` (same as the step 1 response) and `playUrl`. The `errCode` and `message` fields are not included.
-* On failure, returns HTTP 4xx along with `errCode` (100–110) and `message`. For detailed error codes, refer to the Kakao BizMessage guide.
+* On success, `vid` (same as in the Step 1 response) and `playUrl` are returned, and the `errCode`/`message` fields are not included.
+* On failure, HTTP 4xx is returned along with `errCode` (100–110) and `message`. For detailed error codes, refer to the Kakao Biz Message guide.
 
 <a id="upload-video-specifications"></a>
 
-#### Video Upload Specifications
+#### Uploaded Video Specifications
 
-| Item | Limit |
-|:---------|:--------------------------------------------|
-| File format | MP4, MOV, AVI |
-| Maximum file size | 4 GB |
-| Maximum video length | 4 hours |
-| Maximum resolution | 8K |
-| File name length | Up to 250 characters |
+| Item               | Limit                    |
+|:-------------------|:-------------------------|
+| File format        | MP4, MOV, AVI            |
+| Maximum file size  | 4 GB                     |
+| Maximum duration   | 4 hours                  |
+| Maximum resolution | 8K                       |
+| File name length   | Up to 250 characters     |
 
-* Uploaded videos can be used after encoding is complete in KakaoBizCenter. Encoding time varies depending on the video length and typically takes 5–10 minutes.
-* Immediately after upload, the video status starts as `REGISTERED`, transitions through `ENCODING`, and then changes to `PUBLIC` or `PRIVATE`. The status can be checked in the console or through the [Retrieve Video](#retrieve-video) API.
-* Registered videos are permanently stored on Kakao's side, and deleting a template does not automatically remove the video from KakaoBizCenter. The KakaoTalk channel administrator can delete the video directly from the management screen on the channel business home.
-* If the step 2 file upload fails or is delayed after step 1 registration and the token (5 minutes) expires, you must call a new registration again. Videos that have been registered but not actually uploaded will be automatically marked as `ERROR` after a certain period of time.
+* Uploaded videos are available after encoding is complete in the Kakao Biz Center. Encoding time varies depending on the video length and typically takes 5 to 10 minutes.
+* Immediately after upload, the video status starts as `REGISTERED`, transitions through `ENCODING`, and then changes to either `PUBLIC` or `PRIVATE`. You can check the status in the console or via the [View Video](#동영상-조회) API.
+* Registered videos are permanently retained by Kakao. Even if a template is deleted, the videos in the Kakao Biz Center are not automatically removed. The KakaoTalk Channel administrator can manually delete them from the management screen on the channel's business home.
+* If the Step 2 file upload fails or is delayed after Step 1 registration and the token (valid for 5 minutes) expires, you must call the registration again. Videos that were registered but never actually uploaded will be automatically marked with a status of `ERROR` after a certain period of time.
 
 <a id="view-video"></a>
 
-### Retrieve Video
+### Query Video
 
 <a id="requested-18"></a>
 
-#### Requested
+#### Request
 
 [URL]
 
@@ -3741,7 +3838,7 @@ Content-Type: application/json;charset=UTF-8
 
 | Name | Type | Description |
 |--------|--------|--------|
-| appKey | String | Unique appkey |
+| appKey | String | Unique app key |
 
 [Header]
 
@@ -3753,15 +3850,15 @@ Content-Type: application/json;charset=UTF-8
 
 | Name | Type | Required | Description |
 |--------------|--------|----|------------------|
-| X-Secret-Key | String | O | Can be created in the console. |
+| X-Secret-Key | String | O  | Can be created in the console. |
 
 [Request parameter]
 
 | Name | Type | Required | Description |
 |------------|--------|----|-------------------|
-| senderKey | String | X | Sender profile key (40 characters) |
-| pageNum | String | X | Page number (default: 1) |
-| pageSize | String | X | Number of results to retrieve (default: 15) |
+| senderKey  | String | X  | Sender profile key (40 characters) |
+| pageNum    | String | X  | Page number (default: 1) |
+| pageSize   | String | X  | Number of records to query (default: 15) |
 
 <a id="response-18"></a>
 
@@ -3799,36 +3896,36 @@ Content-Type: application/json;charset=UTF-8
 
 | Name | Type | Not Null | Description |
 |:--------------------|:--------|:---------|:------------------------------------------------------------|
-| header | Object | O | |
-| - resultCode | Integer | O | Result code |
-| - resultMessage | String | O | Result message |
-| - isSuccessful | boolean | O | Whether the request was successful |
-| videosResponse | Object | X | Video list area |
-| - videos | Array | O | Video array |
-| - - videoSeq | Long | O | Video sequence |
-| - - vid | String | O | Kakao video ID |
-| - - senderKey | String | O | Sender profile key |
-| - - title | String | X | Video title (immediately after upload, the file name is used; synchronized with the value modified in KakaoBizCenter after encoding is complete) |
-| - - fileName | String | O | Uploaded file name |
-| - - fileSize | Long | O | File size (in bytes) |
-| - - status | String | O | Video status (see [Video Status](#video-status)) |
-| - - thumbnailUrl | String | X | Thumbnail URL (available after encoding is complete) |
-| - - videoUrl | String | X | URL for sending and management (available in `PUBLIC` status) |
-| - - playUrl | String | X | Playback URL |
-| - - createDate | String | O | Registration time |
-| - - updateDate | String | X | Status synchronization time (recorded upon webhook/batch update) |
-| - - createUser | String | X | Upload user identifier |
-| - totalCount | Integer | O | Total number of videos |
+| header              | Object  | O        | Header area |
+| - resultCode        | Integer | O        | Result code |
+| - resultMessage     | String  | O        | Result message |
+| - isSuccessful      | boolean | O        | Success |
+| videosResponse      | Object  | X        | Video list area |
+| - videos            | Array   | O        | Video array |
+| - - videoSeq        | Long    | O        | Video sequence |
+| - - vid             | String  | O        | Kakao video ID |
+| - - senderKey       | String  | O        | Sender profile key |
+| - - title           | String  | X        | Video title (immediately after upload, set to the file name; synced with the value modified in Kakao Biz Center after encoding is complete) |
+| - - fileName        | String  | O        | Uploaded file name |
+| - - fileSize        | Long    | O        | File size (bytes) |
+| - - status          | String  | O        | Video status (see [Video Status](#동영상-상태)) |
+| - - thumbnailUrl    | String  | X        | Thumbnail URL (provided after encoding is complete) |
+| - - videoUrl        | String  | X        | URL for sending and management (provided in `PUBLIC` status) |
+| - - playUrl         | String  | X        | Playback URL |
+| - - createDate      | String  | O        | Registration time |
+| - - updateDate      | String  | X        | Status sync time (recorded when updated via webhook or batch) |
+| - - createUser      | String  | X        | Upload user identifier |
+| - totalCount        | Integer | O        | Total number of videos |
 
-> In the upload registration response, `video` reflects the state immediately after registration, so `status` is always `REGISTERED` and the `thumbnailUrl`, `videoUrl`, `playUrl`, `createDate`, `updateDate`, and `createUser` fields are not included. These fields can be checked through the Retrieve Video API after encoding is complete.
+> The `video` in the upload registration response represents the state immediately after registration, so `status` is always `REGISTERED`, and the `thumbnailUrl`, `videoUrl`, `playUrl`, `createDate`, `updateDate`, and `createUser` fields are not included. These fields can be checked in the Query Video API after encoding is complete.
 
 <a id="delete-video"></a>
 
-### Delete Video
+### Delete a Video
 
 <a id="requested-19"></a>
 
-#### Requested
+#### Request
 
 [URL]
 
@@ -3839,9 +3936,9 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| Name | Type | Description |
+| Name     | Type   | Description        |
 |--------|--------|--------|
-| appKey | String | Unique appkey |
+| appKey | String | Unique app key |
 
 [Header]
 
@@ -3851,15 +3948,15 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name | Type | Required | Description |
+| Name           | Type   | Required | Description                        |
 |--------------|--------|----|------------------|
-| X-Secret-Key | String | O | Can be created in the console. |
+| X-Secret-Key | String | O  | Can be created in the console. |
 
 [Query parameter]
 
-| Name | Type | Required | Description |
+| Name       | Type   | Required | Description                                                          |
 |----------|--------|----|-----------------------------------|
-| videoSeq | String | O | Video sequence (multiple values can be passed separated by commas) |
+| videoSeq | String | O  | Video sequence (multiple values can be passed separated by commas) |
 
 <a id="response-19"></a>
 
@@ -3875,29 +3972,29 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name | Type | Not Null | Description |
+| Name              | Type    | Not Null | Description     |
 |:----------------|:--------|:---------|:-------|
-| header | Object | O | |
-| - resultCode | Integer | O | Result code |
-| - resultMessage | String | O | Result message |
-| - isSuccessful | boolean | O | Whether the request was successful |
+| header          | Object  | O        | Header area     |
+| - resultCode    | Integer | O        | Result code     |
+| - resultMessage | String  | O        | Result message  |
+| - isSuccessful  | boolean | O        | Success         |
 
 <a id="video-status"></a>
 
 ### Video Status
 
-Describes the `status` field values in the video retrieval response.
+Describes the `status` field values in the video query response.
 
-| Status | Description |
-|:-----------|:------------------------------------|
-| REGISTERED | Upload registered |
-| ENCODING | Encoding in progress |
-| PUBLIC | Public status (available for sending and template registration) |
-| PRIVATE | Private status (available for template registration only) |
-| VIOLATED | Policy-violating video |
-| ILLEGAL | Illegally filmed video |
-| DELETED | Deleted video |
-| ERROR | Error occurred during upload or encoding |
+| status     | Description                                                                 |
+|:-----------|:----------------------------------------------------------------------------|
+| REGISTERED | Upload registered                                                           |
+| ENCODING   | Encoding in progress                                                        |
+| PUBLIC     | Public status (delivery and template registration available)                |
+| PRIVATE    | Private status (template registration only; delivery fails)                 |
+| VIOLATED   | Policy-violating video                                                      |
+| ILLEGAL    | Illegally filmed video                                                      |
+| DELETED    | Deleted video                                                               |
+| ERROR      | Error occurred during upload or encoding                                    |
 
 <a id="upload"></a>
 
@@ -3905,27 +4002,27 @@ Describes the `status` field values in the video retrieval response.
 
 <a id="upload-bizform-key"></a>
 
-### Upload Bizform key
+### Upload Biz Form Key
 
 <a id="requested-20"></a>
 
-#### Requested
+#### Request
 
-\[URL]
+[URL]
 
 ```
 POST /brand-message/v1.0/appkeys/{appKey}/senders/{senderKey}/biz-form
 Content-Type: application/json;charset=UTF-8
 ```
 
-\[Path parameter]
+[Path parameter]
 
-| Name| Type| Description|
-|----------|----------|----------|
-| appkey| String| Unique appkey|
-| senderKey| String| Outgoing Key|
+| Name      | Type   | Description    |
+|-----------|--------|----------------|
+| appkey    | String | Unique app key |
+| senderKey | String | Sender Key     |
 
-\[Header]
+[Header]
 
 ```
 {
@@ -3933,9 +4030,9 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| X-Secret-Key| String| O| Available to create from the console.|
+| Name         | Type   | Required | Description                        |
+|--------------|--------|----------|------------------------------------|
+| X-Secret-Key | String | O        | Can be created in the console. |
 
 <a id="response-20"></a>
 
@@ -3951,40 +4048,40 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Not Null| Description|
-|:----------|:----------|:----------|:----------|
-| header| Object| O| Header zone|
-| \- resultCode| Integer| O| Result code|
-| \- resultMessage| String| O| Result message|
-| \- isSuccessful| boolean| O| Success status|
+| Name            | Type    | Not Null | Description    |
+|:----------------|:--------|:---------|:---------------|
+| header          | Object  | O        | Header area    |
+| - resultCode    | Integer | O        | Result code    |
+| - resultMessage | String  | O        | Result message |
+| - isSuccessful  | boolean | O        | Success        |
 
 <a id="manage-outgoing-profiles"></a>
 
-## Manage Outgoing Profiles
+## Sender Profile Management
 
 <a id="view-outgoing-profile"></a>
 
-### View outgoing profile
+### View Sender Profile
 
 <a id="requested-21"></a>
 
-#### Requested
+#### Request
 
-\[URL]
+[URL]
 
 ```
 GET  /brand-message/v1.0/appkeys/{appKey}/senders/{senderKey}
 Content-Type: application/json;charset=UTF-8
 ```
 
-\[Path parameter]
+[Path parameter]
 
-| Name| Type| Description|
-|----------|----------|----------|
-| appkey| String| Unique appkey|
-| senderKey| String| Outgoing Key|
+| Name      | Type   | Description    |
+|-----------|--------|----------------|
+| appkey    | String | Unique app key |
+| senderKey | String | Sender Key     |
 
-\[Header]
+[Header]
 
 ```
 {
@@ -3992,9 +4089,9 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| X-Secret-Key| String| O| Available to create from the console.|
+| Name         | Type   | Required | Description                          |
+|--------------|--------|----------|--------------------------------------|
+| X-Secret-Key | String | O        | Can be created in the console. |
 
 <a id="response-21"></a>
 
@@ -4036,60 +4133,60 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Not Null| Description|
-|:----------|:----------|:----------|:----------|
-| header| Object| O| Header zone|
-| \- resultCode| Integer| O| Result code|
-| \- resultMessage| String| O| Result message|
-| \- isSuccessful| boolean| O| Success status|
-| sender| Object| X| Outgoing Profile|
-| \- plusFriendId| String| O| PlusFriend ID|
-| \- senderKey| String| O| Outgoing Key|
-| \- categoryCode| String| X| Category code|
-| \- unsubscribePhoneNumber| String| X| Toll-free opt-out phone number|
-| \- unsubscribeAuthNumber| String| X| toll-free opt-out verification number|
-| \- status| String| X| NHN Cloud PlusFriend status code <br>(YSC02: pending registration, YSC03: normal registration)|
-| \- statusName| String| X| NHN Cloud PlusFriend status name (pending registration, normal registration)|
-| \- kakaoStatus| String| X| Kakao PlusFriend status code <br>(A: normal, S: blocked)<br>if status is YSC02, have kakaoStatus null value.|
-| \- kakaoStatusName| String| X| Kakao PlusFriend status name (normal, blocked)<br>if status is YSC02, have kakaoStatusName null value.|
-| \- kakaoProfileStatus| String| X| Kakao PlusFriend profile status code <br>(A: enabled, B: blocked, C: disabled, D:deleted E:deletion in progress)<br>if status is YSC02, have kakaoProfileStatus null value.|
-| \- kakaoProfileStatusName| String| X| Kakao PlusFriend profile status name (enabled, disabled, blocked, deletion in progress, deleted)<br>if status is YSC02, have kakaoProfileStatusName null value.|
-| \- profileSpamLevel| String| X| KakaoTalk channel spam status name (permanent restriction, warning restriction, normal)<br>It may have a null value if the outgoing profile status is not normal.|
-| \- profileMessageSpamLevel| String| X| KakaoTalk Message spam status name (activity restriction, warning restriction, normal)<br>It may have a null value if the outgoing profile status is not normal.|
-| \- block| boolean| O| Outgoing profile blocked status|
-| \- brandMessage| Object| X| Brand Message settings information|
-| \-- resendAppKey| String| X| SMS service appkey to be set as fallback|
-| \-- isResend| boolean| O| Fallback settings (resending) status|
-| \-- resendSendNo| String| X| If resending, tc-sms outgoing number|
-| \-- resendUnsubscribeNo| String| X| If resending, tc-sms 080 opt-out number|
-| \- dormant| boolean| O| Outgoing profile inactive status|
-| \- marketingAgreement| boolean| O| M/N-type use application status|
-| \- createDate| String| X| Registered Date|
-| \- initialUserRestriction| boolean| O| First-time user restriction status|
+| Name                      | Type    | Not Null | Description                                                                                                                                                           |
+|:--------------------------|:--------|:---------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| header                    | Object  | O        | Header area                                                                                                                                                           |
+| - resultCode              | Integer | O        | Result code                                                                                                                                                           |
+| - resultMessage           | String  | O        | Result message                                                                                                                                                        |
+| - isSuccessful            | boolean | O        | Success                                                                                                                                                               |
+| sender                    | Object  | X        | Sender Profile                                                                                                                                                        |
+| - plusFriendId            | String  | O        | PlusFriend ID                                                                                                                                                         |
+| - senderKey               | String  | O        | Sender Key                                                                                                                                                            |
+| - categoryCode            | String  | X        | Category code                                                                                                                                                         |
+| - unsubscribePhoneNumber  | String  | X        | Toll-free opt-out phone number                                                                                                                                        |
+| - unsubscribeAuthNumber   | String  | X        | Toll-free opt-out authentication number                                                                                                                               |
+| - status                  | String  | X        | NHN Cloud PlusFriend status code <br>(YSC02: Registration pending, YSC03: Normally registered)                                                                        |
+| - statusName              | String  | X        | NHN Cloud PlusFriend status name (Registration pending, Normally registered)                                                                                          |
+| - kakaoStatus             | String  | X        | Kakao PlusFriend status code<br>(A: Normal, S: Blocked)<br>If status is YSC02, kakaoStatus has a null value.                                                          |
+| - kakaoStatusName         | String  | X        | Kakao PlusFriend status name (Normal, Blocked)<br>If status is YSC02, kakaoStatusName has a null value.                                                               |
+| - kakaoProfileStatus      | String  | X        | Kakao PlusFriend profile status code<br>(A: Active, B: Blocked, C: Inactive, D: Deleted, E: Deletion in progress)<br>If status is YSC02, kakaoProfileStatus has a null value. |
+| - kakaoProfileStatusName  | String  | X        | Kakao PlusFriend profile status name (Active, Inactive, Blocked, Deletion in progress, Deleted)<br>If status is YSC02, kakaoProfileStatusName has a null value.       |
+| - profileSpamLevel        | String  | X        | KakaoTalk Channel spam status name (Permanently restricted, Warning restricted, Normal)<br>May have a null value if the sender profile status is not normal.           |
+| - profileMessageSpamLevel | String  | X        | KakaoTalk message spam status name (Activity restricted, Warning restricted, Normal)<br>May have a null value if the sender profile status is not normal.              |
+| - block                   | boolean | O        | Whether the sender profile is blocked                                                                                                                                 |
+| - brandMessage            | Object  | X        | Brand Message configuration information                                                                                                                               |
+| -- resendAppKey           | String  | X        | SMS service appkey to set for fallback                                                                                                                                |
+| -- isResend               | boolean | O        | Whether fallback (resend) is configured                                                                                                                               |
+| -- resendSendNo           | String  | X        | tc-sms sender number used for resending                                                                                                                               |
+| -- resendUnsubscribeNo    | String  | X        | tc-sms 080 opt-out number used for resending                                                                                                                          |
+| - dormant                 | boolean | O        | Whether the sender profile is dormant                                                                                                                                 |
+| - marketingAgreement      | boolean | O        | Whether M/N type usage is requested                                                                                                                                   |
+| - createDate              | String  | X        | Registration date                                                                                                                                                     |
+| - initialUserRestriction  | boolean | O        | Whether the initial user restriction is applied                                                                                                                       |
 
 <a id="modify-outgoing-profile-080-opt-out-number"></a>
 
-### Modify outgoing profile 080 opt-out number
+### Modify Sender Profile 080 Opt-Out Number
 
 <a id="requested-22"></a>
 
-#### Requested
+#### Request
 
-\[URL]
+[URL]
 
 ```
 PUT /brand-message/v1.0/appkeys/{appKey}/senders/{senderKey}/unsubscribe-content
 Content-Type: application/json;charset=UTF-8
 ```
 
-\[Path parameter]
+[Path parameter]
 
-| Name| Type| Description|
-|----------|----------|----------|
-| appkey| String| Unique appkey|
-| senderKey| String| Outgoing Key|
+| Name      | Type   | Description    |
+|-----------|--------|----------------|
+| appkey    | String | Unique app key |
+| senderKey | String | Sender Key     |
 
-\[Header]
+[Header]
 
 ```
 {
@@ -4097,11 +4194,11 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| X-Secret-Key| String| O| Available to create from the console.|
+| Name         | Type   | Required | Description                          |
+|--------------|--------|----------|--------------------------------------|
+| X-Secret-Key | String | O        | Can be created in the console. |
 
-\[Request body]
+[Request body]
 
 ```
 {
@@ -4110,10 +4207,10 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| unsubscribeNo| String| O| 080 toll-free opt-out phone number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx|
-| unsubscribeAuthNo| String| X| 080 toll-free opt-out verification number (If not entered, the message will be sent using the free opt-out information registered in the outgoing profile)<br>unsubscribeAuthNo cannot be entered without unsubscribeNo<br>ex) 1234|
+| Name              | Type   | Required | Description                                                                                                                                                                                                          |
+|-------------------|--------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| unsubscribeNo     | String | O        | 080 toll-free opt-out phone number (if neither field is entered, the message is sent using the opt-out information registered in the sender profile)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx |
+| unsubscribeAuthNo | String | X        | 080 toll-free opt-out authentication number (up to 10 characters; if neither field is entered, the message is sent using the opt-out information registered in the sender profile)<br>Cannot enter unsubscribeAuthNo without unsubscribeNo<br>Example: 1234 |
 
 <a id="response-22"></a>
 
@@ -4129,35 +4226,35 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Not Null| Description|
-|:----------|:----------|:----------|:----------|
-| header| Object| O| Header zone|
-| \- resultCode| Integer| O| Result code|
-| \- resultMessage| String| O| Result message|
-| \- isSuccessful| boolean| O| Success status|
+| Name            | Type    | Not Null | Description     |
+|:----------------|:--------|:---------|:----------------|
+| header          | Object  | O        | Header area     |
+| - resultCode    | Integer | O        | Result code     |
+| - resultMessage | String  | O        | Result message  |
+| - isSuccessful  | boolean | O        | Success         |
 
 <a id="manage-fallback"></a>
 
-## Manage Fallback
+## Alternative Delivery Management
 
 <a id="register-sms-appkey"></a>
 
 ### Register SMS AppKey
 
-\[URL]
+[URL]
 
 ```
 POST  /brand-message/v1.0/appkeys/{appkey}/failback/appkey
 Content-Type: application/json;charset=UTF-8
 ```
 
-\[Path parameter]
+[Path parameter]
 
-| Name| Type| Description|
-|----------|----------|----------|
-| appkey| String| Unique appkey|
+| Name     | 	Type     | 	Description     |
+|--------|---------|---------|
+| appkey | 	String | 	Unique appkey |
 
-\[Header]
+[Header]
 
 ```
 {
@@ -4165,11 +4262,11 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| X-Secret-Key| String| O| Available to create from the console.|
+| Name           | 	Type     | 	Required | 	Description              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | Can be created in the console. |
 
-\[Request body]
+[Request body]
 
 ```
 {
@@ -4177,11 +4274,11 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| resendAppKey| String| O| SMS service appkey to be set as fallback|
+| Name           | 	Type     | 	Required | 	Description                    |
+|--------------|---------|-----|------------------------|
+| resendAppKey | 	String | 	O  | SMS service appkey to set for fallback |
 
-\[Example]
+[Example]
 
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
@@ -4204,22 +4301,22 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 
 <a id="register-fallback-settings"></a>
 
-### Register fallback settings
+### Register Alternative Delivery Settings
 
-\[URL]
+[URL]
 
 ```
 POST  /brand-message/v1.0/appkeys/{appkey}/failback
 Content-Type: application/json;charset=UTF-8
 ```
 
-\[Path parameter]
+[Path parameter]
 
-| Name| Type| Description|
-|----------|----------|----------|
-| appkey| String| Unique appkey|
+| Name     | 	Type     | 	Description     |
+|--------|---------|---------|
+| appkey | 	String | 	Unique appkey |
 
-\[Header]
+[Header]
 
 ```
 {
@@ -4227,11 +4324,11 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| X-Secret-Key| String| O| Available to create from the console.|
+| Name           | 	Type     | 	Required | 	Description              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | Can be created in the console. |
 
-\[Request body]
+[Request body]
 
 ```
 {  
@@ -4242,14 +4339,14 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| Name| Type| Required| Description|
-|----------|----------|----------|----------|
-| senderKey| String| O| Outgoing Key|
-| isResend| Boolean| O| Fallback text status if sending fails<br>When setting up fallbacks in the console, fallbacks will be sent by default.|
-| resendSendNo| String| X| Fallback outgoing number<br><span style="color:red">(if the outgoing number is not registered with the SMS product, the fallback may fail.)</span>|
-| resendUnsubscribeNo| String| X| Fallback 080 opt-out number<br><span style="color:red">(if the 080 opt-out number is not registered with the SMS service the fallback may fail.)</span>|
+| Name                  | 	Type      | 	Required | 	Description                                                                                                        |
+|---------------------|----------|-----|------------------------------------------------------------------------------------------------------------|
+| senderKey           | 	String  | 	O  | Sender Key                                                                                                       |
+| isResend            | 	Boolean | 	O  | Whether to send an SMS as a fallback if delivery fails<br>If alternative delivery is configured in the console, it is sent as a fallback by default.                                           |
+| resendSendNo        | 	String  | 	X  | Sender number for alternative delivery<br><span style="color:red">(Fallback may fail if the sender number is not registered on the SMS service.)</span>                  |
+| resendUnsubscribeNo | 	String  | 	X  | 080 opt-out number for alternative delivery<br><span style="color:red">(Fallback may fail if the 080 opt-out number is not registered on the SMS service.)</span> |
 
-\[Example]
+[Example]
 
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/failback/appkey -d '{"senderKey": "0be23c29de88d6888798aeda57062516354d74ba","isResend": true,"resendSendNo": "01012341234" }
@@ -4269,10 +4366,9 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 }
 ```
 
-| Name| Type| Not Null| Description|
-|:----------|:----------|:----------|:----------|
-| header| Object| O| Header zone|
-| \- resultCode| Integer| O| Result code|
-| \- resultMessage| String| O| Result message|
-| \- isSuccessful| boolean| O| Success status|
-
+| Name              | Type      | Not Null | Description     |
+|:----------------|:--------|:---------|:-------|
+| header          | Object  | O        | Header area  |
+| - resultCode    | Integer | O        | Result code  |
+| - resultMessage | String  | O        | Result message |
+| - isSuccessful  | boolean | O        | Success  |

--- a/en/friendtalkupgrade-api-guide.md
+++ b/en/friendtalkupgrade-api-guide.md
@@ -1870,6 +1870,24 @@ Content-Type: application/json;charset=UTF-8
 | \- senderGroupingKey| String| X| Outgoing grouping key|
 | \- recipientGroupingKey| String| X| Recipient grouping key|
 
+<a id="message-results"></a>
+
+## Query Updated Message Results
+
+<!-- TODO: translate body -->
+
+<a id="requested-25"></a>
+
+#### Request
+
+<!-- TODO: translate body -->
+
+<a id="response-25"></a>
+
+#### Response
+
+<!-- TODO: translate body -->
+
 <a id="cancel-message-sending"></a>
 
 ## Cancel message sending

--- a/en/friendtalkupgrade-api-guide.md
+++ b/en/friendtalkupgrade-api-guide.md
@@ -3750,12 +3750,12 @@ Content-Type: application/json;charset=UTF-8
 | - title         | String  | X        | Video title (set to the file name immediately after upload; synchronized with the value edited in Kakao Biz Center after encoding is complete)                        |
 | - fileName      | String  | O        | Uploaded file name                                                                         |
 | - fileSize      | Long    | O        | File size (bytes)                                                                    |
-| - status        | String  | O        | Video status (see [Video Status](#동영상-상태)). Always `REGISTERED` in the upload registration response.                     |
+| - status        | String  | O        | Video status (see [Video Status](#video-status)). Always `REGISTERED` in the upload registration response.                     |
 | uploadInfo      | Object  | O        | Kakao upload information. Used in step 2.                                                            |
 | - uploadUrl     | String  | O        | Kakao endpoint to which the video file is uploaded directly                                                     |
 | - token         | String  | O        | Upload authentication token. Passed via the `x-kamp-upload-token` header.                                          |
 
-> The `thumbnailUrl`, `videoUrl`, `playUrl`, and `updateDate` fields, which are populated after encoding is complete, can be retrieved using the [Get Video](#동영상-조회) API.
+> The `thumbnailUrl`, `videoUrl`, `playUrl`, and `updateDate` fields, which are populated after encoding is complete, can be retrieved using the [Query Video](#view-video) API.
 
 <a id="video-file-upload-step-2"></a>
 
@@ -3815,7 +3815,7 @@ Content-Type: multipart/form-data
 | File name length   | Up to 250 characters     |
 
 * Uploaded videos are available after encoding is complete in the Kakao Biz Center. Encoding time varies depending on the video length and typically takes 5 to 10 minutes.
-* Immediately after upload, the video status starts as `REGISTERED`, transitions through `ENCODING`, and then changes to either `PUBLIC` or `PRIVATE`. You can check the status in the console or via the [View Video](#동영상-조회) API.
+* Immediately after upload, the video status starts as `REGISTERED`, transitions through `ENCODING`, and then changes to either `PUBLIC` or `PRIVATE`. You can check the status in the console or via the [Query Video](#view-video) API.
 * Registered videos are permanently retained by Kakao. Even if a template is deleted, the videos in the Kakao Biz Center are not automatically removed. The KakaoTalk Channel administrator can manually delete them from the management screen on the channel's business home.
 * If the Step 2 file upload fails or is delayed after Step 1 registration and the token (valid for 5 minutes) expires, you must call the registration again. Videos that were registered but never actually uploaded will be automatically marked with a status of `ERROR` after a certain period of time.
 
@@ -3908,7 +3908,7 @@ Content-Type: application/json;charset=UTF-8
 | - - title           | String  | X        | Video title (immediately after upload, set to the file name; synced with the value modified in Kakao Biz Center after encoding is complete) |
 | - - fileName        | String  | O        | Uploaded file name |
 | - - fileSize        | Long    | O        | File size (bytes) |
-| - - status          | String  | O        | Video status (see [Video Status](#동영상-상태)) |
+| - - status          | String  | O        | Video status (see [Video Status](#video-status)) |
 | - - thumbnailUrl    | String  | X        | Thumbnail URL (provided after encoding is complete) |
 | - - videoUrl        | String  | X        | URL for sending and management (provided in `PUBLIC` status) |
 | - - playUrl         | String  | X        | Playback URL |

--- a/ja/alimtalk-api-guide-v2.0.md
+++ b/ja/alimtalk-api-guide-v2.0.md
@@ -1,3 +1,5 @@
+<!-- pre-align:aligned sig=6622ebb72190 -->
+
 ## Notification > KakaoTalk Bizmessage > お知らせトーク > API v2.0 Guide
 
 <a id="alimtalk"></a>
@@ -466,15 +468,6 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
-#### SMS/LMS再送信ステータス
-| 値 | 説明                      |
-| ----- | ------------------------------- |
-| RSC01 | 再送信の対象ではない                 |
-| RSC02 | 再送信の対象(送信結果が失敗の時、再送信が行われます。) |
-| RSC03 | 再送信中                    |
-| RSC04 | 再送信成功                  |
-| RSC05 | 再送信失敗                  |
-
 <a id="get-messages"></a>
 
 ### メッセージ単件照会
@@ -910,6 +903,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 
 ### メッセージリストの照会
 
+<a id="request-3"></a>
+
 #### リクエスト
 
 [URL]
@@ -958,7 +953,7 @@ Content-Type: application/json;charset=UTF-8
 * 90日以上前の送信リクエストデータは照会されません。
 * 送信リクエスト日時の範囲は最大30日です。
 
-<a id="request-3"></a>
+<a id="response-7"></a>
 
 #### レスポンス
 ```
@@ -1047,17 +1042,6 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.0/appkeys/{appkey}/auth/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
-
-<a id="response-7"></a>
-
-#### SMS/LMS再送信ステータス
-| 値 | 説明                      |
-| ----- | ------------------------------- |
-| RSC01 | 再送信の対象ではない                 |
-| RSC02 | 再送信の対象(送信結果が失敗の時、再送信が行われます。) |
-| RSC03 | 再送信中                    |
-| RSC04 | 再送信成功                  |
-| RSC05 | 再送信失敗                  |
 
 <a id="get-messages-2"></a>
 

--- a/ja/alimtalk-api-guide-v2.1.md
+++ b/ja/alimtalk-api-guide-v2.1.md
@@ -1,3 +1,5 @@
+<!-- pre-align:aligned sig=59b3050f8882 -->
+
 ## Notification > KakaoTalk Bizmessage > お知らせトーク > API v2.1 Guide
 
 <a id="alimtalk"></a>
@@ -467,15 +469,6 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
-#### SMS/LMS再送信ステータス
-| 値 | 説明                      |
-| ----- | ------------------------------- |
-| RSC01 | 再送信の対象ではない                 |
-| RSC02 | 再送信の対象(送信結果が失敗の時、再送信が行われます。) |
-| RSC03 | 再送信中                    |
-| RSC04 | 再送信成功                  |
-| RSC05 | 再送信失敗                  |
-
 <a id="get-messages"></a>
 
 ### メッセージ単件照会
@@ -911,6 +904,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 
 ### メッセージリストの照会
 
+<a id="request-3"></a>
+
 #### リクエスト
 
 [URL]
@@ -959,7 +954,7 @@ Content-Type: application/json;charset=UTF-8
 * 90日以上前の送信リクエストデータは照会されません。
 * 送信リクエスト日時の範囲は最大30日です。
 
-<a id="request-3"></a>
+<a id="response-7"></a>
 
 #### レスポンス
 ```
@@ -1048,17 +1043,6 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.1/appkeys/{appkey}/auth/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
-
-<a id="response-7"></a>
-
-#### SMS/LMS再送信ステータス
-| 値 | 説明                      |
-| ----- | ------------------------------- |
-| RSC01 | 再送信の対象ではない                 |
-| RSC02 | 再送信の対象(送信結果が失敗の時、再送信が行われます。) |
-| RSC03 | 再送信中                    |
-| RSC04 | 再送信成功                  |
-| RSC05 | 再送信失敗                  |
 
 <a id="get-messages-2"></a>
 

--- a/ja/alimtalk-api-guide-v2.2.md
+++ b/ja/alimtalk-api-guide-v2.2.md
@@ -1,3 +1,5 @@
+<!-- pre-align:aligned sig=ff88f5bc1ceb -->
+
 ## Notification > KakaoTalk Bizmessage > お知らせトーク > API v2.2 Guide
 
 <a id="alimtalk"></a>
@@ -497,15 +499,6 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
 
-#### SMS/LMS再送信ステータス
-| 値 | 説明                      |
-| ----- | ------------------------------- |
-| RSC01 | 再送信の対象ではない                 |
-| RSC02 | 再送信の対象(送信結果が失敗の時、再送信が行われます。) |
-| RSC03 | 再送信中                    |
-| RSC04 | 再送信成功                  |
-| RSC05 | 再送信失敗                  |
-
 <a id="get-messages"></a>
 
 ### メッセージ単件照会
@@ -970,6 +963,8 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 
 ### メッセージリストの照会
 
+<a id="request-3"></a>
+
 #### リクエスト
 
 [URL]
@@ -1018,7 +1013,7 @@ Content-Type: application/json;charset=UTF-8
 * 90日以上前の送信リクエストデータは照会されません。
 * 送信リクエスト日時の範囲は最大30日です。
 
-<a id="request-3"></a>
+<a id="response-7"></a>
 
 #### レスポンス
 ```
@@ -1113,17 +1108,6 @@ Content-Type: application/json;charset=UTF-8
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.2/appkeys/{appkey}/auth/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
-
-<a id="response-7"></a>
-
-#### SMS/LMS再送信ステータス
-| 値 | 説明                      |
-| ----- | ------------------------------- |
-| RSC01 | 再送信の対象ではない                 |
-| RSC02 | 再送信の対象(送信結果が失敗の時、再送信が行われます。) |
-| RSC03 | 再送信中                    |
-| RSC04 | 再送信成功                  |
-| RSC05 | 再送信失敗                  |
 
 <a id="get-messages-2"></a>
 

--- a/ja/alimtalk-api-guide.md
+++ b/ja/alimtalk-api-guide.md
@@ -1,4 +1,4 @@
-## Notification > KakaoTalk Bizmessage > お知らせトーク > API v2.3 Guide
+## Notification > KakaoTalk Bizmessage > 알림톡 > API v2.3 Guide
 
 <a id="alimtalk"></a>
 
@@ -6,12 +6,12 @@
 
 <a id="api-domain"></a>
 
-#### [APIドメイン]
+#### [API Domain]
 
 <table>
 <thead>
 <tr>
-<th>ドメイン</th>
+<th>Domain</th>
 </tr>
 </thead>
 <tbody>
@@ -23,11 +23,12 @@
 
 <a id="overview-of-v23-api"></a>
 
-## v2.3 API紹介
-1. お知らせトーク大量送信照会、統計照会APIが追加されました。
-2. 置換メッセージ送信時、buttonsフィールドが追加されました。
-3. 専門メッセージ送信時、buttonsフィールドにchatExtra、chatEvent、targetフィールドが追加されました。
-4. メッセージ照会時、buttonsフィールドにchatExtra、chatEvent、targetフィールドが追加されました。
+## Overview of v2.3 API
+
+1. お知らせトークのクイックリプライ、アイテムリストタイプ、トークビズプラグイン、代表リンク、ビジネスフォームボタン機能が追加されました。
+2. お知らせトークのアイテムハイライト画像登録 API が追加されました。
+3. お知らせトークのプラグイン登録/修正/削除/照会 API が追加されました。
+4. メッセージリスト照会 API で buttons フィールドが削除されました。
 
 <a id="general-messages"></a>
 
@@ -46,23 +47,24 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 値 | タイプ | 説明 |
-| ------ | ------ | ------ |
-| appkey | String | 固有のアプリキー |
+| 名前     | 	タイプ     | 	説明     |
+|--------|---------|---------|
+| appkey | 	String | 	固有のアプリキー |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| 値    | タイプ | 必須 | 説明                               |
-| ------------ | ------ | ---- | ---------------------------------------- |
-| X-Secret-Key | String | O    | コンソールで作成できます。 |
-|X-NC-API-IDEMPOTENCY-KEY|	String| X | 重複メッセージ送信要求基準key<br>10分間同じkeyで要求すると、その要求を失敗処理します。 |
+
+| 名前                       | 	タイプ     | 	必須 | 	説明                                                        |
+|--------------------------|---------|-----|------------------------------------------------------------|
+| X-Secret-Key             | 	String | O   | コンソールで生成できます。                                           |
+| X-NC-API-IDEMPOTENCY-KEY | 	String | X   | 重複メッセージ送信リクエストの基準 key<br>10分間、同一の key でリクエストした場合、該当リクエストを失敗として処理します。 |
 
 [Request body]
-
 
 ```
 {
@@ -111,46 +113,55 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 値               | タイプ | 必須 | 説明                                |
-| ---------------------- | ------- | ---- | ---------------------------------------- |
-| senderKey              | String  | O    | 発信キー                            |
-| templateCode           | String  | O    | 登録した送信テンプレートコード(最大20桁)                    |
-| requestDate            | String  | X    | リクエスト日時(yyyy-MM-dd HH:mm)<br>(入力しない場合は即時送信)<br>最大60日後まで予約可能 |
-| senderGroupingKey      | String  | X    | 発信グルーピングキー(最大100文字)                        |
-| createUser             | String  | X    | 登録者(コンソールから送信する場合、ユーザーUUIDとして保存)|
-| recipientList          | List    | O    | 受信者リスト(最大1000人)                         |
-| - recipientNo          | String  | O    | 受信番号(最大15桁)                            |
-| - templateParameter    | Object  | X    | テンプレートパラメータ<br>(テンプレートに置換する変数が含まれる時は必須)       |
-| -- key                 | String  | X    | 置換キー(#{key})                             |
-| -- value               | String  | X    | 置換キーにマッピングされるvalue値                |
-| - resendParameter      | Object  | X    | 代替発送情報 |
-| -- isResend            | boolean | X    | 送信失敗時、代替送信するかどうか<br>コンソールで送信失敗設定をした時、デフォルト設定は再送信になっています。 |
-| -- resendType          | String  | X    | 代替送信タイプ(SMS、LMS)<br>値がない場合は、テンプレート本文の長さに応じてタイプが決まります。 |
-| -- resendTitle         | String  | X    | LMS代替送信タイトル(最大20文字)<br>(値がない場合は、プラスフレンドIDで再送信されます。) |
-| -- resendContent       | String  | X    | 代替送信内容(最大1000文字)<br>(値がない場合は、テンプレートの内容で再送信されます。) |
-| -- resendSendNo        | String  | X    | 代替送信発信番号(最大13桁)<br><span style="color:red">(SMSサービスに登録された発信番号ではない場合、代替送信が失敗することがあります。)</span> |
-| - buttons              | List    | X    | ボタン追加情報 |
-| -- ordering            | Integer | X    |	ボタン順序(ボタンがある場合は必須) |
-| -- chatExtra           | String  | X    |	BC(相談トークに切替) / BT(Botに切替)タイプボタンの時、伝達するメタ情報 |
-| -- chatEvent           | String  | X    |	BT(Bot切替)タイプボタンの時、接続するBotイベント名 |
-| -- target              | String  | X    |	Webリンクボタンの場合、"target":"out"プロパティ追加時のアウトリンク<br>基本インアプリリンクで送信 |
-| -- telNumber | String | X | TN(電話する)タイプのボタンの場合、伝達する電話番号 |
-| - recipientGroupingKey | String  | X    | 受信者グルーピングキー(最大100文字)                       |
-| messageOption          | Object  | X    |	メッセージオプション                                         |
-| - price                | Integer | X    |	message(ユーザーに伝達されるメッセージ)内に含まれた価格/金額/決済金額(モーメント広告に該当) |
-| - currencyType         | String  | X    |	message(ユーザーに伝達されるメッセージ)内に含まれた価格/金額/決済金額(モーメント広告に該当) |
-| statsId                | String  | X    |	統計ID(発信検索条件には含まれません, 最大8文字) |
+| 名前                     | 	タイプ      | 	必須 | 	説明                                                                                           |
+|------------------------|----------|-----|-----------------------------------------------------------------------------------------------|
+| senderKey              | 	String  | 	O  | 発信キー（40文字）                                                                                     |
+| templateCode           | 	String  | 	O  | 登録済み送信テンプレートコード（最大 20 文字）                                                                         |
+| requestDate            | String   | X   | リクエスト日時（yyyy-MM-dd HH:mm）<br>（入力しない場合は即時送信）<br>最大 60 日後まで予約可能                            |
+| senderGroupingKey      | String   | X   | 発信グルーピングキー（最大 100 文字）                                                                             |
+| createUser             | String   | X   | 登録者（コンソールから送信する場合、ユーザーの UUID で保存）                                                                   |
+| recipientList          | 	List    | 	O  | 	受信者リスト（最大 1000 名）                                                                            |
+| - recipientNo          | 	String  | 	O  | 	受信番号（最大 15 文字）                                                                                 |
+| - templateParameter    | 	Object  | 	X  | 	テンプレートパラメータ<br>（テンプレートに置換する変数を含む場合は必須）                                                           |
+| -- key                 | 	String  | 	X  | 	置換キー（#{key}）                                                                                 |
+| -- value               | String   | 	X  | 	置換キーにマッピングされる Value 値                                                                            |
+| - resendParameter      | 	Object  | 	X  | 代替送信情報                                                                                      |
+| -- isResend            | 	boolean | 	X  | 	送信失敗時、SMS 代替送信の有無<br>コンソールで代替送信を設定した場合、デフォルトで代替送信されます。                                      |
+| -- resendType          | 	String  | 	X  | 	代替送信タイプ（SMS、LMS）<br>値がない場合、テンプレート本文の長さに応じてタイプが決まります。                                      |
+| -- resendTitle         | 	String  | 	X  | 	LMS 代替送信タイトル<br>（値がない場合、プラスフレンド ID で代替送信されます。）                                              |
+| -- resendContent       | 	String  | 	X  | 	代替送信内容<br>（値がない場合、[メッセージ本文とウェブリンクボタン名 - ウェブリンク Mobile リンク] で代替送信されます。）                        |
+| -- resendSendNo        | String   | X   | 代替送信の発信番号<br><span style="color:red">（SMS サービスに登録された発信番号でない場合、代替送信が失敗する可能性があります。）</span> |
+| - buttons              | 	List    | 	X  | ボタン追加情報                                                                                      |
+| -- ordering            | Integer  | X   | 	ボタン順序（ボタンがある場合は必須）                                                                          |
+| -- chatExtra           | 	String  | 	X  | BC（相談トーク転換） / BT（ボット転換）タイプのボタンの場合、転送するメタ情報                                                       |
+| -- chatEvent           | 	String  | 	X  | BT（ボット転換）タイプのボタンの場合、接続するボットイベント名                                                                  |
+| -- relayId             | 	String  | 	X  | プラグイン実行時に X-Kakao-Plugin-Relay-Id ヘッダーを通じて受け取る値                                               |
+| -- oneClickId          | 	String  | 	X  | ワンクリック決済プラグインで使用する決済情報                                                                      |
+| -- productId           | 	String  | 	X  | ワンクリック決済プラグインで使用する決済情報                                                                      |
+| -- target              | 	String  | 	X  | 	ウェブリンクボタンの場合、`"target":"out"` 属性を追加するとアウトリンク<br>デフォルトはインアプリリンクで送信                                    |
+| -- telNumber           | 	String  | 	X  | TN（電話する）タイプのボタンの場合、転送する電話番号                                                                    |
+| - quickReplies         | 	List    | 	X  | クイックリプライ情報                                                                                       |
+| -- ordering            | Integer  | X   | 	クイックリプライ順序（クイックリプライがある場合は必須）                                                                      |
+| -- chatExtra           | 	String  | 	X  | BC（相談トーク転換） / BT（ボット転換）タイプの場合、転送するメタ情報                                                          |
+| -- chatEvent           | 	String  | 	X  | BT（ボット転換）タイプの場合、接続するボットイベント名                                                                     |
+| -- target              | 	String  | 	X  | 	ウェブリンクタイプの場合、`"target":"out"` 属性を追加するとアウトリンク<br>デフォルトはインアプリリンクで送信                                    |
+| - recipientGroupingKey | 	String  | 	X  | 	受信者グルーピングキー（最大 100 文字）                                                                           |
+| messageOption          | Object   | 	X  | メッセージオプション                                                                                        |
+| - price                | Integer  | 	X  | ユーザーに届くメッセージ内に含まれる価格/金額/決済金額（モーメント広告に該当）                                                   |
+| - currencyType         | String   | 	X  | ユーザーに届くメッセージ内に含まれる価格/金額/決済金額の通貨単位。KRW、USD、EUR などの国際通貨コードを使用（モーメント広告に該当）                |
+| statsId                | String   | 	X  | 統計 ID（発信検索条件には含まれません。最大 8 文字）                                                            |
 
-* <b>リクエスト日時は呼び出す時点から60日後まで設定可能です。</b>
-* <b>SMSサービスで代替送信されるため、SMSサービスの送信APIの仕様に応じてフィールドを入力する必要があります。(SMSサービスに登録された発信番号、各種フィールドの長さ制限など)</b>
-* <b>SMSサービスは、国際SMSのみサポートします。国際受信者番号の場合、 resendType(代替送信タイプ)をSMSに変更すると正常に代替送信できます。</b>
-* <b>指定した代替送信タイプのバイト制限を超える代替送信のタイトルや内容は、途中で切れて代替送信されることがあります。([[SMS注意事項](https://docs.toast.com/ko/Notification/SMS/ko/api-guide/#_1)]参考)</b>
-* <b>templateTitleとtemplateItemHighlight.titleフィールドの一番後ろに日本語識別子とtemplateParameterを利用して`\s`文字を追加する場合、取り消し線スタイルを適用できます。</b>
-    * <b>ただし、テンプレート登録時にあらかじめ\sをフィールドに追加しておいた場合は適用されません。</b>
+* <b>リクエスト日時は、呼び出し時点から 60 日後まで設定できます。</b>
+* <b>SMS サービスで代替送信されるため、SMS サービスの送信 API 仕様に従ってフィールドを入力する必要があります。（SMS サービスに登録された発信番号、各種フィールドの長さ制限など）</b>
+* <b>代替送信は SMS、LMS で送信可能であり、国際代替送信は SMS のみサポートします。国際受信者番号の場合、resendType（代替送信タイプ）を SMS に変更する必要があります。</b>
+* <b>指定した代替送信タイプのバイト制限を超える代替送信タイトルや内容は、切り捨てられて代替送信される場合があります。（[[SMS 注意事項](https://docs.toast.com/ko/Notification/SMS/ko/api-guide/#_1)] 参考）</b>
+* <b>templateTitle および templateItemHighlight.title フィールドの末尾に、置換子と templateParameter を使用して `\s` 文字を追加すると、取り消し線スタイルを適用できます。</b>
+    * <b>ただし、テンプレート登録時にあらかじめ \s をフィールドに追加しておく場合は適用されません。</b>
 
 [例]
+
 ```
-curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","templateParameter":{"{日本語識別子フィールド}":"{置換データ}"}}]}'
+curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","templateParameter":{"{置換子フィールド}":"{置換データ}"}}]}'
 ```
 
 <a id="response"></a>
@@ -180,21 +191,21 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 }
 ```
 
-| 値                | タイプ | 説明    |
-| ----------------------- | ------- | ------------ |
-| header                  | Object  | ヘッダ領域 |
-| - resultCode            | Integer | 結果コード |
-| - resultMessage         | String  | 結果メッセージ |
-| - isSuccessful          | Boolean | 成否  |
-| message                 | Object  | 本文領域 |
-| - requestId             | String  | リクエストID        |
-| - senderGroupingKey     | String  | 発信グルーピングキー |
-| - sendResults           | Object  | 送信リクエスト結果 |
-| -- recipientSeq         | Integer | 受信者シーケンス番号 |
-| -- recipientNo          | String  | 受信番号 |
-| -- resultCode           | Integer | 送信リクエスト結果コード |
-| -- resultMessage        | String  | 送信リクエスト結果メッセージ |
-| -- recipientGroupingKey | String  | 受信者グルーピングキー |
+| 名前                      | タイプ      | Not Null | 説明           |
+|-------------------------|---------|:--------:|--------------|
+| header                  | Object  |    O     | ヘッダー領域        |
+| - resultCode            | Integer |    O     | 結果コード        |
+| - resultMessage         | String  |    O     | 結果メッセージ       |
+| - isSuccessful          | Boolean |    O     | 成否        |
+| message                 | Object  |    X     | 本文領域        |
+| - requestId             | String  |    X     | リクエスト ID       |
+| - senderGroupingKey     | String  |    X     | 発信グルーピングキー     |
+| - sendResults           | Object  |    O     | 送信リクエスト結果     |
+| -- recipientSeq         | Integer |    O     | 受信者シーケンス番号   |
+| -- recipientNo          | String  |    X     | 受信番号        |
+| -- resultCode           | Integer |    O     | 送信リクエスト結果コード  |
+| -- resultMessage        | String  |    O     | 送信リクエスト結果メッセージ |
+| -- recipientGroupingKey | String  |    X     | 受信者グルーピングキー    |
 
 <a id="request-of-sending-full-text"></a>
 
@@ -209,22 +220,24 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 値 | タイプ | 説明 |
-| ------ | ------ | ------ |
-| appkey | String | 固有のアプリキー |
+| 名前     | 	タイプ     | 	説明     |
+|--------|---------|---------|
+| appkey | 	String | 	固有のアプリキー |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| 値    | タイプ | 必須 | 説明                               |
-| ------------ | ------ | ---- | ---------------------------------------- |
-| X-Secret-Key | String | O    | コンソールで作成できます。 |
-|X-NC-API-IDEMPOTENCY-KEY|	String| X | 重複メッセージ送信要求基準key<br>10分間同じkeyで要求すると、その要求を失敗処理します。 |
 
-[Request body]
+| 名前                       | 	タイプ     | 	必須 | 	説明                                                        |
+|--------------------------|---------|-----|------------------------------------------------------------|
+| X-Secret-Key             | 	String | O   | コンソールで生成できます。                                           |
+| X-NC-API-IDEMPOTENCY-KEY | 	String | X   | 重複メッセージ送信リクエストの基準 key<br>10分間、同一の key でリクエストした場合、該当リクエストを失敗として処理します。 |
+
+[Request Body]
 
 ```
 {
@@ -313,49 +326,83 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 値               | タイプ | 必須 | 説明                                |
-| ---------------------- | ------- | ---- | ---------------------------------------- |
-| senderKey           | String  | O    | 発信キー                                   |
-| templateCode           | String  | O    | 登録した送信テンプレートコード(最大20桁)                    |
-| requestDate            | String  | X    | リクエスト日時(yyyy-MM-dd HH:mm)<br>(入力しない場合は即時送信) |
-| senderGroupingKey      | String  | X    | 発信グルーピングキー(最大100文字)                        |
-| recipientList          | List    | O    | 受信者リスト(最大1,000人)                        |
-| - recipientNo          | String  | O    | 受信番号(最大15桁)                            |
-| - content              | String  | O    | 内容(最大1300文字)                             |
-| - templateTitle        | String  | X    | テンプレートハイライトタイトル(最大50桁) |
-| - buttons              | List    | X    | ボタンリスト(最大5個)                             |
-| -- ordering            | Integer | X    | ボタン順序(ボタンがある場合は必須)                      |
-| -- type                | String  | X    | ボタンタイプ(WL：Webリンク、AL：アプリリンク、DS：配送照会、BK：Botキーワード、MD：メッセージ伝達、BC：相談トーク転換、BT：Bot転換、AC：チャンネル追加、 TN:電話発信) |
-| -- name                | String  | X    | ボタン名(ボタンがある場合は必須、最大14文字)              |
-| -- linkMo              | String  | X    | モバイルWebリンク(WLタイプの場合は必須フィールド、最大500文字)       |
-| -- linkPc              | String  | X    | PC Webリンク(WLタイプの場合は任意フィールド、最大500文字)        |
-| -- schemeIos           | String  | X    | iOSアプリリンク(ALタイプの場合は必須フィールド、最大500文字)       |
-| -- schemeAndroid       | String  | X    | Androidアプリリンク(ALタイプの場合は必須フィールド、最大500文字)   |
-| -- chatExtra           | String  | X    |	BC(相談トークに切替) / BT(Botに切替)タイプボタンの時、伝達するメタ情報 |
-| -- chatEvent           | String  | X    |	BT(Botに切替)タイプボタンの時、接続するBotイベント名 |
-| -- target              | String  | X    |	Webリンクボタンの場合、 "target":"out"プロパティ追加時のアウトリンク<br>基本インアプリリンクで送信 |
-| -- telNumber | String | X | TN(電話する)タイプのボタンの場合、伝達する電話番号 |
-| - resendParameter      | Object  | X    | 代替発送情報 |
-| -- isResend            | boolean | X    | 送信失敗時、代替送信するかどうか<br>コンソールで送信失敗設定をした時、デフォルト設定は再送信になっています。 |
-| -- resendType          | String  | X    | 代替送信タイプ(SMS、LMS)<br>値がない場合は、テンプレート本文の長さに応じてタイプが決まります。 |
-| -- resendTitle         | String  | X    | LMS代替送信タイトル(最大20文字)<br>(値がない場合は、プラスフレンドIDで再送信されます。) |
-| -- resendContent       | String  | X    | 代替送信内容(最大1000文字)<br>(値がない場合は、テンプレートの内容で再送信されます。) |
-| -- resendSendNo        | String  | X    | 代替送信発信番号(最大13桁)<br><span style="color:red">(SMSサービスに登録された発信番号ではない場合、代替送信が失敗することがあります。)</span> |
-| - recipientGroupingKey | String  | X    | 受信者グルーピングキー(最大100文字)                       |
-| messageOption          | Object  | X    |	メッセージオプション                                         |
-| - price                | Integer | X    |	message(ユーザーに伝達されるメッセージ)内に含まれた価格/金額/決済金額(モーメント広告に該当) |
-| - currencyType         | String  | X    |	message(ユーザーに伝達されるメッセージ)内に含まれた価格/金額/決済金額(モーメント広告に該当) |
-| statsId                | String  | X    |	統計ID(発信検索条件には含まれません, 最大8文字) |
+| 名前                      | 	タイプ      | 	必須 | 	説明                                                                                                                                                                        |
+|-------------------------|----------|-----|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| senderKey               | 	String  | 	O  | 発信キー（40文字）                                                                                                                                                                  |
+| templateCode            | 	String  | 	O  | 登録済み送信テンプレートコード（最大20文字）                                                                                                                                                      |
+| requestDate             | String   | X   | リクエスト日時（yyyy-MM-dd HH:mm）<br>（入力しない場合は即時送信）<br>最大60日後まで予約可能                                                                                                         |
+| senderGroupingKey       | String   | X   | 発信グループキー（最大100文字）                                                                                                                                                          |
+| createUser              | String   | X   | 登録者（コンソールから送信する場合はユーザーUUIDで保存）                                                                                                                                                |
+| recipientList           | 	List    | 	O  | 	受信者リスト（最大1,000名）                                                                                                                                                        |
+| - recipientNo           | 	String  | 	O  | 	受信番号（最大15文字）                                                                                                                                                              |
+| - content               | 	String  | 	O  | 	内容（最大1,300文字）                                                                                                                                                              |
+| - templateTitle         | String   | X   | タイトル（最大50文字）                                                                                                                                                                 |
+| - templateHeader        | String   | X   | テンプレートヘッダー（最大16文字）                                                                                                                                                             |
+| - templateItem          | Object   | X   | アイテム                                                                                                                                                                        |
+| -- list                 | List     | X   | アイテムリスト（最小2個、最大10個）                                                                                                                                                     |
+| --- title               | String   | X   | タイトル（最大6文字）                                                                                                                                                                 |
+| --- description         | String   | X   | 説明（最大23文字）                                                                                                                                                              |
+| -- summary              | Object   | X   | アイテムサマリー情報                                                                                                                                                                  |
+| --- title               | String   | X   | タイトル（最大6文字）                                                                                                                                                                 |
+| --- description         | String   | X   | 説明（変数および通貨単位、数字、カンマ、ピリオドのみ使用可能、最大14文字）                                                                                                                              |
+| - templateItemHighlight | Object   | X   | アイテムハイライト                                                                                                                                                                  |
+| --- title               | String   | X   | タイトル（最大30文字、サムネイル画像がある場合は21文字）                                                                                                                                            |
+| --- description         | String   | X   | 説明（最大19文字、サムネイル画像がある場合は13文字）                                                                                                                                          |
+| --- imageUrl            | String   | X   | サムネイル画像のURL                                                                                                                                                                 |
+| - templateRepresentLink | Object   | X   | 代表リンク                                                                                                                                                                      |
+| -- linkMo               | String   | 	X  | 	モバイルWebリンク（最大500文字）                                                                                                                                                         |
+| -- linkPc               | String   | 	X  | PCウェブリンク（最大500文字）                                                                                                                                                           |
+| -- schemeIos            | String   | X   | 	iOSアプリリンク（最大500文字）                                                                                                                                                         |
+| -- schemeAndroid        | String   | X   | 	Androidアプリリンク（最大500文字）                                                                                                                                                       |
+| - buttons               | 	List    | 	X  | ボタンリスト（最大5個）                                                                                                                                                              |
+| -- ordering             | 	Integer | 	X  | 	ボタン順序（ボタンがある場合は必須）                                                                                                                                                       |
+| -- type                 | String   | 	X  | 	ボタンタイプ（WL: Webリンク、AL: アプリリンク、DS: 配送照会、BK: Botキーワード、MD: メッセージ転送、BC: 相談トーク転換、BT: Bot転換、AC: チャンネル追加ボタン、BF: ビジネスフォーム、P1: 画像セキュリティ送信プラグインID、P2: 個人情報利用プラグインID、P3: ワンクリック決済プラグインID、TN: 電話する） |
+| -- name                 | String   | 	X  | 	ボタン名（ボタンがある場合は必須、最大14文字）                                                                                                                                               |
+| -- linkMo               | String   | 	X  | 	モバイルWebリンク（WLタイプの場合は必須フィールド、最大500文字）                                                                                                                                        |
+| -- linkPc               | String   | 	X  | PCウェブリンク（WLタイプの場合は任意フィールド、最大500文字）                                                                                                                                          |
+| -- schemeIos            | String   | X   | 	iOSアプリリンク（ALタイプの場合は必須フィールド、最大500文字）                                                                                                                                        |
+| -- schemeAndroid        | String   | X   | 	Androidアプリリンク（ALタイプの場合は必須フィールド、最大500文字）                                                                                                                                      |
+| -- chatExtra            | 	String  | 	X  | BC（相談トーク転換）／BT（Bot転換）タイプのボタン使用時に転送するメタ情報                                                                                                                                    |
+| -- chatEvent            | 	String  | 	X  | BT（Bot転換）タイプのボタン使用時に接続するBotイベント名                                                                                                                                               |
+| -- bizFormId            | 	Integer | 	X  | 	ビジネスフォームID（BFタイプの場合は必須）                                                                                                                                                    |
+| -- pluginId             | 	String  | 	X  | 	プラグインID（最大24文字）                                                                                                                                                           |
+| -- relayId              | 	String  | 	X  | プラグイン実行時にX-Kakao-Plugin-Relay-Idヘッダーを通じて受け取る値                                                                                                                            |
+| -- oneClickId           | 	String  | 	X  | ワンクリック決済プラグインで使用する決済情報                                                                                                                                                   |
+| -- productId            | 	String  | 	X  | ワンクリック決済プラグインで使用する決済情報                                                                                                                                                   |
+| -- target               | 	String  | 	X  | 	Webリンクボタンの場合、`"target":"out"` 属性を追加するとアウトリンク<br>デフォルトはインアプリリンクで送信                                                                                                                 |
+| -- telNumber           | 	String  | 	X  | TN（電話する）タイプのボタン使用時に転送する電話番号                                                                                    |
+| - quickReplies          | 	List    | 	X  | クイックリプライリスト（最大5個）                                                                                                                                                            |
+| -- ordering             | 	Integer | 	X  | 	クイックリプライの順序（クイックリプライがある場合は必須）                                                                                                                                                   |
+| -- type                 | String   | 	X  | 	クイックリプライのタイプ（WL: ウェブリンク、AL: アプリリンク、BK: ボットキーワード、BC: 相談トーク切り替え、BT: ボット切り替え、BF: ビジネスフォーム）                                                                                                   |
+| -- name                 | String   | 	X  | 	クイックリプライの名前（クイックリプライがある場合は必須、最大 14 文字）                                                                                                                                           |
+| -- linkMo               | String   | 	X  | 	モバイルウェブリンク（WL タイプの場合は必須、最大 500 文字）                                                                                                                                        |
+| -- linkPc               | String   | 	X  | PC ウェブリンク（WL タイプの場合は任意、最大 500 文字）                                                                                                                                          |
+| -- schemeIos            | String   | X   | 	iOS アプリリンク（AL タイプの場合は必須、最大 500 文字）                                                                                                                                        |
+| -- schemeAndroid        | String   | X   | 	Android アプリリンク（AL タイプの場合は必須、最大 500 文字）                                                                                                                                      |
+| -- bizFormId            | 	Integer | 	X  | 	ビジネスフォーム ID（BF タイプの場合は必須）                                                                                                                                                    |
+| -- target               | 	String  | 	X  | 	ウェブリンクタイプの場合、`"target":"out"` 属性を追加するとアウトリンク<br>デフォルトはインアプリリンクで送信されます                                                                                                                 |
+| - resendParameter       | 	Object  | 	X  | 代替送信情報                                                                                                                                                                   |
+| -- isResend             | 	boolean | 	X  | 	送信失敗時、SMS 代替送信を行うかどうか<br>コンソールで代替送信設定を行った場合、デフォルトで代替送信されます。                                                                                                                   |
+| -- resendType           | 	String  | 	X  | 	代替送信タイプ（SMS、LMS）<br>値がない場合、テンプレート本文の長さによってタイプが決まります。                                                                                                                   |
+| -- resendTitle          | 	String  | 	X  | 	LMS 代替送信タイトル<br>（値がない場合、プラスフレンド ID で代替送信されます。）                                                                                                                           |
+| -- resendContent        | 	String  | 	X  | 	代替送信内容<br>（値がない場合、[メッセージ本文とウェブリンクボタン名 - ウェブリンクモバイルリンク] で代替送信されます。）                                                                                                     |
+| -- resendSendNo         | String   | X   | 代替送信の発信番号<br><span style="color:red">（SMS サービスに登録された発信番号でない場合、代替送信に失敗する可能性があります。）</span>                                                                              |
+| - recipientGroupingKey  | 	String  | 	X  | 	受信者グルーピングキー（最大 100 文字）                                                                                                                                        |
+| messageOption           | Object   | 	X  | メッセージオプション                                                                                                                                                                     |
+| - price                 | Integer  | 	X  | ユーザーに送信されるメッセージに含まれる価格/金額/決済金額（モーメント広告に該当）                                                                                                                                |
+| - currencyType          | String   | 	X  | ユーザーに送信されるメッセージに含まれる価格/金額/決済金額の通貨単位。KRW、USD、EUR などの国際通貨コードを使用（モーメント広告に該当）                                                                                             |
+| statsId                 | String   | 	X  | 統計 ID（送信検索条件には含まれません。最大 8 文字）                                                                                                                                         |
 
-* <b>本文とボタンに置換が完了したデータを入れてください。</b>
-* <b>リクエスト日時は呼び出す時点から60日後まで設定可能です。</b>
-* <b>SMSサービスで代替送信されるため、SMSサービスの送信APIの仕様に応じてフィールドを入力する必要があります。(SMSサービスに登録された発信番号、各種フィールドの長さ制限など)</b>
-* <b>SMSサービスは、国際SMSのみサポートします。国際受信者番号の場合、 resendType(代替送信タイプ)をSMSに変更すると正常に代替送信できます。</b>
-* <b>指定した代替送信タイプのバイト制限を超える代替送信のタイトルや内容は、途中で切れて代替送信されることがあります。([[SMS注意事項](https://docs.toast.com/ko/Notification/SMS/ko/api-guide/#_1)]参考)<
-* <b>送信時にtemplateTitleとtemplateItemHighlight.titleフィールドの一番後ろに`\s`文字を追加すると、取り消し線スタイルを適用できます。</b>
-    * <b>ただし、テンプレート登録時にあらかじめ\sをフィールドに追加しておいた場合は適用されません。</b>
+* <b>本文とボタンに置換が完了したデータを入力してください。</b>
+* <b>リクエスト日時は、呼び出し時点から60日後まで設定できます。</b>
+* <b>SMSサービスで代替送信されるため、SMSサービスの送信API仕様に従ってフィールドを入力する必要があります。（SMSサービスに登録された発信番号、各種フィールドの長さ制限など）</b>
+* <b>代替送信はSMS、LMSで送信可能で、国際代替送信はSMSのみサポートします。国際受信者番号の場合、resendType（代替送信タイプ）をSMSに変更する必要があります。</b>
+* <b>指定した代替送信タイプのバイト制限を超える代替送信タイトルや内容は、切り捨てられて代替送信される場合があります。（[[SMS 注意事項](https://docs.toast.com/ko/Notification/SMS/ko/api-guide/#_1)] 参照）</b>
+* <b>送信時点でtemplateTitleとtemplateItemHighlight.titleフィールドの末尾に`\s`文字を追加した場合、取り消し線スタイルを適用できます。</b>
+    * <b>ただし、テンプレート登録時にあらかじめ\sをフィールドに追加している場合は適用されません。</b>
 
 [例]
+
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/raw-messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","content":"{内容}","buttons":[{"ordering":"{ボタン順序}","type":"{ボタンタイプ}","name":"{ボタン名}","linkMo":"{モバイルWebリンク}"}]}]}'
 ```
@@ -387,25 +434,25 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 }
 ```
 
-| 値                | タイプ | 説明    |
-| ----------------------- | ------- | ------------ |
-| header                  | Object  | ヘッダ領域 |
-| - resultCode            | Integer | 結果コード |
-| - resultMessage         | String  | 結果メッセージ |
-| - isSuccessful          | Boolean | 成否  |
-| message                 | Object  | 本文領域 |
-| - requestId             | String  | リクエストID        |
-| - senderGroupingKey     | String  | 発信グルーピングキー |
-| - sendResults           | Object  | 送信リクエスト結果 |
-| -- recipientSeq         | Integer | 受信者シーケンス番号 |
-| -- recipientNo          | String  | 受信番号 |
-| -- resultCode           | Integer | 送信リクエスト結果コード |
-| -- resultMessage        | String  | 送信リクエスト結果メッセージ |
-| -- recipientGroupingKey | String  | 受信者グルーピングキー |
+| 名前                      | タイプ      | Not Null | 説明           |
+|-------------------------|---------|:--------:|--------------|
+| header                  | Object  |    O     | ヘッダー領域        |
+| - resultCode            | Integer |    O     | 結果コード        |
+| - resultMessage         | String  |    O     | 結果メッセージ       |
+| - isSuccessful          | Boolean |    O     | 成功かどうか        |
+| message                 | Object  |    X     | 本文領域        |
+| - requestId             | String  |    X     | リクエスト ID       |
+| - senderGroupingKey     | String  |    X     | 発信グルーピングキー     |
+| - sendResults           | Object  |    O     | 送信リクエスト結果     |
+| -- recipientSeq         | Integer |    O     | 受信者シーケンス番号   |
+| -- recipientNo          | String  |    X     | 受信番号        |
+| -- resultCode           | Integer |    O     | 送信リクエスト結果コード  |
+| -- resultMessage        | String  |    O     | 送信リクエスト結果メッセージ |
+| -- recipientGroupingKey | String  |    X     | 受信者グルーピングキー    |
 
 <a id="list-messages"></a>
 
-### メッセージリストの照会
+### メッセージリスト照会
 
 <a id="request"></a>
 
@@ -420,46 +467,49 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 値 | タイプ | 説明 |
-| ------ | ------ | ------ |
-| appkey | String | 固有のアプリキー |
+| 名前     | 	タイプ     | 	説明     |
+|--------|---------|---------|
+| appkey | 	String | 	固有のアプリキー |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| 値    | タイプ | 必須 | 説明                               |
-| ------------ | ------ | ---- | ---------------------------------------- |
-| X-Secret-Key | String | O    | コンソールで作成できます。 |
 
-[Query parameter] 1番or(2番、 3番)の条件は必須
+| 名前           | 	タイプ     | 	必須 | 	説明              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | コンソールで作成できます。 |
 
-| 値             | タイプ | 必須 | 説明                                |
-| -------------------- | ------- | --------- | ---------------------------------------- |
-| requestId            | String  | 条件必須(1番) | リクエストID                                    |
-| startRequestDate     | String  | 条件必須(2番) | 送信リクエスト日の開始値(yyyy-MM-dd HH:mm)          |
-| endRequestDate       | String  | 条件必須(2番) | 送信リクエスト日の終了値(yyyy-MM-dd HH:mm)           |
-| startCreateDate      | String  | 条件必須(3番) | 登録日開始値(yyy-MM-dd HH:mm)                   |
-| endCreateDate        | String  | 条件必須(3番) | 登録日終値(yyy-MM-dd HH:mm)                    |
-| recipientNo          | String  | X         | 受信番号                             |
-| senderKey            | String  | X         | 発信キー                                 |
-| templateCode         | String  | X         | テンプレートコード                            |
-| senderGroupingKey    | String  | X         | 発信グルーピングキー                            |
-| recipientGroupingKey | String  | X         | 受信者グルーピングキー                           |
-| messageStatus        | String  | X         | リクエストステータス(COMPLETED -> 成功、FAILED -> 失敗、CANCEL -> キャンセル) |
-| resultCode           | String  | X         | 送信結果(MRC01 -> 成功、MRC02 -> 失敗)          |
-| createUser           | String  | X         | 登録者(コンソールから送信する場合、ユーザーUUIDとして保存)|
-| pageNum              | Integer | X         | ページ番号(基本：1)                            |
-| pageSize             | Integer | X         | 照会件数(基本：15、最大: 1000)                |
+[Query parameter] 1番 または(2番、3番)の条件が必須
 
-* 90日以上前の送信リクエストデータは照会されません。
-* 送信リクエスト日時の範囲は最大30日です。
+| 名前                   | 	タイプ      | 	必須        | 	説明                                                   |
+|----------------------|----------|------------|-------------------------------------------------------|
+| requestId            | 	String  | 	条件必須(1番) | リクエストID                                                |
+| startRequestDate     | 	String  | 	条件必須(2番) | 送信リクエスト日時の開始値(yyyy-MM-dd HH:mm)                       |
+| endRequestDate       | 	String  | 条件必須(2番)  | 	送信リクエスト日時の終了値(yyyy-MM-dd HH:mm)                       |
+| startCreateDate      | String   | 条件必須(3番)  | 登録日時の開始値(yyyy-MM-dd HH:mm)                           |
+| endCreateDate        | String   | 条件必須(3番)  | 登録日時の終了値(yyyy-MM-dd HH:mm)                            |
+| recipientNo          | 	String  | 	X         | 	受信番号                                                 |
+| senderKey            | 	String  | 	X         | 	発信キー                                                 |
+| templateCode         | 	String  | 	X         | 	テンプレートコード                                               |
+| senderGroupingKey    | String   | X          | 発信グルーピングキー                                              |
+| recipientGroupingKey | 	String  | 	X         | 	受信者グルーピングキー                                            |
+| messageStatus        | String   | 	X         | リクエスト状態( COMPLETED -> 成功、FAILED -> 失敗、CANCEL -> 取消 )	 |
+| resultCode           | String   | 	X         | 送信結果( MRC01 -> 成功 MRC02 -> 失敗 )	                     |
+| createUser           | String   | X          | 登録者(コンソールから送信時にユーザー UUID で保存)                           |
+| pageNum              | 	Integer | 	X         | 	ページ番号(Default: 1)                                   |
+| pageSize             | 	Integer | 	X         | 	照会件数(Default: 15、Max: 1000)                        |
+
+* 90日以前の送信リクエストデータは照会できません。
+* 送信リクエスト日時の範囲は最大 30 日です。
 
 <a id="response-3"></a>
 
 #### レスポンス
+
 ```
 {
   "header": {
@@ -495,61 +545,39 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 値                   | タイプ | 説明                               |
-| --------------------------- | ------- | ---------------------------------------- |
-| header                      | Object  | ヘッダ領域                            |
-| - resultCode                | Integer | 結果コード                            |
-| - resultMessage             | String  | 結果メッセージ                           |
-| - isSuccessful              | Boolean | 成否                             |
-| messageSearchResultResponse | Object  | 本文領域                            |
-| - messages                  | List    | メッセージリスト                           |
-| -- requestId                | String  | リクエストID                                    |
-| -- recipientSeq             | Integer | 受信者シーケンス番号                       |
-| -- plusFriendId             | String  | プラスフレンドID                                 |
-| -- senderKey                | String  | 発信キー                                  |
-| -- templateCode             | String  | テンプレートコード                           |
-| -- recipientNo              | String  | 受信番号                            |
-| -- content                  | String  | 本文                               |
-| -- requestDate              | String  | リクエスト日
-| -- createDate               | String  | 登録日時                            |
-| -- receiveDate              | String  | 受信日時                            |
-| -- resendStatus             | String  | 再送信ステータスコード                        |
-| -- resendStatusName         | String  | 再送信ステータスコード名                        |
-| -- messageStatus            | String  | リクエストステータス(COMPLETED -> 成功、FAILED -> 失敗、CANCEL -> キャンセル) |
-| -- createUser               | String  | 登録者(コンソールから送信する場合、ユーザーUUIDとして保存) |
-| -- resultCode               | String  | 受信結果コード                         |
-| -- resultCodeName           | String  | 受信結果コード名                         |
-| -- buttons                  | List    | ボタンリスト                            |
-| --- ordering                | Integer | ボタン順序                            |
-| --- type                    | String  | ボタンタイプ(WL：Webリンク、AL：アプリリンク、DS：配送照会、BK：Botキーワード、MD：メッセージ伝達、BC：相談トーク転換、BT：Bot転換、AC：チャンネル追加) |
-| --- name                    | String  | ボタン名                            |
-| --- linkMo                  | String  | モバイルWebリンク(WLタイプの場合は必須フィールド)                |
-| --- linkPc                  | String  | PC Webリンク(WLタイプの場合は任意フィールド)                 |
-| --- schemeIos               | String  | iOSアプリリンク(ALタイプの場合は必須フィールド)                |
-| --- schemeAndroid           | String  | Androidアプリリンク(ALタイプの場合は必須フィールド)            |
-| --- chatExtra               | String  | BC(相談トークに切替) / BT(Botに切替)タイプボタンの時、伝達するメタ情報 |
-| --- chatEvent               | String  | BT(Botに切替)タイプボタンの時、接続するBotイベント名 |
-| --- target                  | String  | Webリンクボタンの場合、 "target":"out"プロパティ追加時のアウトリンク<br>基本インアプリリンクで送信 |
-| -- telNumber | String | X | TN(電話する)タイプのボタンの場合、伝達する電話番号 |
-| -- senderGroupingKey        | String  | 発信グルーピングキー                            |
-| -- recipientGroupingKey     | String  | 受信者グルーピングキー                           |
-| - totalCount                | Integer | 総個数                              |
+| 名前                          | タイプ      | Not Null | 説明                                                                                                                                                                     |
+|-----------------------------|---------|:--------:|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| header                      | Object  |    O     | ヘッダ領域                                                                                                                                                                  |
+| - resultCode                | Integer |    O     | 結果コード                                                                                                                                                                  |
+| - resultMessage             | String  |    O     | 結果メッセージ                                                                                                                                                                 |
+| - isSuccessful              | Boolean |    O     | 成否                                                                                                                                                                  |
+| messageSearchResultResponse | Object  |    X     | 本文領域                                                                                                                                                                  |
+| - messages                  | List    |    O     | メッセージリスト                                                                                                                                                                |
+| -- requestId                | String  |    O     | リクエスト ID                                                                                                                                                                 |
+| -- recipientSeq             | Integer |    O     | 受信者シーケンス番号                                                                                                                                                             |
+| -- plusFriendId             | String  |    O     | プラスフレンド ID                                                                                                                                                               |
+| -- senderKey                | String  |    O     | 発信キー                                                                                                                                                                   |
+| -- templateCode             | String  |    O     | テンプレートコード                                                                                                                                                                 |
+| -- recipientNo              | String  |    O     | 受信番号                                                                                                                                                                  |
+| -- content                  | String  |    X     | 本文                                                                                                                                                                     |
+| -- requestDate              | String  |    O     | リクエスト日時                                                                                                                                                                  |
+| -- createDate               | String  |    O     | 登録日時                                                                                                                                                                  |
+| -- receiveDate              | String  |    X     | 受信日時                                                                                                                                                                  |
+| -- resendStatus             | String  |    O     | 代替送信状態コード(RSC01、RSC02、RSC03、RSC04、RSC05)\<br\>([[下記の代替送信状態表](http://docs.toast.com/ko/Notification/KakaoTalk%20Bizmessage/ko/alimtalk-api-guide/#smslms)] 参照) |
+| -- resendStatusName         | String  |    O     | 代替送信状態コード名                                                                                                                                                           |
+| -- messageStatus            | String  |    O     | リクエスト状態( COMPLETED \-> 成功、FAILED \-> 失敗、CANCEL \-> 取消 )                                                                                                                |
+| -- createUser               | String  |    X     | 登録者(コンソールから送信時にユーザー UUID で保存)                                                                                                                                            |
+| -- resultCode               | String  |    X     | 受信結果コード                                                                                                                                                               |
+| -- resultCodeName           | String  |    X     | 受信結果コード名                                                                                                                                                              |
+| -- senderGroupingKey        | String  |    X     | 発信グルーピングキー                                                                                                                                                               |
+| -- recipientGroupingKey     | String  |    X     | 受信者グルーピングキー                                                                                                                                                              |
+| - totalCount                | Integer |    X     | 総件数                                                                                                                                                                    |
 
 [例]
+
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
 ```
-
-<a id="get-messages"></a>
-
-### SMS/LMS再送信ステータス
-| 値 | 説明                      |
-| ----- | ------------------------------- |
-| RSC01 | 再送信の対象ではない                 |
-| RSC02 | 再送信の対象(送信結果が失敗の時、再送信が行われます。) |
-| RSC03 | 再送信中                    |
-| RSC04 | 再送信成功                  |
-| RSC05 | 再送信失敗                  |
 
 <a id="get-messages"></a>
 
@@ -568,30 +596,34 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 値    | タイプ | 説明 |
-| ------------ | ------- | ---------- |
-| appkey       | String  | 固有のアプリキー |
-| requestId    | String  | リクエストID      |
-| recipientSeq | Integer | 受信者シーケンス番号 |
+| 名前           | 	タイプ      | 	説明         |
+|--------------|----------|-------------|
+| appkey       | 	String  | 	固有のアプリキー     |
+| requestId    | 	String  | 	リクエスト ID     |
+| recipientSeq | 	Integer | 	受信者シーケンス番号 |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| 値    | タイプ | 必須 | 説明                               |
-| ------------ | ------ | ---- | ---------------------------------------- |
-| X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+| 名前           | 	タイプ     | 	必須 | 	説明              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | コンソールで作成できます。 |
 
 [例]
+
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}/{recipientSeq}"
 ```
 
 <a id="response-4"></a>
 
-#### レスポンス
+#### 応答
+
 ```
 {
   "header": {
@@ -689,99 +721,101 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 }
 ```
 
-| 値               | タイプ | 説明                                |
-| ---------------------- | ------- | ---------------------------------------- |
-| header                 | Object  | ヘッダ領域                             |
-| - resultCode           | Integer | 結果コード                             |
-| - resultMessage        | String  | 結果メッセージ                            |
-| - isSuccessful         | Boolean | 成否                              |
-| message                | Object  | メッセージ                               |
-| - requestId            | String  | リクエストID                                    |
-| - recipientSeq         | Integer | 受信者シーケンス番号                        |
-| - plusFriendId         | String  | プラスフレンドID                                 |
-| - senderKey            | String  | 発信キー                                   |
-| - templateCode         | String  | テンプレートコード                            |
-| - recipientNo          | String  | 受信番号                             |
-| - content              | String  | 本文                                |
-|- templateTitle         | String  | テンプレートハイライトタイトル              |
-|- templateSubtitle      | String  | テンプレートハイライトサブタイトル           |
-|- templateExtra         | String  | テンプレート付加情報                     |
-|- templateAd            | String  | テンプレート内の受信同意または簡単な広告文句   |
-| - templateHeader | String | X | テンプレートヘッダ(最大16文字) |
-| - templateItem | Object | X | アイテム |
-| -- list | List | X | アイテムリスト(最小2件、最大10件) |
-| --- title | String | X | タイトル(最大6文字) |
-| --- description | String | X | 説明(最大23文字) |
-| -- summary | Object | X | アイテム要約情報 |
-| --- title | String | X | タイトル(最大6文字) |
-| --- description | String | X | 説明(変数及び通貨単位、数字、カンマ、ピリオドのみ使用可能、最大14文字) |
-| - templateItemHighlight | Object  |    X     | アイテムハイライト                                                                                                                                                            |
-| --- title | String | X | タイトル(最大30文字、サムネイル画像がある場合は21文字) |
-| --- description | String | X | 説明(最大19文字、サムネイル画像がある場合は13文字) |
-| --- imageUrl            | String  |    X     | サムネイル画像アドレス                                                                                                                                                           |
-| - templateRepresentLink | Object  |    X     | 代表リンク                                                                                                                                                                |
-| -- linkMo               | String  |    X     | モバイルWebリンク(最大500文字)                                                                                                                                                      |
-| -- linkPc               | String  |    X     | PC Webリンク(最大500文字)                                                                                                                                                       |
-| -- schemeIos            | String  |    X     | iOSアプリリンク(最大500文字)                                                                                                                                                      |
-| -- schemeAndroid        | String  |    X     | Androidアプリリンク(最大500文字)                                                                                                                                                    |
-| - requestDate          | String  | リクエスト日時                             |
-| - receiveDate          | String  | 受信日時                             |
-| - createDate           | String  | 登録日時                            |
-| - resendStatus         | String  | 再送信ステータスコード                         |
-| - resendStatusName     | String  | 再送信ステータスコード名                          |
-| - resendResultCode      | String  |    X     | 代替送信結果コード[SMS結果コード](https://docs.toast.com/ko/Notification/SMS/ko/error-code/#api)                                                                                 |
-| - resendRequestId       | String  |    X     | 代替送信SMSリクエストID                                                                                                                                                        |
-| - messageStatus        | String  | リクエストステータス(COMPLETED -> 成功、FAILED -> 失敗、CANCEL -> キャンセル) |
-| - resultCode           | String  | 受信結果コード                          |
-| - resultCodeName       | String  | 受信結果コード名                           |
-| - createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
-| - buttons              | List    | ボタンリスト                             |
-| -- ordering            | Integer | ボタン順序                             |
-| -- type                | String  | ボタンタイプ(WL：Webリンク、AL：アプリリンク、DS：配送照会、BK：Botキーワード、MD：メッセージ伝達、BC：相談トーク転換、BT：Bot転換、AC：チャンネル追加、 TN:電話発信) |
-| -- name                | String  | ボタン名                             |
-| -- linkMo              | String  | モバイルWebリンク(WLタイプの場合は必須フィールド)                |
-| -- linkPc              | String  | PC Webリンク(WLタイプの場合は任意フィールド)                 |
-| -- schemeIos           | String  | iOSアプリリンク(ALタイプの場合は必須フィールド)                |
-| -- schemeAndroid       | String  | Androidアプリリンク(ALタイプの場合は必須フィールド)            |
-| -- chatExtra           | String  | BC(相談トークに切替) / BT(Botに切替)タイプボタンの時、伝達するメタ情報 |
-| -- chatEvent           | String  | BT(Botに切替)タイプボタンの時、接続するBotイベント名 |
-| -- bizFormId | Integer | X | ビジネスフォームID(BFタイプの場合、必須) |
-| -- pluginId             | String  |    X     | プラグインID(最大24文字)                                                                                                                                                        |
-| -- relayId | String | X | プラグイン実行の際、X-Kakao-Plugin-Relay-Idヘッダを介して受け取る値 |
-| -- oneClickId | String | X | ワンクリック決済プラグインで使用する決済情報 |
-| -- productId | String | X | ワンクリック決済プラグインで使用する決済情報 |
-| -- target              | String  | Webリンクボタンの場合、 "target":"out"プロパティ追加時のアウトリンク<br>基本インアプリリンクで送信 |
-| - quickReplies | List | X | クイック返信リスト(最大5件) |
-| -- ordering | Integer | X | クイック返信の順序(クイック返信がある場合、必須) |
-| -- type | String | X | クイック返信タイプ(WL: Webリンク、AL:アプリリンク、BK: ボットキーワード、BC:相談トーク切り替え、BT: ボット切り替え、BF:ビジネスフォーム) |
-| -- name | String | X | クイック返信名(クイック返信がある場合、必須、最大14文字) |
-| -- linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド、最大500文字) |
-| -- linkPc | String | X | PCWebリンク(WLタイプの場合、任意フィールド、最大500文字) |
-| -- schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド、最大500文字) |
-| -- schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド、最大500文字) |
-| -- pluginId             | String  |    X     | プラグインID(最大24文字)                                                                                                                                                        |
-| -- target | String | X | Webリンクタイプの場合、「"target":"out"」属性を追加すると外部リンク<br>デフォルトではアプリ内リンクとして送信 |
-| -- telNumber | String | X | TN(電話する)タイプのボタンの場合、伝達する電話番号 |
-| - messageOption        | Object  |	メッセージオプション                                         |
-| -- price               | Integer |	message(ユーザーに伝達されるメッセージ)内に含まれた価格/金額/決済金額(モーメント広告に該当) |
-| -- currencyType        | String  |	message(ユーザーに伝達されるメッセージ)内に含まれた価格/金額/決済金額(モーメント広告に該当) |
-| - senderGroupingKey    | String  | 発信グルーピングキー                            |
-| - recipientGroupingKey | String  | 受信者グルーピングキー                           |
+-----
+
+| 名前                      | タイプ      | Not Null | 説明                                                                                                                                                                     |
+|-------------------------|---------|:--------:|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| header                  | Object  |    O     | ヘッダー領域                                                                                                                                                                  |
+| - resultCode            | Integer |    O     | 結果コード                                                                                                                                                                  |
+| - resultMessage         | String  |    O     | 結果メッセージ                                                                                                                                                                 |
+| - isSuccessful          | Boolean |    O     | 成否                                                                                                                                                                  |
+| message                 | Object  |    X     | メッセージ                                                                                                                                                                    |
+| - requestId             | String  |    O     | リクエスト ID                                                                                                                                                                 |
+| - recipientSeq          | Integer |    O     | 受信者シーケンス番号                                                                                                                                                             |
+| - plusFriendId          | String  |    O     | プラスフレンド ID                                                                                                                                                               |
+| - senderKey             | String  |    O     | 発信キー                                                                                                                                                                   |
+| - templateCode          | String  |    O     | テンプレートコード                                                                                                                                                                 |
+| - recipientNo           | String  |    X     | 受信番号                                                                                                                                                                  |
+| - content               | String  |    X     | 本文                                                                                                                                                                     |
+| - templateTitle         | String  |    X     | テンプレートタイトル                                                                                                                                                                 |
+| - templateSubtitle      | String  |    X     | テンプレート補助文言                                                                                                                                                              |
+| - templateExtra         | String  |    X     | テンプレート付加内容                                                                                                                                                              |
+| - templateAd            | String  |    X     | テンプレート内の受信同意リクエストまたは簡単な広告文言                                                                                                                                            |
+| - templateHeader        | String  |    X     | テンプレートヘッダー（最大 16 文字）                                                                                                                                                         |
+| - templateItem          | Object  |    X     | アイテム                                                                                                                                                                    |
+| -- list                 | List    |    X     | アイテムリスト（最小 2 個、最大 10 個）                                                                                                                                                 |
+| --- title               | String  |    X     | タイトル（最大 6 文字）                                                                                                                                                             |
+| --- description         | String  |    X     | 説明（最大 23 文字）                                                                                                                                                          |
+| -- summary              | Object  |    X     | アイテム要約情報                                                                                                                                                              |
+| --- title               | String  |    X     | タイトル（最大 6 文字）                                                                                                                                                             |
+| --- description         | String  |    X     | 説明（変数および通貨単位、数字、カンマ、ピリオドのみ使用可能、最大 14 文字）                                                                                                                          |
+| - templateItemHighlight | Object  |    X     | アイテムハイライト                                                                                                                                                              |
+| --- title               | String  |    X     | タイトル（最大 30 文字、サムネイル画像がある場合は 21 文字）                                                                                                                                        |
+| --- description         | String  |    X     | 説明（最大 19 文字、サムネイル画像がある場合は 13 文字）                                                                                                                                      |
+| --- imageUrl            | String  |    X     | サムネイル画像 URL                                                                                                                                                             |
+| - templateRepresentLink | Object  |    X     | 代表リンク                                                                                                                                                                  |
+| -- linkMo               | String  |    X     | モバイル Web リンク（最大 500 文字）                                                                                                                                                      |
+| -- linkPc               | String  |    X     | PC Web リンク（最大 500 文字）                                                                                                                                                       |
+| -- schemeIos            | String  |    X     | iOS アプリリンク（最大 500 文字）                                                                                                                                                      |
+| -- schemeAndroid        | String  |    X     | Android アプリリンク（最大 500 文字）                                                                                                                                                    |
+| - requestDate           | String  |    O     | リクエスト日時                                                                                                                                                                  |
+| - receiveDate           | String  |    X     | 受信日時                                                                                                                                                                  |
+| - createDate            | String  |    O     | 登録日時                                                                                                                                                                  |
+| - resendStatus          | String  |    O     | 代替送信ステータスコード（RSC01、RSC02、RSC03、RSC04、RSC05）\<br\>（[[下記の代替送信ステータス表](http://docs.toast.com/ko/Notification/KakaoTalk%20Bizmessage/ko/alimtalk-api-guide/#smslms)] 参照） |
+| - resendStatusName      | String  |    O     | 代替送信ステータスコード名                                                                                                                                                           |
+| - resendResultCode      | String  |    X     | 代替送信結果コード [SMS 結果コード](https://docs.toast.com/ko/Notification/SMS/ko/error-code/#api)                                                                                 |
+| - resendRequestId       | String  |    X     | 代替送信 SMS リクエスト ID                                                                                                                                                        |
+| - messageStatus         | String  |    O     | リクエストステータス（COMPLETED -\> 成功、FAILED -\> 失敗、CANCEL -\> 取消）                                                                                                                |
+| - resultCode            | String  |    X     | 受信結果コード                                                                                                                                                               |
+| - resultCodeName        | String  |    X     | 受信結果コード名                                                                                                                                                              |
+| - createUser            | String  |    X     | 登録者（コンソールから送信する場合はユーザー UUID で保存）                                                                                                                                            |
+| - buttons               | List    |    X     | ボタンリスト                                                                                                                                                                 |
+| -- ordering             | Integer |    X     | ボタン順序                                                                                                                                                                  |
+| -- type                 | String  |    X     | ボタンタイプ（WL: Webリンク、AL: アプリリンク、DS: 配送照会、BK: ボットキーワード、MD: メッセージ転達、BC: 相談トーク転換、BT: ボット転換、AC: チャンネル追加、BF: ビジネスフォーム、P1: 画像セキュリティ転送プラグイン ID、P2: 個人情報利用プラグイン ID、P3: ワンクリック決済プラグイン ID、TN: 電話する） |
+| -- name                 | String  |    X     | ボタン名                                                                                                                                                                  |
+| -- linkMo               | String  |    X     | モバイル Web リンク（WL タイプの場合は必須フィールド）                                                                                                                                              |
+| -- linkPc               | String  |    X     | PC Web リンク（WL タイプの場合は選択フィールド）                                                                                                                                               |
+| -- schemeIos            | String  |    X     | iOS アプリリンク（AL タイプの場合は必須フィールド）                                                                                                                                              |
+| -- schemeAndroid        | String  |    X     | Android アプリリンク（AL タイプの場合は必須フィールド）                                                                                                                                            |
+| -- chatExtra            | String  |    X     | BC（相談トーク転換）/ BT（ボット転換）タイプのボタン時、転達するメタ情報                                                                                                                                |
+| -- chatEvent            | String  |    X     | BT（ボット転換）タイプのボタン時、接続するボットイベント名                                                                                                                                           |
+| -- bizFormId            | Integer |    X     | ビジネスフォーム ID（BF タイプの場合は必須）                                                                                                                                                 |
+| -- pluginId             | String  |    X     | プラグイン ID（最大 24 文字）                                                                                                                                                        |
+| -- relayId              | String  |    X     | プラグイン実行時に X-Kakao-Plugin-Relay-Id ヘッダーを通じて転達される値                                                                                                                        |
+| -- oneClickId           | String  |    X     | ワンクリック決済プラグインで使用する決済情報                                                                                                                                               |
+| -- productId            | String  |    X     | ワンクリック決済プラグインで使用する決済情報                                                                                                                                               |
+| -- target               | String  |    X     | Web リンクボタンの場合、"target":"out" 属性を追加するとアウトリンク\<br\>デフォルトはインアプリリンクで送信                                                                                                            |
+| - quickReplies          | List    |    X     | クイックリプライリスト（最大 5 件）                                                                                                                                                        |
+| -- ordering             | Integer |    X     | クイックリプライ順序（クイックリプライがある場合は必須）                                                                                                                                                |
+| -- type                 | String  |    X     | クイックリプライタイプ（WL: Web リンク、AL: アプリリンク、BK: ボットキーワード、BC: 相談トーク転換、BT: ボット転換、BF: ビジネスフォーム）                                                                                                |
+| -- name                 | String  |    X     | クイックリプライ名（クイックリプライがある場合は必須、最大 14 文字）                                                                                                                                        |
+| -- linkMo               | String  |    X     | モバイル Web リンク（WL タイプの場合は必須フィールド、最大 500 文字）                                                                                                                                     |
+| -- linkPc               | String  |    X     | PC Web リンク（WL タイプの場合は選択フィールド、最大 500 文字）                                                                                                                                      |
+| -- schemeIos            | String  |    X     | iOS アプリリンク（AL タイプの場合は必須フィールド、最大 500 文字）                                                                                                                                     |
+| -- schemeAndroid        | String  |    X     | Android アプリリンク（AL タイプの場合は必須フィールド、最大 500 文字）                                                                                                                                   |
+| -- pluginId             | String  |    X     | プラグイン ID（最大 24 文字）                                                                                                                                                        |
+| -- target               | String  |    X     | Web リンクタイプの場合、"target":"out" 属性を追加するとアウトリンク\<br\>デフォルトはインアプリリンクで送信                                                                                                            |
+| -- telNumber           | 	String  | 	X  | TN（電話する）タイプのボタン時、転達する電話番号                                                                    |
+| - messageOption         | Object  |    X     | メッセージオプション                                                                                                                                                                 |
+| -- price                | Integer |    X     | ユーザーに転達されるメッセージ内に含まれる価格/金額/決済金額（モーメント広告に該当）                                                                                                                            |
+| -- currencyType         | String  |    X     | ユーザーに転達されるメッセージ内に含まれる価格/金額/決済金額の通貨単位。KRW、USD、EUR などの国際通貨コードを使用（モーメント広告に該当）                                                                                         |
+| - senderGroupingKey     | String  |    X     | 発信グルーピングキー                                                                                                                                                               |
+| - recipientGroupingKey  | String  |    X     | 受信者グルーピングキー                                                                                                                                                              |
 
 <a id="authentication-messages"></a>
 
 ## 認証メッセージ
 
 <span id="precautions-authword"></span>
-1. 認証メッセージの送信時、含まれる必要がある認証文言案内
 
-| 区分 | 認証文言 |
-| --- | --- |
-| 認証メッセージ | auth、password、verif、にんしょう、認証、パスワード、認証 |
+1. 認証メッセージ送信時に含める必要がある認証文言のご案内
 
-- 例1)認証メッセージAPI送信リクエストした時、全文(テンプレート日本語識別子含む)に認証文言が含まれていない場合は、送信に失敗します。
-- 例2)認証文言が英文の場合、大文字/小文字の区別なしで有効性チェックが行われます。
+| 区分       | 認証文言                                          |
+|----------|-----------------------------------------------|
+| 認証メッセージ | auth, password, verif, にんしょう, 認証, 비밀번호, 인증 |
 
+- 例 1-1) 認証メッセージ API リクエスト時に本文（テンプレート置換変数を含む）に認証文言が含まれていない場合、送信失敗となります。
+- 例 1-2) 認証文言が英文の場合、大文字・小文字を区別せずバリデーションが実施されます。
 
 <a id="request-of-sending-replaced-messages-2"></a>
 
@@ -796,96 +830,25 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 値 | タイプ | 説明 |
-| ------ | ------ | ------ |
-| appkey | String | 固有のアプリキー |
+| 名前     | 	タイプ   | 	説明        |
+|--------|---------|------------|
+| appkey | 	String | 	固有のアプリキー |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| 値    | タイプ | 必須 | 説明                               |
-| ------------ | ------ | ---- | ---------------------------------------- |
-| X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+| 名前                       | 	タイプ   | 	必須 | 	説明                                                               |
+|--------------------------|---------|-----|-------------------------------------------------------------------|
+| X-Secret-Key             | 	String | O   | コンソールで生成できます。                                                     |
+| X-NC-API-IDEMPOTENCY-KEY | 	String | X   | 重複メッセージ送信リクエストの基準 key<br>10 分間、同一の key でリクエストした場合、該当リクエストを失敗として処理します。 |
 
 [Request body]
-
-```
-{
-    "senderKey": String,
-    "templateCode": String,
-    "requestDate": String,
-    "senderGroupingKey": String,
-    "createUser" : String,
-    "recipientList": [{
-        "recipientNo": String,
-        "templateParameter": {
-            String: String
-        },
-        "resendParameter": {
-          "isResend" : boolean,
-          "resendType" : String,
-          "resendTitle" : String,
-          "resendContent" : String,
-          "resendSendNo" : String
-        },
-        "buttons": [
-          {
-            "ordering": Integer,
-            "chatExtra": String,
-            "chatEvent": String,
-            "target": String
-          }
-        ],
-        "recipientGroupingKey": String
-    }],
-    "messageOption": {
-      "price": Integer,
-      "currencyType": String
-    },
-    "statsId": String
-}
-```
-
-| 値               | タイプ | 必須 | 説明                                |
-| ---------------------- | ------- | ---- | ---------------------------------------- |
-| senderKey              | String  | O    | 発信キー                         |
-| templateCode           | String  | O    | 登録した送信テンプレートコード(最大20桁)                    |
-| requestDate            | String  | X    | リクエスト日時(yyyy-MM-dd HH:mm)<br>(入力しない場合は即時送信) |
-| createUser             | String  | X    | 登録者(コンソールから送信する場合、ユーザーUUIDとして保存)|
-| senderGroupingKey      | String  | X    | 発信グルーピングキー(最大100文字)                        |
-| recipientList          | List    | O    | 受信者リスト(最大1000人)                         |
-| - recipientNo          | String  | O    | 受信番号(最大15桁)                            |
-| - templateParameter    | Object  | X    | テンプレートパラメータ<br>(テンプレートに置換する変数が含まれる時は必須)       |
-| -- key                 | String  | X    | 置換キー(#{key})                             |
-| -- value               | String  | X    | 置換キーにマッピングされるvalue値                |
-| - resendParameter      | Object  | X    | 代替発送情報 |
-| -- isResend            | boolean | X    | 送信失敗時、代替送信するかどうか<br>コンソールで送信失敗設定をした時、デフォルト設定は再送信になっています。 |
-| -- resendType          | String  | X    | 代替送信タイプ(SMS、LMS)<br>値がない場合は、テンプレート本文の長さに応じてタイプが決まります。 |
-| -- resendTitle         | String  | X    | LMS代替送信タイトル(最大20文字)<br>(値がない場合は、プラスフレンドIDで再送信されます。) |
-| -- resendContent       | String  | X    | 代替送信内容(最大1000文字)<br>(値がない場合は、テンプレートの内容で再送信されます。) |
-| -- resendSendNo        | String  | X    | 代替送信発信番号(最大13桁)<br><span style="color:red">(SMSサービスに登録された発信番号ではない場合、代替送信が失敗することがあります。)</span> |
-| - buttons              | List    | X    | ボタン追加情報 |
-| -- ordering            | Integer | X    |	ボタン順序(ボタンがある場合は必須) |
-| -- chatExtra           | String  | X    |	BC(相談トークに切替) / BT(Botに切替)タイプボタンの時、伝達するメタ情報 |
-| -- chatEvent           | String  | X    |	BT(Botに切替)タイプボタンの時、接続するBotイベント名 |
-| -- target              | String  | X    |	Webリンクボタンの場合、 "target":"out"プロパティ追加時のアウトリンク<br>基本インアプリリンクで送信 |
-| - recipientGroupingKey | String  | X    | 受信者グルーピングキー(最大100文字)                       |
-| messageOption          | Object  | X    |	メッセージオプション                                         |
-| - price                | Integer | X    |	message(ユーザーに伝達されるメッセージ)内に含まれた価格/金額/決済金額(モーメント広告に該当) |
-| - currencyType         | String  | X    |	message(ユーザーに伝達されるメッセージ)内に含まれた価格/金額/決済金額(モーメント広告に該当) |
-| statsId                | String  | X    |	統計ID(発信検索条件には含まれません, 最大8文字) |
-
-* <b>リクエスト日時は呼び出す時点から60日後まで設定可能です。</b>
-* <b>SMSサービスで代替送信されるため、SMSサービスの送信APIの仕様に応じてフィールドを入力する必要があります。(SMSサービスに登録された発信番号、各種フィールドの長さ制限など)</b>
-* <b>指定した代替送信タイプのバイト制限を超える代替送信のタイトルや内容は、途中で切れて代替送信されることがあります。([[SMS注意事項](https://docs.toast.com/ko/Notification/SMS/ko/api-guide/#_1)]参考)</b>
-
-[例]
-```
-curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","templateParameter":{"{日本語識別子フィールド}":"{置換データ}"}}]}'
-```
+[上記と同様](./alimtalk-api-guide/#_3)
 
 <a id="request-of-sending-full-text-2"></a>
 
@@ -900,112 +863,29 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 値 | タイプ | 説明 |
-| ------ | ------ | ------ |
-| appkey | String | 固有のアプリキー |
+| 名前     | 	タイプ   | 	説明        |
+|--------|---------|------------|
+| appkey | 	String | 	固有のアプリキー |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| 値    | タイプ | 必須 | 説明                               |
-| ------------ | ------ | ---- | ---------------------------------------- |
-| X-Secret-Key | String | O    | コンソールで作成できます。 |
-|X-NC-API-IDEMPOTENCY-KEY|	String| X | 重複メッセージ送信要求基準key<br>10分間同じkeyで要求すると、その要求を失敗処理します。 |
 
-[Request body]
+| 名前                       | 	タイプ   | 	必須 | 	説明                                                               |
+|--------------------------|---------|-----|-------------------------------------------------------------------|
+| X-Secret-Key             | 	String | O   | コンソールで生成できます。                                                     |
+| X-NC-API-IDEMPOTENCY-KEY | 	String | X   | 重複メッセージ送信リクエストの基準 key<br>10 分間、同一の key でリクエストした場合、該当リクエストを失敗として処理します。 |
 
-```
-{
-    "senderKey": String,
-    "templateCode": String,
-    "requestDate": String,
-    "senderGroupingKey": String,
-    "createUser": String,
-    "recipientList": [
-        {
-            "recipientNo": String,
-            "content": String,
-            "templateTitle" : String,
-            "buttons": [
-                {
-                    "ordering": Integer,
-                    "type": String,
-                    "name": String,
-                    "linkMo": String,
-                    "linkPc": String,
-                    "schemeIos": String,
-                    "schemeAndroid": String,
-                    "chatExtra": String,
-                    "chatEvent": String,
-                    "target": String
-                }
-            ],
-            "resendParameter": {
-              "isResend" : boolean,
-              "resendType" : String,
-              "resendTitle" : String,
-              "resendContent" : String,
-              "resendSendNo" : String
-            },
-            "recipientGroupingKey": String
-        }
-    ],
-    "messageOption": {
-      "price": Integer,
-      "currencyType": String
-    },
-    "statsId": String
-}
-```
-
-| 値               | タイプ | 必須 | 説明                                |
-| ---------------------- | ------- | ---- | ---------------------------------------- |
-| senderKey              | String  | O    | 発信キー                         |
-| templateCode           | String  | O    | 登録した送信テンプレートコード(最大20桁)                    |
-| requestDate            | String  | X    | リクエスト日時(yyyy-MM-dd HH:mm)<br>(入力しない場合は即時送信) |
-| senderGroupingKey      | String  | X    | 発信グルーピングキー(最大100文字)                        |
-| createUser             | String  | X    | 登録者(コンソールから送信する場合、ユーザーUUIDとして保存) |
-| recipientList          | List    | O    | 受信者リスト(最大1,000人)                        |
-| - recipientNo          | String  | O    | 受信番号(最大15桁)                            |
-| - content              | String  | O    | 内容(最大1000文字)                             |
-| - templateTitle        | String  | X    | タイトル(最大50桁)                            |
-| - buttons              | List    | X    | ボタンリスト(最大5個)                             |
-| -- ordering            | Integer | X    | ボタン順序(ボタンがある場合は必須)                      |
-| -- type                | String  | X    | ボタンタイプ(WL：Webリンク、AL：アプリリンク、DS：配送照会、BK：Botキーワード、MD：メッセージ伝達、BC：相談トーク転換、BT：Bot転換、AC：チャンネル追加) |
-| -- name                | String  | X    | ボタン名(ボタンがある場合は必須、最大14文字)              |
-| -- linkMo              | String  | X    | モバイルWebリンク(WLタイプの場合は必須フィールド、最大500文字)       |
-| -- linkPc              | String  | X    | PC Webリンク(WLタイプの場合は任意フィールド、最大500文字)        |
-| -- schemeIos           | String  | X    | iOSアプリリンク(ALタイプの場合は必須フィールド、最大500文字)       |
-| -- schemeAndroid       | String  | X    | Androidアプリリンク(ALタイプの場合は必須フィールド、最大500文字)   |
-| -- chatExtra           | String  | X    |	BC(相談トークに切替) / BT(Botに切替)タイプボタンの時、伝達するメタ情報 |
-| -- chatEvent           | String  | X    |	BT(Botに切替)タイプボタンの時、接続するBotイベント名 |
-| -- target              | String  | X    |	Webリンクボタンの場合、 "target":"out"プロパティ追加時のアウトリンク<br>基本インアプリリンクで送信 |
-| - resendParameter      | Object  | X    | 代替発送情報 |
-| -- isResend            | boolean | X    | 送信失敗時、代替送信するかどうか<br>コンソールで送信失敗設定をした時、デフォルト設定は再送信になっています。 |
-| -- resendType          | String  | X    | 代替送信タイプ(SMS、LMS)<br>値がない場合は、テンプレート本文の長さに応じてタイプが決まります。 |
-| -- resendTitle         | String  | X    | LMS代替送信タイトル(最大20文字)<br>(値がない場合は、プラスフレンドIDで再送信されます。) |
-| -- resendContent       | String  | X    | 代替送信内容(最大1000文字)<br>(値がない場合は、テンプレートの内容で再送信されます。) |
-| -- resendSendNo        | String  | X    | 代替送信発信番号(最大13桁)<br><span style="color:red">(SMSサービスに登録された発信番号ではない場合、代替送信が失敗することがあります。)</span> |
-| - recipientGroupingKey | String  | X    | 受信者グルーピングキー(最大100文字)                       |
-| messageOption          | Object  | X    |	メッセージオプション                                         |
-| - price                | Integer | X    |	message(ユーザーに伝達されるメッセージ)内に含まれた価格/金額/決済金額(モーメント広告に該当) |
-| - currencyType         | String  | X    |	message(ユーザーに伝達されるメッセージ)内に含まれた価格/金額/決済金額(モーメント広告に該当) |
-| statsId                | String  | X    |	統計ID(発信検索条件には含まれません, 最大8文字) |
-
-* <b>本文とボタンに置換が完了したデータを入れてください。</b>
-* <b>リクエスト日時は呼び出す時点から60日後まで設定可能です。</b>
-
-[例]
-```
-curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/raw-messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","content":"{内容}","buttons":[{"ordering":"{ボタン順序}","type":"{ボタンタイプ}","name":"{ボタン名}","linkMo":"{モバイルWebリンク}"}]}]}'
-```
+[Request Body]
+[上記と同様](./alimtalk-api-guide/#_5)
 
 <a id="list-messages-2"></a>
 
-### メッセージリストの照会
+### メッセージリスト照会
 
 <a id="request-3"></a>
 
@@ -1020,53 +900,24 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 値 | タイプ | 説明 |
-| ------ | ------ | ------ |
-| appkey | String | 固有のアプリキー |
+| 名前     | 	タイプ   | 	説明        |
+|--------|---------|------------|
+| appkey | 	String | 	固有のアプリキー |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| 値    | タイプ | 必須 | 説明                               |
-| ------------ | ------ | ---- | ---------------------------------------- |
-| X-Secret-Key | String | O    | コンソールで作成できます。 |
 
-[Query parameter] 1番or(2番、 3番)の条件は必須
+| 名前           | 	タイプ   | 	必須 | 	説明              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | コンソールで生成できます。 |
 
-| 値             | タイプ | 必須 | 説明                                |
-| -------------------- | ------- | --------- | ---------------------------------------- |
-| requestId            | String  | 条件必須(1番) | リクエストID                                    |
-| startRequestDate     | String  | 条件必須(2番) | 送信リクエスト日の開始値(yyyy-MM-dd HH:mm)          |
-| endRequestDate       | String  | 条件必須(2番) | 送信リクエスト日の終了値(yyyy-MM-dd HH:mm)           |
-| startCreateDate      | String  | 条件必須(3番) | 登録日開始値(yyy-MM-dd HH:mm)                   |
-| endCreateDate        | String  | 条件必須(3番) | 登録日終値(yyy-MM-dd HH:mm)                    |
-| recipientNo          | String  | X         | 受信番号                             |
-| senderKey            | String  | X         | 発信キー                                 |
-| templateCode         | String  | X         | テンプレートコード                            |
-| senderGroupingKey    | String  | X         | 発信グルーピングキー                            |
-| recipientGroupingKey | String  | X         | 受信者グルーピングキー                           |
-| messageStatus        | String  | X         | リクエストステータス(COMPLETED -> 成功、FAILED -> 失敗、CANCEL -> キャンセル) |
-| createUser           | String  | X         | 登録者(コンソールから送信する場合、ユーザーUUIDとして保存)|
-| resultCode           | String  | X         | 送信結果(MRC01 -> 成功、MRC02 -> 失敗)          |
-| pageNum              | Integer | X         | ページ番号(基本：1)                            |
-| pageSize             | Integer | X         | 照会件数(基本：15、最大: 1000)                |
-
-* 90日以上前の送信リクエストデータは照会されません。
-* 送信リクエスト日時の範囲は最大30日です。
-
-<a id="request-3"></a>
-
-#### SMS/LMS再送信ステータス
-| 値 | 説明                      |
-| ----- | ------------------------------- |
-| RSC01 | 再送信の対象ではない                 |
-| RSC02 | 再送信の対象(送信結果が失敗の時、再送信が行われます。) |
-| RSC03 | 再送信中                    |
-| RSC04 | 再送信成功                  |
-| RSC05 | 再送信失敗                  |
+[Query parameter]
+[上記と同様](./alimtalk-api-guide/#_7)
 
 <a id="get-messages-2"></a>
 
@@ -1085,23 +936,26 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 値    | タイプ | 説明 |
-| ------------ | ------- | ---------- |
-| appkey       | String  | 固有のアプリキー |
-| requestId    | String  | リクエストID      |
-| recipientSeq | Integer | 受信者シーケンス番号 |
+| 名前           | 	タイプ    | 	説明          |
+|--------------|---------|--------------|
+| appkey       | 	String  | 	固有のアプリキー   |
+| requestId    | 	String  | 	リクエスト ID   |
+| recipientSeq | 	Integer | 	受信者シーケンス番号 |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| 値    | タイプ | 必須 | 説明                               |
-| ------------ | ------ | ---- | ---------------------------------------- |
-| X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+| 名前           | 	タイプ   | 	必須 | 	説明              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | コンソールで生成できます。 |
 
 [例]
+
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/messages/{requestId}/{recipientSeq}"
 ```
@@ -1109,6 +963,439 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 <a id="response-5"></a>
 
 #### レスポンス
+
+[上記と同様](./alimtalk-api-guide/#_9)
+
+<a id="message"></a>
+
+## メッセージ
+
+<a id="cancel-sending-messages"></a>
+
+### メッセージ送信取消
+
+<a id="request-5"></a>
+
+#### 요청
+
+[URL]
+
+```
+DELETE  /alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 이름        | 	타입     | 	설명     |
+|-----------|---------|---------|
+| appkey    | 	String | 	固有のアプリキー |
+| requestId | String  | リクエスト ID   |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 이름           | 	타입     | 	필수 | 	설명              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | コンソールで作成できます。 |
+
+[Query parameter]
+
+| 이름           | 	타입     | 	필수 | 	설명                                         |
+|--------------|---------|-----|---------------------------------------------|
+| recipientSeq | 	String | 	X  | 受信者シーケンス番号<br>(入力しない場合、リクエスト ID のすべての送信件を取消) |
+
+* 一般/認証メッセージのどちらも同一の API で取消できます。
+
+<a id="response-6"></a>
+
+#### 응답
+
+```
+{
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
+  }
+}
+```
+
+| 이름              | 타입      | Not Null | 설명     |
+|-----------------|---------|:--------:|--------|
+| header          | Object  |    O     | ヘッダー領域  |
+| - resultCode    | Integer |    O     | 結果コード  |
+| - resultMessage | String  |    O     | 結果メッセージ |
+| - isSuccessful  | Boolean |    O     | 成否  |
+
+[예시]
+
+```
+curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
+```
+
+<a id="query-updates-of-message-result"></a>
+
+### メッセージ結果アップデート照会
+
+<a id="request-6"></a>
+
+#### 요청
+
+[URL]
+
+```
+GET  /alimtalk/v2.3/appkeys/{appkey}/message-results
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 이름     | 	타입     | 	설명     |
+|--------|---------|---------|
+| appkey | 	String | 	固有のアプリキー |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 이름           | 	타입     | 	필수 | 	설명              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | コンソールで作成できます。 |
+
+[Query parameter]
+
+| 이름                  | 	타입      | 	필수 | 	설명                                 |
+|---------------------|----------|-----|-------------------------------------|
+| startUpdateDate     | 	String  | 	O  | 結果アップデート照会開始時間(yyyy-MM-dd HH:mm)  |
+| endUpdateDate       | 	String  | O   | 	結果アップデート照会終了時間(yyyy-MM-dd HH:mm) |
+| alimtalkMessageType | 	String  | X   | 	お知らせトークメッセージタイプ(NORMAL, AUTH)           |
+| pageNum             | 	Integer | 	X  | 	ページ番号(デフォルト: 1)                      |
+| pageSize            | 	Integer | 	X  | 	照会件数(Default: 15, Max: 1000)      |
+
+<a id="response-7"></a>
+
+#### 응답
+
+```
+{
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
+  },
+  "messages": [
+    {
+      "requestId": String,
+      "recipientSeq": Integer,
+      "requestDate": String,
+      "createDate": String,
+      "receiveDate": String,
+      "resendStatus": String,
+      "resendStatusName": String,
+      "resendResultCode": String,
+      "resendRequestId": String,
+      "messageStatus": String,
+      "resultCode": String,
+      "resultCodeName": String
+    }
+  ]
+}
+```
+
+| 이름                 | 타입      | Not Null | 설명                                                                                                                                                                     |
+|--------------------|---------|:--------:|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| header             | Object  |    O     | ヘッダー領域                                                                                                                                                                  |
+| - resultCode       | Integer |    O     | 結果コード                                                                                                                                                                  |
+| - resultMessage    | String  |    O     | 結果メッセージ                                                                                                                                                                 |
+| - isSuccessful     | Boolean |    O     | 成否                                                                                                                                                                  |
+| messages           | List    |    X     | メッセージリスト                                                                                                                                                                |
+| - requestId        | String  |    O     | リクエスト ID                                                                                                                                                                  |
+| - recipientSeq     | Integer |    O     | 受信者シーケンス番号                                                                                                                                                             |
+| - requestDate      | String  |    O     | リクエスト日時                                                                                                                                                                  |
+| - createDate       | String  |    O     | 作成日時                                                                                                                                                                  |
+| - receiveDate      | String  |    X     | 受信日時                                                                                                                                                                  |
+| - resendStatus     | String  |    O     | 代替送信ステータスコード(RSC01, RSC02, RSC03, RSC04, RSC05)\<br\>([[下記の代替送信ステータス表](http://docs.toast.com/ko/Notification/KakaoTalk%20Bizmessage/ko/alimtalk-api-guide/#smslms)] 参照) |
+| - resendStatusName | String  |    O     | 代替送信ステータスコード名                                                                                                                                                           |
+| - resendResultCode | String  |    X     | 代替送信結果コード [SMS 結果コード](https://docs.toast.com/ko/Notification/SMS/ko/error-code/#api)                                                                                 |
+| - resendRequestId  | String  |    X     | 代替送信 SMS リクエスト ID                                                                                                                                                        |
+| - messageStatus    | String  |    O     | リクエストステータス(COMPLETED -\> 成功、FAILED -\> 失敗、CANCEL -\> 取消)                                                                                                                 |
+| - resultCode       | String  |    X     | 受信結果コード                                                                                                                                                               |
+| - resultCodeName   | String  |    X     | 受信結果コード名                                                                                                                                                              |
+
+[예시]
+
+```
+curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/message-results?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
+```
+
+<a id="query-the-number-of-message-result-updates"></a>
+
+### メッセージ結果アップデート件数照会
+
+<a id="request-7"></a>
+
+#### 요청
+
+[URL]
+
+```
+GET  /alimtalk/v2.3/appkeys/{appkey}/message-results/count
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 이름     | 	타입     | 	설명     |
+|--------|---------|---------|
+| appkey | 	String | 	固有のアプリキー |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 이름           | 	타입     | 	필수 | 	설명              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | コンソールで作成できます。 |
+
+[Query parameter]
+
+| 이름                  | 	타입      | 	필수 | 	설명                                 |
+|---------------------|----------|-----|-------------------------------------|
+| startUpdateDate     | 	String  | 	O  | 結果アップデート照会開始時間(yyyy-MM-dd HH:mm)  |
+| endUpdateDate       | 	String  | O   | 	結果アップデート照会終了時間(yyyy-MM-dd HH:mm) |
+| alimtalkMessageType | 	String  | X   | 	お知らせトークメッセージタイプ(NORMAL, AUTH)           |
+
+<a id="response-8"></a>
+
+#### 응답
+
+```
+{
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
+  },
+  "totalCount": Integer
+}
+```
+
+| 이름              | 타입      | Not Null | 설명     |
+|-----------------|---------|:--------:|--------|
+| header          | Object  |    O     | ヘッダー領域  |
+| - resultCode    | Integer |    O     | 結果コード  |
+| - resultMessage | String  |    O     | 結果メッセージ |
+| - isSuccessful  | Boolean |    O     | 成否  |
+| totalCount      | Integer |    O     | 総件数   |
+
+[예시]
+
+```
+curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/message-results/count?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
+```
+
+<a id="status-code-of-smslms-resending"></a>
+
+### SMS/LMS 代替送信ステータスコード
+
+| 이름    | 	설명                                  |
+|-------|--------------------------------------|
+| RSC01 | 	代替送信対象外                           |
+| RSC02 | 	代替送信対象(送信結果が失敗の場合、代替送信が進行されます。) |
+| RSC03 | 	代替送信中                             |
+| RSC04 | 	代替送信成功                            |
+| RSC05 | 	代替送信失敗                            |
+
+<a id="mass-delivery"></a>
+
+## 一括送信
+
+<a id="list-mass-delivery-requests"></a>
+
+### 一括送信リクエスト一覧照会
+
+<a id="request-8"></a>
+
+#### リクエスト
+
+[URL]
+
+```
+GET /alimtalk/v2.3/appkeys/{appKey}/mass-messages
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 名前     | 	タイプ     | 	説明     |
+|--------|---------|---------|
+| appKey | 	String | 	固有のアプリキー |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前           | 	タイプ     | 	説明       |
+|--------------|---------|-----------|
+| X-Secret-Key | 	String | 	固有のシークレットキー |
+
+[Query parameter]
+
+* requestId または startRequestDate + endRequestDate または startCreateDate + endCreateDate は必須です。
+
+| 名前               | 	タイプ               | 最大長 | 	必須 | 	説明       |
+|------------------|-------------------|-------|-----|-----------|
+| requestId        | String            | -     | O   | リクエスト ID     |
+| startRequestDate | String            | -     | O   | 送信日付開始  |
+| endRequestDate   | String            | -     | O   | 送信日付終了  |
+| startCreateDate  | 	String           | -     | 	O  | 	登録日付開始 |
+| endCreateDate    | 	String           | -     | 	O  | 	登録日付終了 |
+| pageNum          | optional, Integer | -     | X   | ページ番号    |
+| pageSize         | optional, Integer | 1000  | X   | 検索数      |
+
+<a id="curl"></a>
+
+#### cURL
+
+```
+curl -X GET \
+'https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appKey}/'"${APP_KEY}"'/mass-messages?requestId='"${REQUEST_ID}" \
+-H 'Content-Type: application/json;charset=UTF-8' \
+-H 'X-Secret-Key:{secretkey}'
+```
+
+<a id="response-9"></a>
+
+#### レスポンス
+
+```
+{
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
+  },
+  "body": {
+    "messages": [
+      {
+        "requestId": String,
+        "requestDate": String,
+        "plusFriendId": String,
+        "senderKey": String,
+        "templateCode": String,
+        "masterStatusCode": String,
+        "content": String,
+        "fileId": String,
+        "autoSendYn": String,
+        "statsId": String,
+        "createDate": String,
+        "createUser": String
+      }
+    ],
+    "totalCount": Integer
+  }
+}
+```
+
+| 名前                  | タイプ      | Not Null | 説明                                                                             |
+|---------------------|---------|:--------:|--------------------------------------------------------------------------------|
+| header              | Object  |    O     | ヘッダー領域                                                                          |
+| - resultCode        | Integer |    O     | 結果コード                                                                          |
+| - resultMessage     | String  |    O     | 結果メッセージ                                                                         |
+| - isSuccessful      | Boolean |    O     | 成否                                                                          |
+| body                | Object  |    X     | 本文領域                                                                          |
+| - messages          | Object  |    X     | メッセージリスト                                                                        |
+| -- requestId        | String  |    O     | リクエスト ID                                                                          |
+| -- requestDate      | String  |    O     | リクエスト日付                                                                          |
+| -- plusFriendId     | String  |    O     | プラスフレンド ID                                                                      |
+| -- senderKey        | String  |    O     | 発信キー（40文字）                                                                      |
+| -- masterStatusCode | String  |    O     | 一括送信ステータスコード（WAIT、READY、SENDREADY、SENDWAIT、SENDING、COMPLETE、CANCEL、FAIL） |
+| -- content          | String  |    X     | 内容                                                                             |
+| -- fileId           | String  |    X     | 添付ファイル ID                                                                       |
+| -- templateCode     | String  |    O     | テンプレートコード（最大 20 文字）                                                                 |
+| -- autoSendYn       | String  |    X     | 自動送信有無                                                                       |
+| -- statsId          | String  |    X     | 統計 ID                                                                          |
+| -- createDate       | String  |    O     | 作成日付                                                                          |
+| -- createUser       | String  |    X     | 作成ユーザー（コンソールから送信時にユーザー UUID で保存）                                                 |
+| - totalCount        | Integer |    X     | 総件数                                                                            |
+
+<a id="list-mass-delivery-recipients"></a>
+
+### 一括送信受信者リスト照会
+
+<a id="request-9"></a>
+
+#### リクエスト
+
+[URL]
+
+```
+GET /alimtalk/v2.3/appkeys/{appKey}/mass-messages/{requestId}/recipients
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 名前        | 	タイプ     | 	説明     |
+|-----------|---------|---------|
+| appKey    | 	String | 	固有のアプリキー |
+| requestId | 	String | 	リクエスト ID  |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前           | 	タイプ     | 	説明       |
+|--------------|---------|-----------|
+| X-Secret-Key | 	String | 	固有のシークレットキー |
+
+| 名前               | 	タイプ               | 最大長 | 	必須 | 	説明       |
+|------------------|-------------------|-------|-----|-----------|
+| requestId        | String            | -     | O   | リクエスト ID     |
+| startRequestDate | String            | -     | X   | 送信日付の開始  |
+| endRequestDate   | String            | -     | X   | 送信日付の終了  |
+| startCreateDate  | 	String           | -     | 	X  | 	登録日付の開始 |
+| endCreateDate    | 	String           | -     | 	X  | 	登録日付の終了 |
+| pageNum          | optional, Integer | -     | X   | ページ番号    |
+| pageSize         | optional, Integer | 1000  | X   | 検索件数      |
+
+<a id="curl-2"></a>
+
+#### cURL
+
+```
+curl -X GET \
+'https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appKey}/'"${APP_KEY}"'/mass-messages/recipients?requestId='"${REQUEST_ID}" \
+-H 'Content-Type: application/json;charset=UTF-8' \
+-H 'X-Secret-Key:{secretkey}'
+```
+
+<a id="response-10"></a>
+
+#### レスポンス
+
 ```
 {
     "header": {
@@ -1134,469 +1421,34 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 }
 ```
 
-| 値               | タイプ | 説明                                |
-| ---------------------- | ------- | ---------------------------------------- |
-| header                 | Object  | ヘッダ領域                             |
-| - resultCode           | Integer | 結果コード                             |
-| - resultMessage        | String  | 結果メッセージ                            |
-| - isSuccessful         | Boolean | 成否                              |
-| message                | Object  | メッセージ                               |
-| - requestId            | String  | リクエストID                                    |
-| - recipientSeq         | Integer | 受信者シーケンス番号                        |
-| - plusFriendId         | String  | プラスフレンドID                                 |
-| - senderKey            | String  | 発信キー                                   |
-| - templateCode         | String  | テンプレートコード                            |
-| - recipientNo          | String  | 受信番号                             |
-| - content              | String  | 本文                                |
-| - templateTitle        | String  | テンプレートハイライトタイトル              |
-| - templateSubtitle     | String  | テンプレートハイライトサブタイトル           |
-| - templateExtra        | String  | テンプレート付加情報                     |
-| - templateAd           | String  | テンプレート内の受信同意または簡単な広告文句   |
-| - requestDate          | String  | リクエスト日時                             |
-| - createDate           | String  | 登録日時                            |
-| - receiveDate          | String  | 受信日時                             |
-| - resendStatus         | String  | 再送信ステータスコード                         |
-| - resendStatusName     | String  | 再送信ステータスコード名                          |
-| - resendResultCode     | String  | 再送結果コード[SMS結果コード](https://docs.toast.com/ja/Notification/SMS/ja/error-code/#api) |
-| - resendRequestId      | String  | 再送SMSリクエストID                                                  |
-| - messageStatus        | String  | リクエストステータス(COMPLETED -> 成功、FAILED -> 失敗、CANCEL -> キャンセル) |
-| - resultCode           | String  | 受信結果コード                          |
-| - resultCodeName       | String  | 受信結果コード名                           |
-| - createUser           | String  | 登録者(コンソールから送信する場合、ユーザーUUIDとして保存)|
-| - buttons              | List    | ボタンリスト                             |
-| -- ordering            | Integer | ボタン順序                             |
-| -- type                | String  | ボタンタイプ(WL：Webリンク、AL：アプリリンク、DS：配送照会、BK：Botキーワード、MD：メッセージ伝達、BC：相談トーク転換、BT：Bot転換、AC：チャンネル追加、 TN:電話発信) |
-| -- name                | String  | ボタン名                             |
-| -- linkMo              | String  | モバイルWebリンク(WLタイプの場合は必須フィールド)                |
-| -- linkPc              | String  | PC Webリンク(WLタイプの場合は任意フィールド)                 |
-| -- schemeIos           | String  | iOSアプリリンク(ALタイプの場合は必須フィールド)                |
-| -- schemeAndroid       | String  | Androidアプリリンク(ALタイプの場合は必須フィールド)            |
-| -- chatExtra           | String  | BC(相談トークに切替) / BT(Botに切替)タイプボタンの時、伝達するメタ情報 |
-| -- chatEvent           | String  | BT(Botに切替)タイプボタンの時、接続するBotイベント名 |
-| -- target              | String  | Webリンクボタンの場合、 "target":"out"プロパティ追加時のアウトリンク<br>基本インアプリリンクで送信 |
-| - messageOption        | Object  |	メッセージオプション                                         |
-| -- price               | Integer |	message(ユーザーに伝達されるメッセージ)内に含まれた価格/金額/決済金額(モーメント広告に該当) |
-| -- currencyType        | String  |	message(ユーザーに伝達されるメッセージ)内に含まれた価格/金額/決済金額(モーメント広告に該当) |
-| - senderGroupingKey    | String  | 発信グルーピングキー                            |
-| - recipientGroupingKey | String  | 受信者グルーピングキー                           |
-
-<a id="message"></a>
-
-## メッセージ
-<a id="cancel-sending-messages"></a>
-
-### メッセージ送信取消
-
-<a id="request-5"></a>
-
-#### リクエスト
-
-[URL]
-
-```
-DELETE  /alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}
-Content-Type: application/json;charset=UTF-8
-```
-
-[Path parameter]
-
-| 値 | タイプ | 説明 |
-| --------- | ------ | ------ |
-| appkey    | String | 固有のアプリキー |
-| requestId | String | リクエストID  |
-
-[Header]
-```
-{
-  "X-Secret-Key": String
-}
-```
-| 値    | タイプ | 必須 | 説明                               |
-| ------------ | ------ | ---- | ---------------------------------------- |
-| X-Secret-Key | String | O    | コンソールで作成できます。 |
-
-[Query parameter]
-
-| 値    | タイプ | 必須 | 説明                               |
-| ------------ | ------ | ---- | ---------------------------------------- |
-| recipientSeq | String | X    | 受信者シーケンス番号<br>(入力しない場合、リクエストIDのすべての送信件をキャンセル) |
-
-* 一般/認証メッセージは同じAPIでキャンセルできます。
-
-<a id="response-6"></a>
-
-#### レスポンス
-```
-{
-  "header" : {
-      "resultCode" :  Integer,
-      "resultMessage" :  String,
-      "isSuccessful" :  boolean
-  }
-}
-```
-
-| 値       | タイプ | 説明 |
-| --------------- | ------- | ------ |
-| header          | Object  | ヘッダ領域 |
-| - resultCode    | Integer | 結果コード |
-| - resultMessage | String  | 結果メッセージ |
-| - isSuccessful  | Boolean | 成否 |
-
-[例]
-```
-curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
-```
-
-<a id="query-updates-of-message-result"></a>
-
-### メッセージ結果アップデートの照会
-
-<a id="request-6"></a>
-
-#### リクエスト
-
-[URL]
-
-```
-GET  /alimtalk/v2.3/appkeys/{appkey}/message-results
-Content-Type: application/json;charset=UTF-8
-```
-
-[Path parameter]
-
-| 値 | タイプ | 説明 |
-| ------ | ------ | ------ |
-| appkey | String | 固有のアプリキー |
-
-[Header]
-```
-{
-  "X-Secret-Key": String
-}
-```
-| 値    | タイプ | 必須 | 説明                               |
-| ------------ | ------ | ---- | ---------------------------------------- |
-| X-Secret-Key | String | O    | コンソールで作成できます。 |
-
-[Query parameter]
-
-| 値            | タイプ | 必須 | 説明                          |
-| ------------------- | ------- | ---- | ---------------------------------- |
-| startUpdateDate     | String  | O    | 結果アップデート照会開始時間(yyyy-MM-dd HH:mm) |
-| endUpdateDate       | String  | O    | 結果アップデート照会終了時間(yyyy-MM-dd HH:mm) |
-| alimtalkMessageType | String  | X    | お知らせトークメッセージタイプ(NORMAL、AUTH)           |
-| pageNum             | Integer | X    | ページ番号(基本：1)                      |
-| pageSize            | Integer | X    | 照会件数(基本：15、最大: 1000)          |
-
-<a id="response-7"></a>
-
-#### レスポンス
-```
-{
-  "header" : {
-      "resultCode" :  Integer,
-      "resultMessage" :  String,
-      "isSuccessful" :  boolean
-  },
-  "messages" : [
-    {
-      "requestId" :  String,
-      "recipientSeq" : Integer,
-      "requestDate" :  String,
-      "createDate" :  String,
-      "receiveDate" : String,
-      "resendStatus" :  String,
-      "resendStatusName" :  String,
-      "resendResultCode" :  String,
-      "resendRequestId" :  String,
-      "messageStatus" :  String,
-      "resultCode" :  String,
-      "resultCodeName" : String
-    }
-  ]
-}
-```
-
-| 値                   | タイプ | 説明                               |
-| --------------------------- | ------- | ---------------------------------------- |
-| header                      | Object  | ヘッダ領域                            |
-| - resultCode                | Integer | 結果コード                            |
-| - resultMessage             | String  | 結果メッセージ                           |
-| - isSuccessful              | Boolean | 成否                             |
-| messages                  | List    | メッセージリスト                           |
-| - requestId                | String  | リクエストID                                    |
-| - recipientSeq             | Integer | 受信者シーケンス番号                       |
-| - requestDate              | String  | リクエスト日時                            |
-| - createDate               | String  | 作成日時                            |
-| - receiveDate              | String  | 受信日時                            |
-| - resendStatus             | String  | 再送信ステータスコード                        |
-| - resendStatusName         | String  | 再送信ステータスコード名                        |
-| - resendResultCode         | String  | 再送結果コード[SMS結果コード](https://docs.toast.com/ja/Notification/SMS/ja/error-code/#api)                        |
-| - resendRequestId          | String  | 再送SMSリクエストID                        |
-| - messageStatus            | String  | リクエストステータス(COMPLETED -> 成功、FAILED -> 失敗、CANCEL -> キャンセル) |
-| - resultCode               | String  | 受信結果コード                         |
-| - resultCodeName           | String  | 受信結果コード名                         |
-
-[例]
-```
-curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/message-results?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
-```
-
-<a id="mass-delivery"></a>
-
-## 大量送信
-<a id="list-mass-delivery-requests"></a>
-
-### 大量送信リクエストリスト照会
-
-<a id="request-8"></a>
-
-#### リクエスト
-[URL]
-```
-GET /alimtalk/v2.3/appkeys/{appKey}/mass-messages
-Content-Type: application/json;charset=UTF-8
-```
-
-[Path parameter]
-
-|値|	タイプ|	説明|
-|---|---|---|
-|appKey|	String|	固有のアプリキー|
-
-[Header]
-
-```
-{
-  "X-Secret-Key": String
-}
-```
-
-|値|	タイプ|	説明|
-|---|---|---|
-|X-Secret-Key|	String|	固有のシークレットキー |
-
-[Query parameter]
-* requestIdまたはstartRequestDate + endRequestDateまたはstartCreateDate + endCreateDateは必須です。
-
-|値|	タイプ| 最大長さ |	必須|	説明|
-|---|---|---|---|---|
-| requestId | String | - | O | リクエストID |
-| startRequestDate | String | - | O | 送信日の開始 |
-| endRequestDate | String | - | O | 送信日の終了 |
-| startCreateDate |	String| - |	O |	登録日の開始 |
-| endCreateDate |	String| - |	O |	登録日の終了 |
-| pageNum | optional, Integer | - | X | ページ番号 |
-| pageSize | optional, Integer | 1000 | X | 検索数 |
-
-<a id="curl"></a>
-
-#### cURL
-```
-curl -X GET \
-https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appKey}/'"${APP_KEY}"'/mass-messages?requestId='"${REQUEST_ID}" \
--H 'Content-Type: application/json;charset=UTF-8' \
--H 'X-Secret-Key:{secretkey}'
-```
-
-<a id="response-9"></a>
-
-#### レスポンス
-```
-{
-  "header": {
-    "resultCode" :  Integer,
-    "resultMessage" :  String,
-    "isSuccessful" :  boolean
-  },
-  "body": {
-    "messages": [
-      {
-        "requestId": String,
-        "requestDate": String,
-        "plusFriendId": String,
-        "senderKey": String,
-        "templateCode": String,
-        "masterStatusCode": String,
-        "content": String,
-        "buttons": [
-          {
-            "ordering": 1,
-            "type": String,
-            "name": String,
-            "linkMo": String,
-            "linkPc": String,
-            "schemeIos": String,
-            "schemeAndroid": String,
-            "chatExtra": String,
-            "chatEvent": String,
-            "target": String
-          }
-        ],
-        "fileId": String,
-        "templateExtra": String,
-        "templateAd": String,
-        "templateTitle": String,
-        "templateSubtitle": String,
-        "autoSendYn": String,
-        "statsId": String,
-        "createDate": String,
-        "createUser": String
-      }
-    ],
-    "totalCount": Integer
-  }
-}
-```
-
-|値|	タイプ|	説明|
-|---|---|---|
-| header | Object |	ヘッダ領域 |
-| - resultCode |	Integer |	結果コード |
-| - resultMessage |	String | 結果メッセージ |
-| - isSuccessful |	Boolean | 成否 |
-| body | Object | 本文領域 |
-| - messages | Object | メッセージリスト |
-| -- requestId | String | リクエストID |
-| -- requestDate | String | リクエスト日 |
-| -- createDate | String | 作成日 |
-| -- createUser | String | 作成日 |
-| -- plusFriendId | String | プラスフレンドID |
-| -- senderKey | String| 発信キー(40文字) |
-| -- masterStatusCode | String | 大量送信ステータスコード(WAIT, READY, SENDREADY, SENDWAIT, SENDING, COMPLETE, CANCEL, FAIL) |
-| -- content | String | 内容 |
-| -- buttons | List | ボタンリスト |
-| --- ordering | String | ボタンの順序 |
-| --- type | String | ボタンの種類<br/> - WL：Webリンク<br/> - AL：アプリリンク<br/> - DS：配送照会<br/> - BK：Botキーワード<br/> - MD：メッセージ伝達<br/> - BC：相談トーク切り替え<br/> - BT：Bot切り替え<br/> - AC：チャンネル追加[広告追加/複合型のみ], TN:電話発信) |
-| --- name | String | ボタン名 |
-| --- linkMo | String | モバイルWebリンク(WLタイプの場合は必須フィールド) |
-| --- linkPc | String | PC Webリンク(WLタイプの場合は任意フィールド)|
-| --- schemeIos | String | IOSアプリリンク(ALタイプの場合は必須フィールド) |
-| --- schemeAndroid | String | Androidアプリリンク(ALタイプの場合は必須フィールド) |
-| --- chatExtra | String | BC：相談トークに切り替える時に伝達するメタ情報<br/> BT：Botに切り替える時に伝達するメタ情報 |
-| --- chatEvent | String | BT：Botに切り替える時に接続するBotイベント名 |
-| --- target|	String|	Webリンクボタンの場合、"target"："out"プロパティを追加時アウトリンク<br>基本アプリ内リンクで送信 |
-| -- fileId | String | 添付ファイルID |
-| -- templateCode |	String | テンプレートコード(最大20文字) |
-| -- templateExtra | String | テンプレート付加情報(テンプレートメッセージタイプが[付加情報型/複合型]の場合は必須) |
-| -- templateAd | String | テンプレート内の受信同意リクエストまたは簡単な広告文言 |
-| -- tempalteTitle| String | テンプレートタイトル(最大50文字、Android：2行、23文字以上省略処理、IOS：2行、27文字以上省略処理) |
-| -- templateSubtitle| String | テンプレート補助文言(最大50文字、Android：18文字以上省略処理、IOS：21文字以上省略処理) |
-| -- autoSendYn | String | 自動送信を行うかどうか |
-| -- statsId | String | 統計ID |
-| -- createDate | String | 作成日 |
-| -- createUser | String | 登録者(コンソールから送信時、ユーザーUUIDに保存) |
-| - totalCount | Integer | 総数
-
-
-<a id="list-mass-delivery-recipients"></a>
-
-### 大量送信大量送信受信者リスト照会
-
-<a id="request-9"></a>
-
-#### リクエスト
-[URL]
-```
-GET /alimtalk/v2.3/appkeys/{appKey}/mass-messages/{requestId}/recipients
-Content-Type: application/json;charset=UTF-8
-```
-
-[Path parameter]
-
-|値|	タイプ|	説明|
-|---|---|---|
-| appKey |	String |	固有のアプリキー |
-| requestId |	String |	リクエストID |
-
-[Header]
-
-```
-{
-  "X-Secret-Key": String
-}
-```
-
-|値|	タイプ|	説明|
-|---|---|---|
-| X-Secret-Key |	String|	固有のシークレットキー |
-
-
-|値|	タイプ| 最大長さ |	必須|	説明|
-|---|---|---|---|---|
-| requestId | String | - | O | リクエストID |
-| startRequestDate | String | - | X | 送信日の開始 |
-| endRequestDate | String | - | X | 送信日の終了 |
-| startCreateDate |	String| - |	X |	登録日の開始 |
-| endCreateDate |	String| - |	X |	登録日の終了 |
-| pageNum | optional, Integer | - | X | ページ番号 |
-| pageSize | optional, Integer | 1000 | X | 検索数 |
-
-<a id="curl-2"></a>
-
-#### cURL
-```
-curl -X GET \
-https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appKey}/'"${APP_KEY}"'/mass-messages/recipients?requestId='"${REQUEST_ID}" \
--H 'Content-Type: application/json;charset=UTF-8' \
--H 'X-Secret-Key:{secretkey}'
-```
-
-<a id="response-10"></a>
-
-#### レスポンス
-```
-{
-    "header": {
-      "resultCode" :  Integer,
-      "resultMessage" :  String,
-      "isSuccessful" :  boolean
-    },
-    "body": {
-        "recipients": [
-            {
-                "requestId": String,
-                "recipientSeq": Integer,
-                "recipientNo": String,
-                "requestDate": String,
-                "receiveDate": String,
-                "messageStatus": String,
-                "resultCode": String,
-                "resultCodeName": String
-            }
-        ],
-        "totalCount": Integer
-    }
-}
-```
-
-|値|	タイプ|	説明|
-|---|---|---|
-| header | Object |	ヘッダ領域 |
-| - resultCode |	Integer |	結果コード |
-| - resultMessage |	String | 結果メッセージ |
-| - isSuccessful |	Boolean | 成否 |
-| body | Object | 本文領域 |
-| - messages | Object | メッセージリスト |
-| -- requestId | String | リクエストID |
-| -- recipientSeq | String | 受信者シーケンス番号 |
-| -- recipientNo | String | 受信番号 |
-| -- requestDate | String | リクエスト日 |
-| -- receiveDate | String | 受信日 |
-| -- messageStatus | String | メッセージ状態 |
-| -- resultCode | String | 結果コード |
-| -- resultCodeName | String | 結果コード内容 |
-| - totalCount | Integer | 総数 |
+| 名前                | タイプ      | Not Null | 説明         |
+|-------------------|---------|:--------:|------------|
+| header            | Object  |    O     | ヘッダー領域      |
+| - resultCode      | Integer |    O     | 結果コード      |
+| - resultMessage   | String  |    O     | 結果メッセージ     |
+| - isSuccessful    | Boolean |    O     | 成否      |
+| body              | Object  |    X     | 本文領域      |
+| - messages        | Object  |    X     | メッセージリスト    |
+| -- requestId      | String  |    O     | リクエスト ID      |
+| -- recipientSeq   | String  |    O     | 受信者シーケンス番号 |
+| -- recipientNo    | String  |    X     | 受信番号      |
+| -- requestDate    | String  |    O     | リクエスト日付      |
+| -- receiveDate    | String  |    X     | 受信日付      |
+| -- messageStatus  | String  |    O     | メッセージステータス     |
+| -- resultCode     | String  |    X     | 結果コード      |
+| -- resultCodeName | String  |    X     | 結果コードの内容   |
+| - totalCount      | Integer |    X     | 総件数        |
 
 <a id="get-a-mass-delivery-recipient"></a>
 
-### 大量送信大量送信受信者照会
+### 一括送信受信者照会
 
 <a id="request-10"></a>
 
 #### リクエスト
+
 [URL]
+
 ```
 GET /alimtalk/v2.3/appkeys/{appKey}/mass-messages/{requestId}/recipients/{recipientSeq}
 Content-Type: application/json;charset=UTF-8
@@ -1604,11 +1456,11 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-|値|	タイプ|	説明|
-|---|---|---|
-| appKey |	String | 固有のアプリキー |
-| requestId |	String | リクエストID |
-| recipientSeq | String | 受信者の順序 |
+| 名前           | 	タイプ     | 	説明        |
+|--------------|---------|------------|
+| appKey       | 	String | 固有のアプリキー   |
+| requestId    | 	String | リクエスト ID   |
+| recipientSeq | String  | 受信者の順序     |
 
 [Header]
 
@@ -1618,27 +1470,27 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-|値|	タイプ|	説明|
-|---|---|---|
-|X-Secret-Key|	String|	固有のシークレットキー |
+| 名前           | 	タイプ     | 	説明          |
+|--------------|---------|--------------|
+| X-Secret-Key | 	String | 	固有のシークレットキー |
 
-
-|値|	タイプ| 最大長さ |	必須|	説明|
-|---|---|---|---|---|
-| requestId | String | - | O | リクエストID |
-| startRequestDate | String | - | X | 送信日の開始 |
-| endRequestDate | String | - | X | 送信日の終了 |
-| startCreateDate |	String| - |	X |	登録日の開始 |
-| endCreateDate |	String| - |	X |	登録日の終了 |
-| pageNum | optional, Integer | - | X | ページ番号 |
-| pageSize | optional, Integer | 1000 | X | 検索数 |
+| 名前               | 	タイプ               | 最大長 | 	必須 | 	説明        |
+|------------------|-------------------|-----|-----|------------|
+| requestId        | String            | -   | O   | リクエスト ID   |
+| startRequestDate | String            | -   | X   | 送信日付の開始    |
+| endRequestDate   | String            | -   | X   | 送信日付の終了    |
+| startCreateDate  | 	String           | -   | 	X  | 	登録日付の開始   |
+| endCreateDate    | 	String           | -   | 	X  | 	登録日付の終了   |
+| pageNum          | optional, Integer | -   | X   | ページ番号      |
+| pageSize         | optional, Integer | 1000 | X  | 検索件数       |
 
 <a id="curl-3"></a>
 
 #### cURL
+
 ```
 curl -X GET \
-https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appKey}/'"${APP_KEY}"'/mass-messages/recipients/1?requestId='"${REQUEST_ID}" \
+'https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appKey}/'"${APP_KEY}"'/mass-messages/{requestId}/recipients/1" \
 -H 'Content-Type: application/json;charset=UTF-8' \
 -H 'X-Secret-Key:{secretkey}'
 ```
@@ -1646,12 +1498,13 @@ https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appK
 <a id="response-11"></a>
 
 #### レスポンス
+
 ```
 {
     "header": {
-      "resultCode" :  Integer,
-      "resultMessage" :  String,
-      "isSuccessful" :  boolean
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
     },
     "body": {
         "requestId": String,
@@ -1665,6 +1518,28 @@ https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appK
         "templateSubtitle": String,
         "templateExtra": String,
         "templateAd": String,
+        "templateHeader": String,
+        "templateItem": {
+          "list": [{
+            "title": String,
+            "description": String
+          }],
+          "summary": {
+            "title": String,
+            "description": String
+          }
+        },
+        "templateItemHighlight": {
+          "title": String,
+          "description": String,
+          "imageUrl": String
+        },
+        "templateRepresentLink": {
+          "linkMo": String,
+          "linkPc": String,
+          "schemeIos": String,
+          "schemeAndroid": String,
+        },
         "requestDate": String,
         "receiveDate": String,
         "createDate": String,
@@ -1677,73 +1552,117 @@ https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appK
         "resultCodeName": String,
         "createUser": String,
         "buttons": [
-            {
-                "ordering": Integer,
-                "type": String,
-                "name": String,
-                "linkMo": String,
-                "linkPc": String,
-                "schemeIos": String,
-                "schemeAndroid": String,
-                "chatExtra": String,
-                "chatEvent": String
-                "target": String
-	      "pluginId": String,
-	      "telNumber": String                
-            }
+          {
+            "ordering": Integer,
+            "type": String,
+            "name": String,
+            "linkMo": String,
+            "linkPc": String,
+            "schemeIos": String,
+            "schemeAndroid": String,
+            "chatExtra": String,
+            "chatEvent": String,
+            "bizFormId": Integer,
+            "pluginId": String,
+            "relayId": String,
+            "oneClickId": String,
+            "productId": String,
+            "target": String,
+            "telNumber": String
+          }
         ],
-        "messageOption": {
-          "price": Integer,
-          "currencyType": String
-        }
+        "quickReplies": [
+          {
+            "ordering": Integer,
+            "type": String,
+            "name": String,
+            "linkMo": String,
+            "linkPc": String,
+            "schemeIos": String,
+            "schemeAndroid": String,
+            "chatExtra": String,
+            "chatEvent": String,
+            "bizFormId": Integer,
+            "target": String
+            }
+        ]
     }
 }
 ```
 
-|値|	タイプ|	説明|
-|---|---|---|
-| header | Object |	ヘッダ領域 |
-| - resultCode |	Integer |	結果コード |
-| - resultMessage |	String | 結果メッセージ |
-| - isSuccessful |	Boolean | 成否 |
-| body | Object | 本文領域 |
-| - requestId | String | リクエストID |
-| - recipientSeq | String | 受信者シーケンス番号 |
-| - plusFriendId | String | プラスフレンドID |
-| - senderKey | String | 送信者ID |
-| - templateCode |	String | テンプレートコード(最大20文字) |
-| - recipientNo | String | 受信番号 |
-| - content | String | 内容 |
-| - tempalteTitle| String | テンプレートタイトル(最大50文字、Android：2行、23文字以上省略処理、IOS：2行、27文字以上省略処理) |
-| - templateSubtitle| String | テンプレート補助文言(最大50文字、Android：18文字以上省略処理、IOS：21文字以上省略処理) |
-| - templateExtra | String | テンプレート付加情報(テンプレートメッセージタイプが[付加情報型/複合型]の場合は必須) |
-| - templateAd | String | テンプレート内の受信同意リクエストまたは簡単な広告文言 |
-| - requestDate | String | リクエスト日 |
-| - receiveDate | String | 受信日 |
-| - createDate | String | 作成日 |
-| - resendStatus | String | 代替送信ステータスコード(RSC01, RSC02, RSC03, RSC04, RSC05)<br>([[以下の代替送信ステータス表](http://docs.toast.com/ko/Notification/KakaoTalk%20Bizmessage/ko/alimtalk-api-guide/#smslms)]参考) |
-| - resendStatusName | String | 代替送信ステータス名 |
-| - resendResultCode | String | 代替送信結果コード[SMS結果コード](https://docs.toast.com/ko/Notification/SMS/ko/error-code/#api) |
-| - resendRequestId | String | 代替送信リクエストID |
-| - messageStatus | String | 大量受信者送信ステータスコード(READY, COMPLETED, FAILED, CANCEL) |
-| - resultCode | String | 結果ステータスコード |
-| - resultCodeName | String | 結果状態名 |
-| - createUser | String | 作成ユーザーID |
-| - buttons | List | ボタンリスト |
-| -- ordering | String | ボタンの順序 |
-| -- type | String | ボタンの種類<br/> - WL：Webリンク<br/> - AL：アプリリンク<br/> - DS：配送照会<br/> - BK：Botキーワード<br/> - MD：メッセージ配信<br/> - BC：相談トーク切り替え<br/> - BT：Bot切り替え<br/> - AC：チャンネル追加[広告追加/複合型のみ], TN:電話発信) |
-| -- name | String | ボタン名 |
-| -- linkMo | String | モバイルWebリンク(WLタイプの場合は必須フィールド) |
-| -- linkPc | String | PC Webリンク(WLタイプの場合は任意フィールド)|
-| -- schemeIos | String | IOSアプリリンク(ALタイプの場合は必須フィールド) |
-| -- schemeAndroid | String | Androidアプリリンク(ALタイプの場合は必須フィールド) |
-| -- chatExtra | String | BC：相談トークに切り替える時に伝達するメタ情報<br/> BT：Botに切り替える時に伝達するメタ情報 |
-| -- chatEvent | String | BT：Botに切り替える時に接続するBotイベント名 |
-| -- target|	String|	Webリンクボタンの場合、"target"："out"プロパティを追加時アウトリンク<br>基本アプリ内リンクで送信 |
-| - messageOption | Boolean | メッセージオプション |
-|-- price | Integer |	message(ユーザーに伝達されるメッセージ)内に含まれる価格/金額/決済金額(モーメント広告に該当) |
-|-- currencyType | String |	message(ユーザーに伝達されるメッセージ)内に含まれる価格/金額/決済金額の通貨単位KRW、USD、EURなどの国際通貨コードを使用(モーメント広告に該当) |
-
+| 名前                      | タイプ      | Not Null | 説明                                                                                                                                                                     |
+|-------------------------|---------|:--------:|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| header                  | Object  |    O     | ヘッダー領域                                                                                                                                                                  |
+| - resultCode            | Integer |    O     | 結果コード                                                                                                                                                                  |
+| - resultMessage         | String  |    O     | 結果メッセージ                                                                                                                                                                 |
+| - isSuccessful          | Boolean |    O     | 成否                                                                                                                                                                  |
+| body                    | Object  |    X     | 本文領域                                                                                                                                                                  |
+| - requestId             | String  |    O     | リクエスト ID                                                                                                                                                                  |
+| - recipientSeq          | String  |    O     | 受信者シーケンス番号                                                                                                                                                             |
+| - plusFriendId          | String  |    O     | プラスフレンド ID                                                                                                                                                              |
+| - senderKey             | String  |    O     | 送信者 ID                                                                                                                                                                 |
+| - templateCode          | String  |    O     | テンプレートコード（最大 20 文字）                                                                                                                                                         |
+| - recipientNo           | String  |    X     | 受信番号                                                                                                                                                                  |
+| - content               | String  |    X     | 内容                                                                                                                                                                     |
+| - tempalteTitle         | String  |    X     | テンプレートタイトル（最大 50 文字、Android: 2 行、23 文字以上は省略表示、iOS: 2 行、27 文字以上は省略表示）                                                                                                     |
+| - templateSubtitle      | String  |    X     | テンプレート補助文言（最大 50 文字、Android: 18 文字以上は省略表示、iOS: 21 文字以上は省略表示）                                                                                                          |
+| - templateExtra         | String  |    X     | テンプレート付加情報（テンプレートメッセージタイプが [付加情報型/複合型] の場合は必須）                                                                                                                             |
+| - templateAd            | String  |    X     | テンプレート内の受信同意リクエストまたは簡単な広告文言                                                                                                                                            |
+| - templateHeader        | String  |    X     | テンプレートヘッダー（最大 16 文字）                                                                                                                                                         |
+| - templateItem          | Object  |    X     | アイテム                                                                                                                                                                    |
+| -- list                 | List    |    X     | アイテムリスト（最小 2 個、最大 10 個）                                                                                                                                                 |
+| --- title               | String  |    X     | タイトル（最大 6 文字）                                                                                                                                                             |
+| --- description         | String  |    X     | 説明（最大 23 文字）                                                                                                                                                          |
+| -- summary              | Object  |    X     | アイテムサマリー情報                                                                                                                                                              |
+| --- title               | String  |    X     | タイトル（最大 6 文字）                                                                                                                                                             |
+| --- description         | String  |    X     | 説明（変数および通貨単位、数字、カンマ、ピリオドのみ使用可能、最大 14 文字）                                                                                                                          |
+| - templateItemHighlight | Object  |    X     | アイテムハイライト                                                                                                                                                              |
+| --- title               | String  |    X     | タイトル（最大 30 文字、サムネイル画像がある場合は 21 文字）                                                                                                                                        |
+| --- description         | String  |    X     | 説明（最大 19 文字、サムネイル画像がある場合は 13 文字）                                                                                                                                      |
+| --- imageUrl            | String  |    X     | サムネイル画像のアドレス                                                                                                                                                             |
+| - templateRepresentLink | Object  |    X     | 代表リンク                                                                                                                                                                  |
+| -- linkMo               | String  |    X     | モバイル Web リンク（最大 500 文字）                                                                                                                                                      |
+| -- linkPc               | String  |    X     | PC Web リンク（最大 500 文字）                                                                                                                                                       |
+| -- schemeIos            | String  |    X     | iOS アプリリンク（最大 500 文字）                                                                                                                                                      |
+| -- schemeAndroid        | String  |    X     | Android アプリリンク（最大 500 文字）                                                                                                                                                    |
+| - requestDate           | String  |    O     | リクエスト日時                                                                                                                                                                  |
+| - receiveDate           | String  |    X     | 受信日時                                                                                                                                                                  |
+| - createDate            | String  |    O     | 作成日時                                                                                                                                                                  |
+| - resendStatus          | String  |    O     | 代替送信ステータスコード（RSC01、RSC02、RSC03、RSC04、RSC05）\<br\>（[[下記の代替送信ステータス表](http://docs.toast.com/ko/Notification/KakaoTalk%20Bizmessage/ko/alimtalk-api-guide/#smslms)] 参照） |
+| - resendStatusName      | String  |    O     | 代替送信ステータス名                                                                                                                                                              |
+| - resendResultCode      | String  |    O     | 代替送信結果コード [SMS 結果コード](https://docs.toast.com/ko/Notification/SMS/ko/error-code/#api)                                                                                 |
+| - resendRequestId       | String  |    X     | 代替送信リクエスト ID                                                                                                                                                            |
+| - messageStatus         | String  |    O     | 一括受信者送信ステータスコード（READY、COMPLETED、FAILED、CANCEL）                                                                                                                      |
+| - resultCode            | String  |    X     | 結果ステータスコード                                                                                                                                                               |
+| - resultCodeName        | String  |    X     | 結果ステータス名                                                                                                                                                                 |
+| - createUser            | String  |    X     | 作成ユーザー（コンソールから送信した場合、ユーザーの UUID として保存）                                                                                                                                                         |
+| - buttons               | List    |    X     | ボタンリスト                                                                                                                                                                 |
+| -- ordering             | Integer |    X     | ボタンの順序                                                                                                                                                                  |
+| -- type                 | String  |    X     | ボタンタイプ（WL: ウェブリンク、AL: アプリリンク、DS: 配送照会、BK: ボットキーワード、MD: メッセージ転達、BC: 相談トーク転換、BT: ボット転換、AC: チャンネル追加、BF: ビジネスフォーム、P1: 画像セキュリティ送信プラグイン ID、P2: 個人情報利用プラグイン ID、P3: ワンクリック決済プラグイン ID、TN: 電話する） |
+| -- name                 | String  |    X     | ボタン名                                                                                                                                                                  |
+| -- linkMo               | String  |    X     | モバイルウェブリンク（WL タイプの場合、必須フィールド）                                                                                                                                              |
+| -- linkPc               | String  |    X     | PC ウェブリンク（WL タイプの場合、任意フィールド）                                                                                                                                               |
+| -- schemeIos            | String  |    X     | iOS アプリリンク（AL タイプの場合、必須フィールド）                                                                                                                                              |
+| -- schemeAndroid        | String  |    X     | Android アプリリンク（AL タイプの場合、必須フィールド）                                                                                                                                            |
+| -- chatExtra            | String  |    X     | BC（相談トーク転換）/ BT（ボット転換）タイプのボタン時、転達するメタ情報                                                                                                                                |
+| -- chatEvent            | String  |    X     | BT（ボット転換）タイプのボタン時、接続するボットイベント名                                                                                                                                           |
+| -- bizFormId            | Integer |    X     | ビジネスフォーム ID（BF タイプの場合、必須）                                                                                                                                                 |
+| -- pluginId             | String  |    X     | プラグイン ID（最大 24 文字）                                                                                                                                                        |
+| -- relayId              | String  |    X     | プラグイン実行時に X-Kakao-Plugin-Relay-Id ヘッダーを通じて受け取る値                                                                                                                        |
+| -- oneClickId           | String  |    X     | ワンクリック決済プラグインで使用する決済情報                                                                                                                                               |
+| -- productId            | String  |    X     | ワンクリック決済プラグインで使用する決済情報                                                                                                                                               |
+| -- target               | String  |    X     | ウェブリンクボタンの場合、"target":"out" 属性を追加するとアウトリンク\<br\>デフォルトはインアプリリンクで送信                                                                                                            |
+| -- telNumber           | 	String  | 	X  | TN（電話する）タイプのボタン時、転達する電話番号                                                                                                                                                    |
+| - quickReplies          | List    |    X     | クイックリプライリスト（最大 5 件）                                                                                                                                                        |
+| -- ordering             | Integer |    X     | クイックリプライの順序（クイックリプライがある場合、必須）                                                                                                                                                |
+| -- type                 | String  |    X     | クイックリプライタイプ（WL: ウェブリンク、AL: アプリリンク、BK: ボットキーワード、BC: 相談トーク転換、BT: ボット転換、BF: ビジネスフォーム）                                                                                                |
+| -- name                 | String  |    X     | クイックリプライ名（クイックリプライがある場合、必須、最大 14 文字）                                                                                                                                        |
+| -- linkMo               | String  |    X     | モバイルウェブリンク（WL タイプの場合、必須フィールド、最大 500 文字）                                                                                                                                     |
+| -- linkPc               | String  |    X     | PC ウェブリンク（WL タイプの場合、任意フィールド、最大 500 文字）                                                                                                                                      |
+| -- schemeIos            | String  |    X     | iOS アプリリンク（AL タイプの場合、必須フィールド、最大 500 文字）                                                                                                                                     |
+| -- schemeAndroid        | String  |    X     | Android アプリリンク（AL タイプの場合、必須フィールド、最大 500 文字）                                                                                                                                   |
+| -- pluginId             | String  |    X     | プラグイン ID（最大 24 文字）                                                                                                                                                        |
+| -- target               | String  |    X     | ウェブリンクタイプの場合、"target":"out" 属性を追加するとアウトリンク\<br\>デフォルトはインアプリリンクで送信                                                                                                            |
 
 <a id="templates"></a>
 
@@ -1752,9 +1671,11 @@ https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appK
 <a id="list-template-categories"></a>
 
 ### テンプレートカテゴリー照会
+
 <a id="request-11"></a>
 
 #### リクエスト
+
 [URL]
 
 ```
@@ -1764,30 +1685,33 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 値    | タイプ | 説明 |
-| ------------ | ------ | -------- |
-| appkey       | String | 固有のアプリキー |
+| 名前     | 	タイプ     | 	説明     |
+|--------|---------|---------|
+| appkey | 	String | 	固有のアプリキー |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| 値    | タイプ | 必須 | 説明                               |
-|---|---|---|---|
-| X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+| 名前           | 	タイプ     | 	必須 | 	説明              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | コンソールで作成できます。 |
 
 <a id="response-12"></a>
 
 #### レスポンス
+
 ```
 
 {
-  "header" : {
-      "resultCode" :  Integer,
-      "resultMessage" :  String,
-      "isSuccessful" :  boolean
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
   },
   "categories": [
     {
@@ -1806,27 +1730,29 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 値       | タイプ | 説明 |
-| --------------- | ------- | ------ |
-| header          | Object  | ヘッダ領域 |
-| - resultCode    | Integer | 結果コード |
-| - resultMessage | String  | 結果メッセージ |
-| - isSuccessful  | Boolean | 成否 |
-|categories|	List|	カテゴリー一覧 |
-|- name | String | カテゴリー名 |
-|- subCategories | List |	サブカテゴリーのリスト |
-|-- code | String | カテゴリーコード(テンプレートの登録/変更する際、使用) |
-|-- name | String |	カテゴリー名 |
-|-- groupName | String |	カテゴリーグループ名 |
-|-- inclusion | String |	カテゴリー対象テンプレートの説明 |
-|-- exclusion| String| カテゴリの除外対象のテンプレートの説明 |
+| 名前              | タイプ      | Not Null | 説明                       |
+|-----------------|---------|:--------:|--------------------------|
+| header          | Object  |    O     | ヘッダー領域                    |
+| - resultCode    | Integer |    O     | 結果コード                    |
+| - resultMessage | String  |    O     | 結果メッセージ                   |
+| - isSuccessful  | Boolean |    O     | 成否                    |
+| categories      | List    |    X     | カテゴリーリスト                 |
+| - name          | String  |    X     | カテゴリー名                  |
+| - subCategories | List    |    X     | サブカテゴリーリスト              |
+| -- code         | String  |    X     | カテゴリーコード（テンプレート登録/修正時に使用） |
+| -- name         | String  |    X     | カテゴリー名                  |
+| -- groupName    | String  |    X     | カテゴリーグループ名                 |
+| -- inclusion    | String  |    X     | カテゴリー適用対象テンプレートの説明        |
+| -- exclusion    | String  |    X     | カテゴリー除外対象テンプレートの説明        |
 
 <a id="register-templates"></a>
 
-### テンプレートの登録
+### テンプレート登録
+
 <a id="request-12"></a>
 
 #### リクエスト
+
 [URL]
 
 ```
@@ -1836,100 +1762,198 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 値    | タイプ | 説明 |
-| ------------ | ------ | -------- |
-| appkey       | String | 固有のアプリキー |
-| senderKey | String | 発信キー |
+| 이름        | 	타입     | 	설명     |
+|-----------|---------|---------|
+| appkey    | 	String | 	固有のアプリキー |
+| senderKey | 	String | 	発信キー   |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| 値    | タイプ | 必須 | 説明                               |
-| ------------ | ------ | ---- | ---------------------------------------- |
-| X-Secret-Key | String | O    | コンソールで作成できます。 |
 
-[Request body]
+| 이름           | 	타입     | 	필수 | 	설명              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | コンソールで作成できます。 |
+
+[Request Body]
 
 ```
 {
-  "templateCode" : String,
-  "templateName" : String,
-  "templateContent" : String,
+  "templateCode": String,
+  "templateName": String,
+  "templateContent": String,
   "templateMessageType": String,
-  "templateEmphasizeType" : String,
+  "templateEmphasizeType": String,
   "templateExtra": String,
-  "templateTitle" : String,
-  "templateSubtitle" : String,
-  "templateImageName" : String,
-  "templateImageUrl" : String,
+  "templateTitle": String,
+  "templateSubtitle": String,
+  "templateHeader": String,
+  "templateItem": {
+    "list": [{
+      "title": String,
+      "description": String
+    }],
+    "summary": {
+      "title": String,
+      "description": String
+    }
+  },
+  "templateItemHighlight": {
+    "title": String,
+    "description": String,
+    "imageUrl": String
+  },
+  "templateRepresentLink": {
+    "linkMo": String,
+    "linkPc": String,
+    "schemeIos": String,
+    "schemeAndroid": String,
+  },
+  "templateImageName": String,
+  "templateImageUrl": String,
   "securityFlag": Boolean,
   "categoryCode": String,
-  "buttons" : [
+  "buttons": [
     {
-      "ordering" : Integer,
-      "type" : String,
-      "name" : String,
-      "linkMo" : String,
-      "linkPc" : String,
-      "schemeIos" : String,
-      "schemeAndroid" : String
+      "ordering": Integer,
+      "type": String,
+      "name": String,
+      "linkMo": String,
+      "linkPc": String,
+      "schemeIos": String,
+      "schemeAndroid": String
+      "bizFormId": Integer,
+      "pluginId": String,
+      "telNumber": String
+    }
+  ],
+  "quickReplies": [
+    {
+      "ordering": Integer,
+      "type": String,
+      "name": String,
+      "linkMo": String,
+      "linkPc": String,
+      "schemeIos": String,
+      "schemeAndroid": String
+      "bizFormId": Integer
     }
   ]
 }
 ```
 
-| 値       | タイプ | 必須 | 説明                               |
-| --------------- | ------- | ---- | ---------------------------------------- |
-| templateCode    | String  | O    | テンプレートコード(最大20文字)                           |
-| templateName    | String  | O    | テンプレート名(最大150文字)                             |
-| templateContent | String  | O    | テンプレート本文(最大1300文字)                         |
-| templateMessageType| String | X  | テンプレートメッセージタイプ(BA:基本型、EX:付加情報型、AD:広告追加型、MI:複合型)<br>EX：templateExtraフィールド必須<br>MI：templateExtraフィールド必須」 |
-|templateEmphasizeType| String| X  | テンプレートハイライトタイプ（NONE：基本、TEXT：ハイライト、ITEM_LIST:アイテムリスト型, default：NONE）<br>TEXT：templateTitle、templateSubtitleフィールド必須<br>ITEM_LIST: 画像、ヘッダ、アイテムハイライトアイテムリストのうち1つ以上必須 |
-| templateExtra     | String  | X  | テンプレート付加情報 |
-|tempalteTitle      | String  | X  | テンプレートのタイトル(最大50字、Android:2行、23字以上のコマ処理、iOS:2行、27字以上のコマ処理) |
-|templateSubtitle   | String  | X  | テンプレートの補助フレーズ(最大50文字、Android:18字以上のコマを省く、iOS:21字以上のコマを省く) |
-|templateImageName  | String  |	X  | 画像名（アップロードされたファイル名） |
-|templateImageUrl   | String  |	X  | 画像のURL |
-|securityFlag| Boolean | X| セキュリティテンプレートかどうか<br>OTPなどのセキュリティメッセージの場合、設定<br>発信当時のメインデバイスを除くすべてのデバイスにメッセージテキストミノチュル(default: false) |
-|categoryCode| String | X | テンプレートのカテゴリコード(テンプレートカテゴリー照会API参考, default: 999999)<br>カテゴリーを入力し、テンプレートを優先審査 |
-| buttons         | List    | X    | ボタンリスト(最大5個)                             |
-| -ordering       | Integer | X    | ボタン順序(1～5)                               |
-| -type           | String  | X    | ボタンタイプ(WL：Webリンク、AL：アプリリンク、DS：配送照会、BK：Botキーワード、MD：メッセージ伝達、BC：相談トーク転換、BT：Bot転換、AC：チャンネル追加) |[広告追加/複合型のみ]) |
-| -name           | String  | X    | ボタン名(ボタンがある場合は必須、最大14文字)              |
-| -linkMo         | String  | X    | モバイルWebリンク(WLタイプの場合は必須フィールド、最大500文字)       |
-| -linkPc         | String  | X    | PC Webリンク(WLタイプの場合は任意フィールド、最大500文字)        |
-| -schemeIos      | String  | X    | iOSアプリリンク(ALタイプの場合は必須フィールド、最大500文字)       |
-| -schemeAndroid  | String  | X    | Androidアプリリンク(ALタイプの場合は必須フィールド、最大500文字)   |
+| 名前                    | 	タイプ      | 	必須 | 	説明                                                                                                                                                                                                                                             |
+|-----------------------|----------|-----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| templateCode          | 	String  | 	O  | テンプレートコード（最大 20 文字）                                                                                                                                                                                                                                  |
+| templateName          | 	String  | 	O  | テンプレート名（最大 150 文字）                                                                                                                                                                                                                                   |
+| templateContent       | 	String  | 	O  | テンプレート本文（最大 1300 文字）                                                                                                                                                                                                                                |
+| templateMessageType   | String   | X   | テンプレートメッセージタイプ（BA: 基本型、EX: 付加情報型、AD: チャンネル追加型、MI: 複合型、default: BA）                                                                                                                                                                               |
+| templateEmphasizeType | String   | X   | テンプレート強調表示タイプ（NONE: 基本、TEXT: 強調表示、IMAGE: 画像型、ITEM_LIST: アイテムリストタイプ、default: NONE）<br>- TEXT: templateTitle、templateSubtitle フィールド必須<br>- IMAGE: templateImageName、templateImageUrl フィールド必須<br>ITEM_LIST: 画像、ヘッダー、アイテムハイライト、アイテムリストのうち 1 つ以上必須 |
+| templateExtra         | String   | X   | テンプレート付加情報（テンプレートメッセージタイプが［付加情報型/複合型］の場合は必須）                                                                                                                                                                                                      |
+| tempalteTitle         | String   | X   | テンプレートタイトル（最大 50 文字、Android: 2 行、23 文字以上は末尾省略、iOS: 2 行、27 文字以上は末尾省略）                                                                                                                                                                              |
+| templateSubtitle      | String   | X   | テンプレートサブ文言（最大 50 文字、Android: 18 文字以上は末尾省略、iOS: 21 文字以上は末尾省略）                                                                                                                                                                                   |
+| templateHeader        | String   | X   | テンプレートヘッダー（最大 16 文字）                                                                                                                                                                                                                                  |
+| templateItem          | Object   | X   | アイテム                                                                                                                                                                                                                                             |
+| - list                | List     | X   | アイテムリスト（最小 2 個、最大 10 個）                                                                                                                                                                                                                          |
+| -- title              | String   | X   | タイトル（最大 6 文字）                                                                                                                                                                                                                                      |
+| -- description        | String   | X   | 説明（最大 23 文字）                                                                                                                                                                                                                                   |
+| - summary             | Object   | X   | アイテムサマリー情報                                                                                                                                                                                                                                       |
+| -- title              | String   | X   | タイトル（最大 6 文字）                                                                                                                                                                                                                                      |
+| -- description        | String   | X   | 説明（変数および通貨単位、数字、カンマ、ピリオドのみ使用可能、最大 14 文字）                                                                                                                                                                                                   |
+| templateItemHighlight | Object   | X   | アイテムハイライト                                                                                                                                                                                                                                       |
+| - title               | String   | X   | タイトル（最大 30 文字、サムネイル画像がある場合は 21 文字）                                                                                                                                                                                                                 |
+| - description         | String   | X   | 説明（最大 19 文字、サムネイル画像がある場合は 13 文字）                                                                                                                                                                                                               |
+| - imageUrl            | String   | X   | サムネイル画像 URL                                                                                                                                                                                                                                      |
+| templateRepresentLink | Object   | X   | 代表リンク                                                                                                                                                                                                                                           |
+| - linkMo              | String   | 	X  | 	モバイル Web リンク（最大 500 文字）                                                                                                                                                                                                                              |
+| - linkPc              | String   | 	X  | PC Web リンク（最大 500 文字）                                                                                                                                                                                                                                |
+| - schemeIos           | String   | X   | 	iOS アプリリンク（最大 500 文字）                                                                                                                                                                                                                              |
+| - schemeAndroid       | String   | X   | 	Android アプリリンク（最大 500 文字）                                                                                                                                                                                                                            |
+| templateImageName     | String   | 	X  | 画像名（アップロードしたファイル名）                                                                                                                                                                                                                                  |
+| templateImageUrl      | String   | 	X  | 画像 URL                                                                                                                                                                                                                                         |
+| securityFlag          | Boolean  | X   | セキュリティテンプレートかどうか<br>OTP などのセキュリティメッセージの場合に設定<br>送信時のメインデバイスを除くすべてのデバイスにメッセージテキストを非表示（default: false）                                                                                                                                                    |
+| categoryCode          | String   | X   | テンプレートカテゴリコード（テンプレートカテゴリ照会 API 参照、default: 999999）<br>カテゴリがその他の場合、最低優先順位で審査                                                                                                                                                                   |
+| buttons               | 	List    | 	X  | ボタンリスト（最大 5 個）                                                                                                                                                                                                                                   |
+| - ordering            | 	Integer | 	X  | ボタン順序（1〜5）                                                                                                                                                                                                                                      |
+| - type                | String   | 	X  | 	ボタンタイプ（WL: Web リンク、AL: アプリリンク、DS: 配送照会、BK: ボットキーワード、MD: メッセージ転送、BC: 相談トーク転換、BT: ボット転換、AC: チャンネル追加、BF: ビジネスフォーム、P1: 画像セキュリティ送信プラグイン ID、P2: 個人情報利用プラグイン ID、P3: ワンクリック決済プラグイン ID、TN: 電話をかける）                                                                      |
+| - name                | String   | 	X  | 	ボタン名（ボタンがある場合は必須、最大 14 文字）                                                                                                                                                                                                                    |
+| - linkMo              | String   | 	X  | 	モバイル Web リンク (WL タイプの場合は必須フィールド、最大 500 文字)                                                                                                                                                                                                             |
+| - linkPc              | String   | 	X  | PC Web リンク (WL タイプの場合は選択フィールド、最大 500 文字)                                                                                                                                                                                                               |
+| - schemeIos           | String   | X   | 	iOS アプリリンク (AL タイプの場合は必須フィールド、最大 500 文字)                                                                                                                                                                                                             |
+| - schemeAndroid       | String   | X   | 	Android アプリリンク (AL タイプの場合は必須フィールド、最大 500 文字)                                                                                                                                                                                                           |
+| - bizFormId           | 	Integer | 	X  | 	ビジネスフォーム ID (BF タイプの場合は必須)                                                                                                                                                                                                                         |
+| - pluginId            | 	String  | 	X  | 	プラグイン ID (最大 24 文字)                                                                                                                                                                                                                                |
+| -- telNumber           | 	String  | 	X  | TN (電話をかける) タイプのボタンの場合、転送する電話番号                                                                                    |
+| quickReplies          | 	List    | 	X  | クイックリプライリスト (最大 5 個)                                                                                                                                                                                                                                 |
+| - ordering            | 	Integer | 	X  | 	クイックリプライの順序 (クイックリプライがある場合は必須)                                                                                                                                                                                                                        |
+| - type                | String   | 	X  | 	クイックリプライタイプ (WL: Web リンク、AL: アプリリンク、BK: ボットキーワード、BC: 相談トーク切替、BT: ボット切替、BF: ビジネスフォーム)                                                                                                                                                                        |
+| - name                | String   | 	X  | 	クイックリプライ名 (クイックリプライがある場合は必須、最大 14 文字)                                                                                                                                                                                                                |
+| - linkMo              | String   | 	X  | 	モバイル Web リンク (WL タイプの場合は必須フィールド、最大 500 文字)                                                                                                                                                                                                             |
+| - linkPc              | String   | 	X  | PC Web リンク (WL タイプの場合は選択フィールド、最大 500 文字)                                                                                                                                                                                                               |
+| - schemeIos           | String   | X   | 	iOS アプリリンク (AL タイプの場合は必須フィールド、最大 500 文字)                                                                                                                                                                                                             |
+| - schemeAndroid       | String   | X   | 	Android アプリリンク (AL タイプの場合は必須フィールド、最大 500 文字)                                                                                                                                                                                                           |
+| - bizFormId           | 	Integer | 	X  | 	ビジネスフォーム ID (BF タイプの場合は必須)                                                                                                                                                                                                                         |
+
+* チャンネル追加型(AD)または複合型(MI)メッセージタイプのテンプレート登録時、templateAd の値が固定されます。
+* チャンネル追加型(AD)または複合型(MI)メッセージタイプのテンプレート登録時、チャンネル追加(AC)ボタンが最初の順序に配置される必要があります。
+* チャンネル追加(AC)ボタンのボタン名は「チャンネル追加」で固定して登録する必要があります。
+
+フィールドごとの置換変数(`#{変数}`)の使用可否については、以下を参照してください。
+
+| 区分 | フィールド | 置換可否 |
+|------|------|---------|
+| 基本 | templateContent | O |
+| 基本 | templateTitle | O |
+| 基本 | templateSubtitle | X |
+| 基本 | templateHeader | O |
+| 基本 | templateExtra | X |
+| 基本 | templateAd | X |
+| ボタン | name | X |
+| ボタン | linkMo, linkPc, schemeIos, schemeAndroid | O |
+| クイックリプライ | name | X |
+| クイックリプライ | linkMo, linkPc, schemeIos, schemeAndroid | O |
+| テンプレートアイテム | title | X |
+| テンプレートアイテム | description | O |
+| テンプレートアイテム summary | title | X |
+| テンプレートアイテム summary | description | O |
+| テンプレートアイテムハイライト | title | O |
+| テンプレートアイテムハイライト | description | O |
+| テンプレートアイテムハイライト | imageUrl | X |
+| 代表リンク | linkMo, linkPc, schemeIos, schemeAndroid | O |
 
 <a id="response-13"></a>
 
-#### レスポンス
+#### 応答
+
 ```
 {
-  "header" : {
-    "resultCode" :  Integer,
-    "resultMessage" :  String,
-    "isSuccessful" :  boolean
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
   }
 }
 ```
 
-| 値       | タイプ | 説明 |
-| --------------- | ------- | ------ |
-| header          | Object  | ヘッダ領域 |
-| - resultCode    | Integer | 結果コード |
-| - resultMessage | String  | 結果メッセージ |
-| - isSuccessful  | Boolean | 成否 |
+| 名前              | タイプ      | Not Null | 説明     |
+|-----------------|---------|:--------:|--------|
+| header          | Object  |    O     | ヘッダー領域  |
+| - resultCode    | Integer |    O     | 結果コード  |
+| - resultMessage | String  |    O     | 結果メッセージ |
+| - isSuccessful  | Boolean |    O     | 成否  |
 
 <a id="modify-templates"></a>
 
-### テンプレートの修正
+### テンプレート修正
+
 <a id="request-13"></a>
 
 #### リクエスト
+
 [URL]
 
 ```
@@ -1939,99 +1963,174 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 値    | タイプ | 説明 |
-| ------------ | ------ | -------- |
-| appkey       | String | 固有のアプリキー |
-| senderKey | String | 発信キー |
-| templateCode | String | テンプレートコード |
+| 名前           | 	タイプ     | 	説明     |
+|--------------|---------|---------|
+| appkey       | 	String | 	固有のアプリキー |
+| senderKey    | 	String | 	発信キー   |
+| templateCode | 	String | 	テンプレートコード |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| 値    | タイプ | 必須 | 説明                               |
-| ------------ | ------ | ---- | ---------------------------------------- |
-| X-Secret-Key | String | O    | コンソールで作成できます。 |
 
-[Request body]
+| 名前           | 	タイプ     | 	必須 | 	説明              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | コンソールで作成できます。 |
+
+[Request Body]
 
 ```
 {
-  "templateName" : String,
-  "templateContent" : String,
+  "templateName": String,
+  "templateContent": String,
   "templateMessageType": String,
-  "templateEmphasizeType" : String,
+  "templateEmphasizeType": String,
   "templateExtra": String,
-  "templateTitle" : String,
-  "templateSubtitle" : String,
-  "templateImageName" : String,
-  "templateImageUrl" : String,
+  "templateTitle": String,
+  "templateSubtitle": String,
+  "templateHeader": String,
+  "templateItem": {
+    "list": [{
+      "title": String,
+      "description": String
+    }],
+    "summary": {
+      "title": String,
+      "description": String
+    }
+  },
+  "templateItemHighlight": {
+    "title": String,
+    "description": String,
+    "imageUrl": String
+  },
+  "templateRepresentLink": {
+    "linkMo": String,
+    "linkPc": String,
+    "schemeIos": String,
+    "schemeAndroid": String,
+  },
+  "templateImageName": String,
+  "templateImageUrl": String,
   "securityFlag": Boolean,
   "categoryCode": String,
-  "buttons" : [
+  "buttons": [
     {
-      "ordering" : Integer,
-      "type" : String,
-      "name" : String,
-      "linkMo" : String,
-      "linkPc" : String,
-      "schemeIos" : String,
-      "schemeAndroid" : String
+      "ordering": Integer,
+      "type": String,
+      "name": String,
+      "linkMo": String,
+      "linkPc": String,
+      "schemeIos": String,
+      "schemeAndroid": String
+      "bizFormId": Integer,
+      "pluginId": String,
+      "telNumber": String
+    }
+  ],
+  "quickReplies": [
+    {
+      "ordering": Integer,
+      "type": String,
+      "name": String,
+      "linkMo": String,
+      "linkPc": String,
+      "schemeIos": String,
+      "schemeAndroid": String
+      "bizFormId": Integer
     }
   ]
 }
 ```
 
-| 値       | タイプ | 必須 | 説明                               |
-| --------------- | ------- | ---- | ---------------------------------------- |
-| templateName    | String  | O    | テンプレート名(最大150文字)                             |
-| templateContent | String  | O    | テンプレート本文(最大1300文字)                         |
-| templateMessageType| String | X  | テンプレートメッセージタイプ(BA:基本型、EX:付加情報型、AD:広告追加型、MI:複合型)<br>EX：templateExtraフィールド必須<br>MI：templateExtraフィールド必須」 |
-| templateEmphasizeType| String| X  | テンプレートハイライトタイプ（NONE：基本、TEXT：ハイライト、default：NONE）<br>TEXT：templateTitle、templateSubtitleフィールド必須 |
-| templateExtra   | String  | X    |テンプレート付加情報 |
-| tempalteTitle| String | X| テンプレートのタイトル(最大50字、Android:2行、23字以上のコマ処理、iOS:2行、27字以上のコマ処理) |
-| templateSubtitle| String | X| テンプレートの補助フレーズ(最大50文字、Android:18字以上のコマを省く、iOS:21字以上のコマを省く) |
-| templateImageName  | String  |	X  | 画像名（アップロードされたファイル名） |
-| templateImageUrl   | String  |	X  | 画像のURL |
-|securityFlag| Boolean | X| セキュリティテンプレートかどうか<br>OTPなどのセキュリティメッセージの場合、設定<br>発信当時のメインデバイスを除くすべてのデバイスにメッセージテキストミノチュル(default: false) |
-|categoryCode| String | X | テンプレートのカテゴリコード(テンプレートカテゴリー照会API参考, default: 999999)<br>カテゴリーを入力し、テンプレートを優先審査 |
-| buttons         | List    | X    | ボタンリスト(最大5個)                             |
-| -ordering       | Integer | X    | ボタン順序(1～5)                               |
-| -type           | String  | X    | ボタンタイプ(WL：Webリンク、AL：アプリリンク、DS：配送照会、BK：Botキーワード、MD：メッセージ伝達、BC：相談トーク転換、BT：Bot転換、AC：チャンネル追加) |[広告追加/複合型のみ]) |
-| -name           | String  | X    | ボタン名(ボタンがある場合は必須、最大14文字)              |
-| -linkMo         | String  | X    | モバイルWebリンク(WLタイプの場合は必須フィールド、最大500文字)       |
-| -linkPc         | String  | X    | PC Webリンク(WLタイプの場合は任意フィールド、最大500文字)        |
-| -schemeIos      | String  | X    | iOSアプリリンク(ALタイプの場合は必須フィールド、最大500文字)       |
-| -schemeAndroid  | String  | X    | Androidアプリリンク(ALタイプの場合は必須フィールド、最大500文字)   |
+| 名前                    | 	タイプ      | 	必須 | 	説明                                                                                                                                                                        |
+|-----------------------|----------|-----|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| templateName          | 	String  | 	O  | テンプレート名(最大 150 文字)                                                                                                                                                              |
+| templateContent       | 	String  | 	O  | テンプレート本文(最大 1300 文字)                                                                                                                                                           |
+| templateMessageType   | String   | X   | テンプレートメッセージタイプ(BA: 基本型、EX: 付加情報型、AD: チャンネル追加型、MI: 複合型)                                                                                                                       |
+| templateEmphasizeType | String   | X   | テンプレート強調表示タイプ(NONE: 基本、TEXT: 強調表示、IMAGE: 画像型、default: NONE)<br>- TEXT: templateTitle、templateSubtitle フィールド必須<br>- IMAGE: templateImageName、templateImageUrl フィールド必須     |
+| templateExtra         | String   | X   | テンプレート付加情報(テンプレートメッセージタイプが[付加情報型/複合型]の場合は必須)                                                                                                                                 |
+| tempalteTitle         | String   | X   | テンプレートタイトル(最大 50 文字、Android: 2 行、23 文字以上は省略表示、iOS: 2 行、27 文字以上は省略表示)                                                                                                         |
+| templateSubtitle      | String   | X   | テンプレート補助文言(最大 50 文字、Android: 18 文字以上は省略表示、iOS: 21 文字以上は省略表示)                                                                                                              |
+| templateHeader        | String   | X   | テンプレートヘッダー(最大 16 文字)                                                                                                                                                             |
+| templateItem          | Object   | X   | アイテム                                                                                                                                                                        |
+| - list                | List     | X   | アイテムリスト(最小 2 個、最大 10 個)                                                                                                                                                     |
+| -- title              | String   | X   | タイトル(最大 6 文字)                                                                                                                                                                 |
+| -- description        | String   | X   | 説明(最大 23 文字)                                                                                                                                                              |
+| - summary             | Object   | X   | アイテムサマリー情報                                                                                                                                                                  |
+| -- title              | String   | X   | タイトル(最大 6 文字)                                                                                                                                                                 |
+| -- description        | String   | X   | 説明(変数および通貨単位、数字、カンマ、ピリオドのみ使用可能、最大 14 文字)                                                                                                                              |
+| templateItemHighlight | Object   | X   | アイテムハイライト                                                                                                                                                                  |
+| - title               | String   | X   | タイトル(最大 30 文字、サムネイル画像がある場合は 21 文字)                                                                                                                                            |
+| - description         | String   | X   | 説明(最大 19 文字、サムネイル画像がある場合は 13 文字)                                                                                                                                          |
+| - imageUrl            | String   | X   | サムネイル画像 URL                                                                                                                                                                 |
+| templateRepresentLink | Object   | X   | 代表リンク                                                                                                                                                                      |
+| - linkMo              | String   | 	X  | 	モバイル Web リンク(最大 500 文字)                                                                                                                                                         |
+| - linkPc              | String   | 	X  | PC Web リンク(最大 500 文字)                                                                                                                                                           |
+| - schemeIos           | String   | X   | 	iOS アプリリンク(最大 500 文字)                                                                                                                                                         |
+| - schemeAndroid       | String   | X   | 	Android アプリリンク(最大 500 文字)                                                                                                                                                       |
+| templateImageName     | String   | 	X  | 画像名(アップロードしたファイル名)                                                                                                                                                             |
+| templateImageUrl      | String   | 	X  | 画像 URL                                                                                                                                                                    |
+| securityFlag          | Boolean  | X   | セキュリティテンプレート使用有無<br>OTP などのセキュリティメッセージの場合に設定<br>送信時のメインデバイスを除くすべてのデバイスにメッセージテキストを非表示(default: false)                                                                               |
+| categoryCode          | String   | X   | テンプレートカテゴリコード(テンプレートカテゴリ照会 API 参照、default: 999999)<br>カテゴリがその他の場合、最低優先度で審査                                                                                              |
+| buttons               | 	List    | 	X  | ボタンリスト(最大 5 個)                                                                                                                                                              |
+| - ordering            | 	Integer | 	X  | ボタン順序(1〜5)                                                                                                                                                                 |
+| - type                | String   | 	X  | 	ボタンタイプ(WL: Web リンク、AL: アプリリンク、DS: 配送照会、BK: ボットキーワード、MD: メッセージ転達、BC: 相談トーク転換、BT: ボット転換、AC: チャンネル追加、BF: ビジネスフォーム、P1: 画像セキュリティ転送プラグイン ID、P2: 個人情報利用プラグイン ID、P3: ワンクリック決済プラグイン ID、TN: 電話) |
+| - name                | String   | 	X  | 	ボタン名(ボタンがある場合は必須、最大 14 文字)                                                                                                                                               |
+| - linkMo              | String   | 	X  | 	モバイル Web リンク(WL タイプの場合は必須フィールド、最大 500 文字)                                                                                                                                        |
+| - linkPc              | String   | 	X  | PC Web リンク(WL タイプの場合は任意フィールド、最大 500 文字)                                                                                                                                          |
+| - schemeIos           | String   | X   | 	iOS アプリリンク(AL タイプの場合は必須フィールド、最大 500 文字)                                                                                                                                        |
+| - schemeAndroid       | String   | X   | 	Android アプリリンク(AL タイプの場合は必須フィールド、最大 500 文字)                                                                                                                                      |
+| - bizFormId           | 	Integer | 	X  | 	ビジネスフォーム ID(BF タイプの場合は必須)                                                                                                                                                    |
+| - pluginId            | 	String  | 	X  | 	プラグイン ID(最大 24 文字)                                                                                                                                                           |
+| -- telNumber           | 	String  | 	X  | TN(電話)タイプボタン使用時に転達する電話番号                                                                    |
+| quickReplies          | 	List    | 	X  | クイックリプライリスト(最大 5 個)                                                                                                                                                            |
+| - ordering            | 	Integer | 	X  | 	クイックリプライ順序(クイックリプライがある場合は必須)                                                                                                                                                   |
+| - type                | String   | 	X  | 	クイックリプライタイプ(WL: Web リンク、AL: アプリリンク、BK: ボットキーワード、BC: 相談トーク転換、BT: ボット転換、BF: ビジネスフォーム)                                                                                                   |
+| - name                | String   | 	X  | 	クイックリプライ名(クイックリプライがある場合は必須、最大 14 文字)                                                                                                                                           |
+| - linkMo              | String   | 	X  | 	モバイル Web リンク(WL タイプの場合は必須フィールド、最大 500 文字)                                                                                                                                        |
+| - linkPc              | String   | 	X  | PC Webリンク（WLタイプの場合は選択フィールド、最大500文字）                                                                                                                                          |
+| - schemeIos           | String   | X   | 	iOSアプリリンク（ALタイプの場合は必須フィールド、最大500文字）                                                                                                                                        |
+| - schemeAndroid       | String   | X   | 	Androidアプリリンク（ALタイプの場合は必須フィールド、最大500文字）                                                                                                                                      |
+| - bizFormId           | 	Integer | 	X  | 	ビジネスフォームID（BFタイプの場合は必須）                                                                                                                                                    |
+
+* 「チャンネル追加型（AD）」および「複合型（MI）」メッセージタイプのテンプレートを修正する際、templateAd の値が固定されます。
+* チャンネル追加型（AD）および複合型（MI）メッセージタイプのテンプレートを修正する際、チャンネル追加（AC）ボタンを先頭の順番に配置する必要があります。
+* チャンネル追加（AC）ボタンのボタン名は「채널 추가」に固定されているため、修正する必要があります。
 
 <a id="response-14"></a>
 
 #### レスポンス
+
 ```
 {
-  "header" : {
-    "resultCode" :  Integer,
-    "resultMessage" :  String,
-    "isSuccessful" :  boolean
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
   }
 }
 ```
 
-| 値       | タイプ | 説明 |
-| --------------- | ------- | ------ |
-| header          | Object  | ヘッダ領域 |
-| - resultCode    | Integer | 結果コード |
-| - resultMessage | String  | 結果メッセージ |
-| - isSuccessful  | Boolean | 成否 |
+| 名前              | タイプ      | Not Null | 説明     |
+|-----------------|---------|:--------:|--------|
+| header          | Object  |    O     | ヘッダー領域  |
+| - resultCode    | Integer |    O     | 結果コード  |
+| - resultMessage | String  |    O     | 結果メッセージ |
+| - isSuccessful  | Boolean |    O     | 成否  |
 
 <a id="delete-templates"></a>
 
-### テンプレートの削除
+### テンプレート削除
+
 <a id="request-14"></a>
 
 #### リクエスト
+
 [URL]
 
 ```
@@ -2041,50 +2140,53 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 値    | タイプ | 説明 |
-| ------------ | ------ | -------- |
-| appkey       | String | 固有のアプリキー |
-| plusFriendId | String | 発信キー |
-| templateCode | String | テンプレートコード |
+| 名前           | 	タイプ     | 	説明     |
+|--------------|---------|---------|
+| appkey       | 	String | 	固有のアプリキー |
+| senderKey    | 	String | 	発信キー   |
+| templateCode | 	String | 	テンプレートコード |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
 
+* 承認済みのテンプレートを削除した場合、NHN Cloud 内でのみ削除されます（3日間送信されていないテンプレートのみ削除可能）。
+* 承認済みテンプレートの場合、カカオトークビズメッセージの制約により、カカオ内部データは削除できません。
+* カカオに残存しているテンプレートは、1年間未使用の場合に休眠処理され、休眠状態が1年間継続すると削除処理されます（カカオでテンプレートが休眠に移行または削除された場合、担当者に通知が送信されます）。
+
 <a id="response-15"></a>
 
 #### レスポンス
+
 ```
 {
-  "header" : {
-    "resultCode" :  Integer,
-    "resultMessage" :  String,
-    "isSuccessful" :  boolean
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
   }
 }
 ```
 
-| 値       | タイプ | 説明 |
-| --------------- | ------- | ------ |
-| header          | Object  | ヘッダ領域 |
-| - resultCode    | Integer | 結果コード |
-| - resultMessage | String  | 結果メッセージ |
-| - isSuccessful  | Boolean | 成否 |
-
-* 承認されたテンプレートを削除する時、NHN Cloud内でのみ削除されます。(3日間未送信のテンプレートのみ削除可能)
-* 承認されたテンプレートの場合、カカオトークBizメッセージの制約のため、カカオ内部データは削除できません。
-* カカオに残っているテンプレートは1年間使っていないと休眠処理され、休眠状態が1年間続くと削除処理されます。(カカオでテンプレートが休眠に切り替わるときや、削除されるときは担当者に通知が送信されます。)
-
+| 名前              | タイプ      | Not Null | 説明     |
+|-----------------|---------|:--------:|--------|
+| header          | Object  |    O     | ヘッダ領域  |
+| - resultCode    | Integer |    O     | 結果コード  |
+| - resultMessage | String  |    O     | 結果メッセージ |
+| - isSuccessful  | Boolean |    O     | 成否  |
 
 <a id="inquire-of-templates"></a>
 
-### テンプレートの問い合わせをする
+### テンプレートへのお問い合わせ
+
 <a id="request-15"></a>
 
 #### リクエスト
+
 [URL]
 
 ```
@@ -2094,62 +2196,67 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 値    | タイプ | 説明 |
-| ------------ | ------ | -------- |
-| appkey       | String | 固有のアプリキー |
-| plusFriendId | String | 発信キー |
-| templateCode | String | テンプレートコード |
+| 名前           | 	タイプ     | 	説明         |
+|--------------|---------|-------------|
+| appkey       | 	String | 	固有のアプリキー   |
+| senderKey    | 	String | 	発信キー       |
+| templateCode | 	String | 	テンプレートコード  |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| 値    | タイプ | 必須 | 説明                               |
-| ------------ | ------ | ---- | ---------------------------------------- |
-| X-Secret-Key | String | O    | コンソールで作成できます。 |
 
-[Request body]
+| 名前           | 	タイプ     | 	必須 | 	説明                  |
+|--------------|---------|-----|----------------------|
+| X-Secret-Key | 	String | O   | コンソールで作成できます。 |
+
+[Request Body]
 
 ```
 {
-  "comment" : String
+  "comment": String
 }
 ```
 
-| 値 | タイプ | 必須 | 説明 |
-| ------- | ------ | ---- | ----- |
-| comment | String | O    | お問い合わせ内容 |
+| 名前      | 	タイプ     | 	必須 | 	説明       |
+|---------|---------|-----|-----------|
+| comment | 	String | 	O  | お問い合わせ内容  |
 
-* REJステータスのテンプレートにコメントを付けると、REQステータスに変更されます。
+* 反映状態のテンプレートにお問い合わせを送信した場合、検収中 (REQ) の状態に変更されます。
 
 <a id="response-16"></a>
 
 #### レスポンス
+
 ```
 {
-  "header" : {
-    "resultCode" :  Integer,
-    "resultMessage" :  String,
-    "isSuccessful" :  boolean
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
   }
 }
 ```
 
-| 値       | タイプ | 説明 |
-| --------------- | ------- | ------ |
-| header          | Object  | ヘッダ領域 |
-| - resultCode    | Integer | 結果コード |
-| - resultMessage | String  | 結果メッセージ |
-| - isSuccessful  | Boolean | 成否 |
+| 名前              | タイプ      | Not Null | 説明       |
+|-----------------|---------|:--------:|----------|
+| header          | Object  |    O     | ヘッダー領域   |
+| - resultCode    | Integer |    O     | 結果コード    |
+| - resultMessage | String  |    O     | 結果メッセージ  |
+| - isSuccessful  | Boolean |    O     | 成功可否     |
 
 <a id="send-inquiry-on-templates-with-file-attachment"></a>
 
-### ファイルを添付してテンプレートお問い合わせ
+### ファイルを添付してテンプレートに問い合わせる
+
 <a id="request-16"></a>
 
 #### リクエスト
+
 [URL]
 
 ```
@@ -2159,63 +2266,124 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-|値|	タイプ|	説明|
-|---|---|---|
-|appkey|	String|	固有のAppkey|
-|plusFriendId|	String|	発信キー |
-|templateCode|	String|	テンプレートコード |
+| 名前           | 	タイプ     | 	説明        |
+|--------------|---------|------------|
+| appkey       | 	String | 	固有のアプリキー  |
+| senderKey    | 	String | 	発信キー      |
+| templateCode | 	String | 	テンプレートコード |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-|値|	タイプ|	必須|	説明|
-|---|---|---|---|
-|X-Secret-Key|	String| O | コンソールで作成できます。 |
+
+| 名前           | 	タイプ     | 	必須 | 	説明               |
+|--------------|---------|-----|-------------------|
+| X-Secret-Key | 	String | O   | コンソールで作成できます。 |
 
 [Request Body]
 
 ```
 {
-  "comment" : String,
-  "attachments" : File
+  "comment": String,
+  "attachments": File
 }
 ```
 
-|値|	タイプ|	必須| 	説明                                                                                                                                      |
-|---|---|---|------------------------------------------------------------------------------------------------------------------------------------------|
-|comment|	String |	O | お問い合わせ内容                                                                                                                                 |
-|attachments| List<File> | X | 添付ファイルリスト(最大10個)<br>- 対応拡張子 ( .png, .jpg, .jpeg, .gif, .pdf, .hwp, .doc, .docx )<br>- 各個別ファイルの最大サイズ 50mb<br>- アップロード可能なファイルの総最大サイズ 100mb |
+| 名前          | 	タイプ        | 	必須 | 	説明                                                                                                                                                |
+|-------------|------------|-----|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| comment     | 	String    | 	O  | 問い合わせ内容                                                                                                                                            |
+| attachments | List<File> | X   | 添付ファイルリスト（最大10個）<br>- サポートされる拡張子（.png、.jpg、.jpeg、.gif、.pdf、.hwp、.doc、.docx）<br>- 各ファイルの最大サイズ：50MB<br>- アップロード可能なファイルの合計最大サイズ：100MB |
 
-* REJステータスのテンプレートにコメントを付けると、REQステータスに変更されます。
+* 反映済みのテンプレートに問い合わせを残した場合、検収中（REQ）の状態に変更されます。
 
 <a id="response-17"></a>
 
 #### レスポンス
+
 ```
 {
-  "header" : {
-    "resultCode" :  Integer,
-    "resultMessage" :  String,
-    "isSuccessful" :  boolean
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
   }
 }
 ```
 
-|値|	タイプ|	説明|
-|---|---|---|
-|header|	Object|	ヘッダ領域|
-|- resultCode|	Integer|	結果コード|
-|- resultMessage|	String| 結果メッセージ|
-|- isSuccessful|	Boolean| 成否|
+| 名前              | タイプ      | Not Null | 説明       |
+|-----------------|---------|:--------:|----------|
+| header          | Object  |    O     | ヘッダー領域   |
+| - resultCode    | Integer |    O     | 結果コード    |
+| - resultMessage | String  |    O     | 結果メッセージ  |
+| - isSuccessful  | Boolean |    O     | 成功かどうか   |
 
 <a id="change-template-to-channel-add-type"></a>
 
-### テンプレート個別照会
+### テンプレートをチャンネル追加型に変更
 
 <a id="request-17"></a>
+
+#### リクエスト
+
+[URL]
+
+```
+PUT  /alimtalk/v2.3/appkeys/{appKey}/senders/{senderKey}/templates/{templateCode}/convert-add-channel
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 名前           | 	タイプ     | 	説明     |
+|--------------|---------|---------|
+| appkey       | 	String | 	固有のアプリキー |
+| senderKey    | 	String | 	発信キー   |
+| templateCode | 	String | 	テンプレートコード |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前           | 	タイプ     | 	必須 | 	説明              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | コンソールで作成できます。 |
+
+* グループ発信プロフィールに登録されたテンプレートは、チャンネル追加型に変換することはできません。
+
+<a id="response-18"></a>
+
+#### レスポンス
+
+```
+{
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
+  }
+}
+```
+
+| 名前              | タイプ      | Not Null | 説明     |
+|-----------------|---------|:--------:|--------|
+| header          | Object  |    O     | ヘッダー領域  |
+| - resultCode    | Integer |    O     | 結果コード  |
+| - resultMessage | String  |    O     | 結果メッセージ |
+| - isSuccessful  | Boolean |    O     | 成否  |
+
+<a id="single-query-for-template"></a>
+
+### テンプレート単件照会
+
+<a id="request-18"></a>
 
 #### リクエスト
 
@@ -2228,11 +2396,11 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 名前          | 	タイプ    | 	説明    |
+| 名前           | 	タイプ     | 	説明     |
 |--------------|---------|---------|
 | appkey       | 	String | 	固有のアプリキー |
-| senderKey    | 	String | 	発信キー  |
-| templateCode | String  | テンプレートコード |
+| senderKey    | 	String | 	発信キー   |
+| templateCode | String  | テンプレートコード  |
 
 [Header]
 
@@ -2242,16 +2410,16 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前          | 	タイプ    | 	必須 | 	説明             |
+| 名前           | 	タイプ     | 	必須 | 	説明              |
 |--------------|---------|-----|------------------|
-| X-Secret-Key | 	String | O   | コンソールで作成できます。 |
+| X-Secret-Key | 	String | O   | コンソールで作成できます。 |
 
-| テンプレートステータスコード | 説明  |
+| テンプレート状態コード | 説明   |
 |-----------|------|
-| TSC01     | 申請   |
-| TSC02     | 審査中 |
-| TSC03     | 承認  |
-| TSC04     | 却下   |
+| TSC01     | リクエスト   |
+| TSC02     | 検収中 |
+| TSC03     | 承認   |
+| TSC04     | 反映   |
 
 [例]
 
@@ -2259,11 +2427,12 @@ Content-Type: application/json;charset=UTF-8
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}"
 ```
 
-<a id="response-18"></a>
+<a id="response-19"></a>
 
-#### レスポンス
+#### 応答
 
 ```
+
 {
   "header": {
       "resultCode": Integer,
@@ -2359,179 +2528,219 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 }
 ```
 
----
-
-| 名前                     | タイプ     | Not Null | 説明                                                                                                                                                                              |
+| 名前                      | タイプ      | Not Null | 説明                                                                                                                                                                               |
 |-------------------------|---------|:--------:|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| header                  | Object  |    O     | ヘッダ領域                                                                                                                                                                           |
-| - resultCode            | Integer |    O     | 結果コード                                                                                                                                                                           |
-| - resultMessage         | String  |    O     | 結果メッセージ                                                                                                                                                                          |
-| - isSuccessful          | Boolean |    O     | 成否                                                                                                                                                                           |
-| templates               | Object    |    X     | テンプレートリスト                                                                                                                                                                         |
-| - plusFriendId          | String  |    O     | カカオトークチャンネル検索用IDまたは発信プロフィールグループ名                                                                                                                                                 |
-| - senderKey             | String  |    O     | 発信キー                                                                                                                                                                            |
-| - plusFriendType        | String  |    O     | プラスフレンドタイプ(NORMAL, GROUP)                                                                                                                                                          |
-| - templateCode          | String  |    O     | テンプレートコード                                                                                                                                                                          |
-| - kakaoTemplateCode     | String  |    O     | オリジナルテンプレートコード                                                                                                                                                                        |
-| - templateName          | String  |    O     | テンプレート名                                                                                                                                                                            |
-| - templateMessageType   | String  |    X     | テンプレートメッセージタイプ(BA:基本型, EX: 付加情報型, AD:チャンネル追加型, MI:複合型)                                                                                                                             |
-| - templateEmphasizeType | String  |    X     | テンプレート強調表示タイプ(NONE:基本、 TEXT:強調 表示、IMAGE:画像型、 ITEM_LIST:アイテムリスト型)                                                                                                             |
-| - templateContent       | String  |    X     | テンプレート本文                                                                                                                                                                          |
-| - templateExtra         | String  |    X     | テンプレート付加情報                                                                                                                                                                          |
-| - templateAd            | String  |    X     | テンプレート内の受信同意リクエストまたは簡単な広告文言                                                                                                                                                        |
-| - tempalteTitle         | String  |    X     | テンプレートタイトル                                                                                                                                                                          |
-| - templateSubtitle      | String  |    X     | テンプレート補助文言                                                                                                                                                                            |
-| - templateHeader        | String  |    X     | テンプレートヘッダ(最大16文字)                                                                                                                                                                   |
-| - templateItem          | Object  |    X     | アイテム                                                                                                                                                                             |
-| -- list                 | List    |    X     | アイテムリスト(最小2個、最大10個)                                                                                                                                                           |
-| --- title               | String  |    X     | タイトル(最大6文字)                                                                                                                                                                       |
-| --- description         | String  |    X     | 説明(最大23文字)                                                                                                                                                                    |
-| -- summary              | Object  |    X     | アイテム要約情報                                                                                                                                                                       |
-| --- title               | String  |    X     | タイトル(最大6文字)                                                                                                                                                                       |
-| --- description         | String  |    X     | 説明(変数及び通貨単位、数字、カンマ、ピリオドのみ使用可能、最大14文字)                                                                                                                                    |
-| - templateItemHighlight | Object  |    X     | アイテムハイライト                                                                                                                                                                       |
-| -- title                | String  |    X     | タイトル(最大30文字、サムネイル画像がある場合は21文字)                                                                                                                                                   |
-| -- description          | String  |    X     | 説明(最大19文字、サムネイル画像がある場合は13文字)                                                                                                                                                    |
-| -- imageUrl             | String  |    X     | サムネイル画像アドレス                                                                                                                                                                      |
-| - templateRepresentLink | Object  |    X     | 代表リンク                                                                                                                                                                           |
-| -- linkMo               | String  |    X     | モバイルWebリンク(最大500文字)                                                                                                                                                                |
-| -- linkPc               | String  |    X     | PC Webリンク(最大500文字)                                                                                                                                                                 |
-| -- schemeIos            | String  |    X     | iOSアプリリンク(最大500文字)                                                                                                                                                                |
-| -- schemeAndroid        | String  |    X     | Androidアプリリンク(最大500文字)                                                                                                                                                              |
-| - templateImageName     | String  |    X     | 画像名(アップロードしたファイル名)                                                                                                                                                                   |
-| - templateImageUrl      | String  |    X     | 画像URL                                                                                                                                                                            |
-| - buttons               | List    |    X     | ボタンリスト                                                                                                                                                                          |
-| -- ordering             | Integer |    X     | ボタン順序(1～5)                                                                                                                                                                       |
-| -- type                 | String  |    X     | ボタンタイプ(WL: Webリンク, AL: アプリリンク, DS: 配送照会, BK: ボットキーワード, MD: メッセージ転送, BC: 相談トーク切替, BT: ボット切替, AC: チャンネル追加, BF: ビジネスフォーム, P1: 画像セキュリティ転送プラグインID, P2: 個人情報利用プラグインID, P3: ワンクリック決済プラグインID, TN: 電話発信) |
-| -- name                 | String  |    X     | ボタン名                                                                                                                                                                           |
-| -- linkMo               | String  |    X     | モバイルWebリンク(WLタイプの場合は必須フィールド)                                                                                                                                                        |
-| -- linkPc               | String  |    X     | PC Webリンク(WLタイプの場合は任意フィールド)                                                                                                                                                         |
-| -- schemeIos            | String  |    X     | iOSアプリリンク(ALタイプの場合は必須フィールド)                                                                                                                                                        |
-| -- schemeAndroid        | String  |    X     | Androidアプリリンク(ALタイプの場合は必須フィールド)                                                                                                                                                      |
-| -- bizFormId            | Integer |    X     | ビジネスフォーム ID(BFタイプの場合は必須)                                                                                                                                                           |
-| -- pluginId             | String  |    X     | プラグインID(最大24文字)                                                                                                                                                                  |
-| -- telNumber            | 	String  | 	X  | TN(電話発信)タイプボタンの場合、伝達する電話番号                                                                                                                                                       |
-| - quickReplies          | List    |    X     | クイックリプライリスト(最大5個)                                                                                                                                                                  |
-| -- ordering             | Integer |    X     | クイックリプライ順序(クイックリプライがある場合は必須)                                                                                                                                                            |
-| -- type                 | String  |    X     | クイックリプライタイプ(WL: Webリンク, AL: アプリリンク, BK: ボットキーワード, BC: 相談トーク切替, BT: ボット切替, BF: ビジネスフォーム)                                                                                                          |
-| -- name                 | String  |    X     | クイックリプライ名(クイックリプライがある場合は必須、最大14文字)                                                                                                                                                    |
-| -- linkMo               | String  |    X     | モバイルWebリンク(WLタイプの場合は必須フィールド、最大500文字)                                                                                                                                               |
-| -- linkPc               | String  |    X     | PC Webリンク(WLタイプの場合は任意フィールド、最大500文字)                                                                                                                                                  |
-| -- schemeIos            | String  |    X     | iOSアプリリンク(ALタイプの場合は必須フィールド、最大500文字)                                                                                                                                               |
-| -- schemeAndroid        | String  |    X     | Androidアプリリンク(ALタイプの場合は必須フィールド、最大500文字)                                                                                                                                             |
-| -- bizFormId            | Integer |    X     | ビジネスフォーム ID(BFタイプの場合は必須)                                                                                                                                                           |
-| - comments              | List    |    X     | 審査結果                                                                                                                                                                                    |
-| -- id                   | Integer |    X     | お問い合わせID                                                                                                                                                                           |
-| -- content              | String  |    X     | お問い合わせ内容                                                                                                                                                                           |
-| -- userName             | String  |    X     | 作成者                                                                                                                                                                             |
-| -- createAt             | String  |    O     | 登録日                                                                                                                                                                           |
+| header                  | Object  |    O     | ヘッダー領域                                                                                                                                                                            |
+| - resultCode            | Integer |    O     | 結果コード                                                                                                                                                                            |
+| - resultMessage         | String  |    O     | 結果メッセージ                                                                                                                                                                           |
+| - isSuccessful          | Boolean |    O     | 成功の可否                                                                                                                                                                            |
+| templates               | Object    |    X     | テンプレートリスト                                                                                                                                                                          |
+| - plusFriendId          | String  |    O     | カカオトークチャンネル検索用 ID または発信プロフィールグループ名                                                                                                                                                     |
+| - senderKey             | String  |    O     | 発信キー                                                                                                                                                                             |
+| - plusFriendType        | String  |    O     | プラスフレンドタイプ (NORMAL, GROUP)                                                                                                                                                          |
+| - templateCode          | String  |    O     | テンプレートコード                                                                                                                                                                           |
+| - kakaoTemplateCode     | String  |    O     | 元のテンプレートコード                                                                                                                                                                        |
+| - templateName          | String  |    O     | テンプレート名                                                                                                                                                                             |
+| - templateMessageType   | String  |    X     | テンプレートメッセージタイプ (BA: 基本型、EX: 付加情報型、AD: チャンネル追加型、MI: 複合型)                                                                                                                             |
+| - templateEmphasizeType | String  |    X     | テンプレート強調表示タイプ (NONE: 基本、TEXT: 強調表示、IMAGE: 画像型、ITEM_LIST: アイテムリストタイプ)                                                                                                             |
+| - templateContent       | String  |    X     | テンプレート本文                                                                                                                                                                           |
+| - templateExtra         | String  |    X     | テンプレート付加情報                                                                                                                                                                        |
+| - templateAd            | String  |    X     | テンプレート内の受信同意リクエストまたは簡単な広告文                                                                                                                                                      |
+| - tempalteTitle         | String  |    X     | テンプレートタイトル                                                                                                                                                                           |
+| - templateSubtitle      | String  |    X     | テンプレート補助文言                                                                                                                                                                        |
+| - templateHeader        | String  |    X     | テンプレートヘッダー (最大 16 文字)                                                                                                                                                                   |
+| - templateItem          | Object  |    X     | アイテム                                                                                                                                                                              |
+| -- list                 | List    |    X     | アイテムリスト (最小 2 件、最大 10 件)                                                                                                                                                           |
+| --- title               | String  |    X     | タイトル (最大 6 文字)                                                                                                                                                                       |
+| --- description         | String  |    X     | 説明 (最大 23 文字)                                                                                                                                                                    |
+| -- summary              | Object  |    X     | アイテム要約情報                                                                                                                                                                        |
+| --- title               | String  |    X     | タイトル (最大 6 文字)                                                                                                                                                                       |
+| --- description         | String  |    X     | 説明 (変数および通貨単位、数字、カンマ、ピリオドのみ使用可能、最大 14 文字)                                                                                                                                    |
+| - templateItemHighlight | Object  |    X     | アイテムハイライト                                                                                                                                                                        |
+| -- title                | String  |    X     | タイトル (最大 30 文字、サムネイル画像がある場合は 21 文字)                                                                                                                                                  |
+| -- description          | String  |    X     | 説明 (最大 19 文字、サムネイル画像がある場合は 13 文字)                                                                                                                                                |
+| -- imageUrl             | String  |    X     | サムネイル画像 URL                                                                                                                                                                       |
+| - templateRepresentLink | Object  |    X     | 代表リンク                                                                                                                                                                            |
+| -- linkMo               | String  |    X     | モバイル Web リンク (最大 500 文字)                                                                                                                                                                |
+| -- linkPc               | String  |    X     | PC Web リンク (最大 500 文字)                                                                                                                                                                 |
+| -- schemeIos            | String  |    X     | iOS アプリリンク (最大 500 文字)                                                                                                                                                                |
+| -- schemeAndroid        | String  |    X     | Android アプリリンク (最大 500 文字)                                                                                                                                                              |
+| - templateImageName     | String  |    X     | 画像名 (アップロードしたファイル名)                                                                                                                                                                   |
+| - templateImageUrl      | String  |    X     | 画像 URL                                                                                                                                                                          |
+| - buttons               | List    |    X     | ボタンリスト                                                                                                                                                                           |
+| -- ordering             | Integer |    X     | ボタン順序 (1〜5)                                                                                                                                                                       |
+| -- type                 | String  |    X     | ボタンタイプ (WL: Web リンク、AL: アプリリンク、DS: 配送照会、BK: ボットキーワード、MD: メッセージ転送、BC: 相談トーク切替、BT: ボット切替、AC: チャンネル追加、BF: ビジネスフォーム、P1: 画像セキュリティ転送プラグイン ID、P2: 個人情報利用プラグイン ID、P3: ワンクリック決済プラグイン ID、TN: 電話発信) |
+| -- name                 | String  |    X     | ボタン名                                                                                                                                                                            |
+| -- linkMo               | String  |    X     | モバイルウェブリンク（WL タイプの場合は必須フィールド）                                                                                                                                                    |
+| -- linkPc               | String  |    X     | PC ウェブリンク（WL タイプの場合は任意フィールド）                                                                                                                                                     |
+| -- schemeIos            | String  |    X     | iOS アプリリンク（AL タイプの場合は必須フィールド）                                                                                                                                                    |
+| -- schemeAndroid        | String  |    X     | Android アプリリンク（AL タイプの場合は必須フィールド）                                                                                                                                                |
+| -- bizFormId            | Integer |    X     | ビジネスフォーム ID（BF タイプの場合は必須）                                                                                                                                                         |
+| -- pluginId             | String  |    X     | プラグイン ID（最大 24 文字）                                                                                                                                                               |
+| -- telNumber            | 	String  | 	X  | TN（電話する）タイプのボタンの場合、送信する電話番号                                                                                                                                                      |
+| - quickReplies          | List    |    X     | クイックリプライリスト（最大 5 件）                                                                                                                                                               |
+| -- ordering             | Integer |    X     | クイックリプライの順序（クイックリプライがある場合は必須）                                                                                                                                                    |
+| -- type                 | String  |    X     | クイックリプライタイプ（WL: ウェブリンク、AL: アプリリンク、BK: ボットキーワード、BC: 相談トーク転換、BT: ボット転換、BF: ビジネスフォーム）                                                                                               |
+| -- name                 | String  |    X     | クイックリプライ名（クイックリプライがある場合は必須、最大 14 文字）                                                                                                                                             |
+| -- linkMo               | String  |    X     | モバイルウェブリンク（WL タイプの場合は必須フィールド、最大 500 文字）                                                                                                                                          |
+| -- linkPc               | String  |    X     | PC ウェブリンク（WL タイプの場合は任意フィールド、最大 500 文字）                                                                                                                                           |
+| -- schemeIos            | String  |    X     | iOS アプリリンク（AL タイプの場合は必須フィールド、最大 500 文字）                                                                                                                                          |
+| -- schemeAndroid        | String  |    X     | Android アプリリンク（AL タイプの場合は必須フィールド、最大 500 文字）                                                                                                                                      |
+| -- bizFormId            | Integer |    X     | ビジネスフォーム ID（BF タイプの場合は必須）                                                                                                                                                         |
+| - comments              | List    |    X     | 検収結果                                                                                                                                                                             |
+| -- id                   | Integer |    X     | 問い合わせ ID                                                                                                                                                                         |
+| -- content              | String  |    X     | 問い合わせ内容                                                                                                                                                                          |
+| -- userName             | String  |    X     | 作成者                                                                                                                                                                              |
+| -- createAt             | String  |    O     | 登録日時                                                                                                                                                                             |
 | -- attachment           | List    |    X     | 添付ファイル                                                                                                                                                                           |
 | --- originalFileName    | String  |    X     | 添付ファイル名                                                                                                                                                                          |
-| --- filePath            | String  |    X     | 添付ファイルパス                                                                                                                                                                        |
-| -- status               | String  |    X     | コメントステータス(INQ: 問い合わせ, APR: 承認, REJ: 却下, REP: 回答, REQ: 審査中)                                                                                                                             |
-| - status                | String  |    O     | テンプレートステータス                                                                                                                                                                           |
-| - statusName            | String  |    X     | テンプレートステータス名                                                                                                                                                                          |
-| - securityFlag          | Boolean |    X     | セキュリティテンプレート区分                                                                                                                                                                        |
-| - categoryCode          | String  |    X     | テンプレートカテゴリーコード                                                                                                                                                                     |
-| - block                 | Boolean |    X     | ブロック可否                                                                                                                                                                              |
-| - dormant               | Boolean |    X     | 休止可否                                                                                                                                                                            |
-| - createDate            | String  |    O     | 作成日                                                                                                                                                                           |
-| - updateDate            | String  |    X     | 修正日                                                                                                                                                                           |
+| --- filePath            | String  |    X     | 添付ファイルパス                                                                                                                                                                         |
+| -- status               | String  |    X     | コメント状態（INQ: 問い合わせ、APR: 承認、REJ: 反映、REP: 返答、REQ: 検収中）                                                                                                                              |
+| - status                | String  |    O     | テンプレート状態                                                                                                                                                                         |
+| - statusName            | String  |    X     | テンプレート状態名                                                                                                                                                                        |
+| - securityFlag          | Boolean |    X     | セキュリティテンプレートかどうか                                                                                                                                                                 |
+| - categoryCode          | String  |    X     | テンプレートカテゴリコード                                                                                                                                                                    |
+| - block                 | Boolean |    X     | ブロックかどうか                                                                                                                                                                         |
+| - dormant               | Boolean |    X     | 休眠かどうか                                                                                                                                                                           |
+| - createDate            | String  |    O     | 作成日時                                                                                                                                                                             |
+| - updateDate            | String  |    X     | 修正日時                                                                                                                                                                             |
 
+<a id="list-templates"></a>
 
-<a id="single-query-for-template"></a>
+### テンプレートリスト照会
 
-### テンプレートリストの照会
-
-<a id="request-18"></a>
+<a id="request-19"></a>
 
 #### リクエスト
 
 [URL]
 
 ```
-GET  /alimtalk/v2.3/appkeys/{appkey}/templates
+GET  /alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates
 Content-Type: application/json;charset=UTF-8
 ```
 
 [Path parameter]
 
-| 値 | タイプ | 説明 |
-| ------ | ------ | ------ |
-| appkey | String | 固有のアプリキー |
+| 名前        | 	タイプ     | 	説明     |
+|-----------|---------|---------|
+| appkey    | 	String | 	固有のアプリキー |
+| senderKey | 	String | 	発信キー   |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| 値    | タイプ | 必須 | 説明                               |
-| ------------ | ------ | ---- | ---------------------------------------- |
-| X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+| 名前           | 	タイプ     | 	必須 | 	説明              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | コンソールで作成できます。 |
 
 [Query parameter]
 
-| 値      | タイプ | 必須 | 説明    |
-| -------------- | ------- | ---- | ------------- |
-| plusFriendId   | String  | X    | 発信キー      |
-| templateCode   | String  | X    | テンプレートコード |
-| templateName   | String  | X    | テンプレート名 |
-| templateStatus | String  | X    | テンプレートステータスコード |
-| pageNum        | Integer | X    | ページ番号(基本：1) |
-| pageSize       | Integer | X    | 照会件数(基本：15、最大: 1000) |
+| 名前             | 	タイプ      | 	必須 | 	説明                            |
+|----------------|----------|-----|--------------------------------|
+| templateCode   | 	String  | 	X  | 	テンプレートコード                        |
+| templateName   | 	String  | 	X  | 	テンプレート名                        |
+| templateStatus | String   | 	X  | テンプレート状態コード                      |
+| pageNum        | 	Integer | 	X  | 	ページ番号（Default: 1）            |
+| pageSize       | 	Integer | 	X  | 	照会件数（Default: 15、Max: 1000） |
 
-| テンプレートステータスコード | 説明 |
-| --------- | ---- |
-| TSC01     | リクエスト |
+| テンプレート状態コード | 説明   |
+|-----------|------|
+| TSC01     | リクエスト   |
 | TSC02     | 検収中 |
-| TSC03     | 承認 |
-| TSC04     | 差し戻し |
+| TSC03     | 承認   |
+| TSC04     | 反映   |
 
 [例]
+
 ```
-curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/templates?plusFriendId={発信キー}&templateStatus={テンプレートステータスコード}"
+curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates?templateStatus={テンプレート状態コード}"
 ```
 
-<a id="response-19"></a>
+<a id="response-20"></a>
 
-#### レスポンス
+#### 応答
+
 ```
 
 {
-  "header" : {
-      "resultCode" :  Integer,
-      "resultMessage" :  String,
-      "isSuccessful" :  boolean
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
   },
   "templateListResponse": {
       "templates": [
           {
               "plusFriendId": String,
+              "senderKey": String,
               "plusFriendType": String,
               "templateCode": String,
+              "kakaoTemplateCode": String,
               "templateName": String,
-              "templateContent": String,
+              "templateMessageType": String,
               "templateEmphasizeType": String,
-              "templateTitle" : String,
-              "templateSubtitle" : String,
-              "templateImageName" : String,
-              "templateImageUrl" : String,
-              "templateMessageType" : String,
-              "templateExtra" : String,
-              "templateAd" : String,
+              "templateContent": String,
+              "templateExtra": String,
+              "templateAd": String,
+              "templateTitle": String,
+              "templateSubtitle": String,
+              "templateHeader": String,
+              "templateItem": {
+                "list": [{
+                  "title": String,
+                  "description": String
+                }],
+                "summary": {
+                  "title": String,
+                  "description": String
+                }
+              },
+              "templateItemHighlight": {
+                "title": String,
+                "description": String,
+                "imageUrl": String
+              },
+              "templateRepresentLink": {
+                "linkMo": String,
+                "linkPc": String,
+                "schemeIos": String,
+                "schemeAndroid": String,
+              },
+              "templateImageName": String,
+              "templateImageUrl": String,
               "buttons": [
                 {
-                    "ordering":Integer,
+                    "ordering": Integer,
                     "type": String,
                     "name": String,
                     "linkMo": String,
                     "linkPc": String,
                     "schemeIos": String,
-                    "schemeAndroid": String
+                    "schemeAndroid": String,
+                    "bizFormId": Integer,
+                    "pluginId": String,
+                    "telNumber": String
                 }
-                ],
-                "comments": [
+              ],
+              "quickReplies": [
+                {
+                    "ordering": Integer,
+                    "type": String,
+                    "name": String,
+                    "linkMo": String,
+                    "linkPc": String,
+                    "schemeIos": String,
+                    "schemeAndroid": String,
+                    "bizFormId": Integer
+                }
+              ],
+              "comments": [
                   {
                       "id": Integer,
                       "content": String,
@@ -2542,117 +2751,101 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
                         "filePath": String
                       }],
                       "status": String
-                    }  
-                ],
-                "status": String,
-                "statusName": String,
-                "createDate": String
-            }
-        ],
-        "totalCount": Integer
-    }
-}
-```
-
-| 値            | タイプ | 説明                                                                                                     |
-| -------------------- | ------- |--------------------------------------------------------------------------------------------------------|
-| header               | Object  | ヘッダ領域                                                                                                  |
-| - resultCode         | Integer | 結果コード                                                                                                  |
-| - resultMessage      | String  | 結果メッセージ                                                                                                |
-| - isSuccessful       | Boolean | 成否                                                                                                     |
-| templateListResponse | Object  | 本文領域                                                                                                   |
-| - templates          | List    | テンプレートリスト                                                                                              |
-| -- plusFriendId      | String  | プラスフレンドID                                                                                              |
-| -- plusFriendType    | String  | プラスフレンドタイプ(NORMAL、GROUP)                                                                               |
-| -- templateCode      | String  | テンプレートコード                                                                                              |
-| -- templateName      | String  | テンプレート名                                                                                                |
-| -- templateContent   | String  | テンプレート本文                                                                                               |
-| -- templateEmphasizeType| String| テンプレートハイライトタイプ（NONE：基本、TEXT：ハイライト、default：NONE）<br>TEXT：templateTitle、templateSubtitleフィールド必須          |
-| -- tempalteTitle     | String  | テンプレートのタイトル(最大50字、Android:2行、23字以上のコマ処理、iOS:2行、27字以上のコマ処理)                                             |
-| -- templateSubtitle  | String  | テンプレートの補助フレーズ(最大50文字、Android:18字以上のコマを省く、iOS:21字以上のコマを省く)                                              |
-| -- templateImageName | String  | 画像名（アップロードされたファイル名）                                                                                    |
-| -- templateImageUrl  | String  | 画像のURL                                                                                                 |
-| -- templateMessageType| String  | テンプレートメッセージタイプ(BA:基本型、EX:付加情報型、AD:広告追加型、MI:複合型)<br>EX：templateExtraフィールド必須<br>MI：templateExtraフィールド必須」 |
-| -- templateExtra     | String  | テンプレート付加情報                                                                                             |
-| -- templateAd        | String  | テンプレート内の受信同意または簡単な広告文句                                                                                 |
-| -- buttons           | List    | ボタンリスト                                                                                                 |
-| --- ordering         | Integer | ボタン順序(1～5)                                                                                             |
-| --- type             | String  | ボタンタイプ(WL：Webリンク、AL：アプリリンク、DS：配送照会、BK：Botキーワード、MD：メッセージ伝達、BC：相談トーク転換、BT：Bot転換、AC：チャンネル追加)              |
-| --- name             | String  | ボタン名                                                                                                   |
-| --- linkMo           | String  | モバイルWebリンク(WLタイプの場合は必須フィールド)                                                                           |
-| --- linkPc           | String  | PC Webリンク(WLタイプの場合は任意フィールド)                                                                            |
-| --- schemeIos        | String  | iOSアプリリンク(ALタイプの場合は必須フィールド)                                                                            |
-| --- schemeAndroid    | String  | Androidアプリリンク(ALタイプの場合は必須フィールド)                                                                        |
-| -- comments          | List    | 検収結果                                                                                                   |
-| --- id               | Integer | お問い合わせID                                                                                               |
-| --- content          | String  | お問い合わせ内容                                                                                               |
-| --- userName          | String  | 作成者                                                                                                    |
-| --- createAt          | String  | 登録日                                                                                                    |
-| --- attachment        | List | 添付ファイル                                                                                                 |
-| ---- originalFileName | String | 添付ファイル名                                                                                                |
-| ---- filePath         | String | 添付ファイルへのパス                                                                                             |
-| --- status            | String  | 応答状態(INQ：お問い合わせ、APR：承認、REJ：差し戻し、REP：返信, REQ : 検査中)                                                     |
-| -- status            | String  | テンプレートのステータス                                                                                           |
-| -- statusName        | String  | テンプレートのステータス名                                                                                          |
-| -- createDate        | String  | 作成日時                                                                                                   |
-| - totalCount         | Integer | 総個数                                                                                                    |
-
-<a id="list-templates"></a>
-
-### テンプレートチャンネル追加型に変更
-
-<a id="request-19"></a>
-
-#### リクエスト
-[URL]
-```
-PUT  /alimtalk/v2.3/appkeys/{appKey}/senders/{senderKey}/templates/{templateCode}/convert-add-channel
-Content-Type: application/json;charset=UTF-8
-```
-
-[Path parameter]
-
-| 名前 |	タイプ|	説明|
-|---|---|---|
-|appkey|	String|	固有のアプリキー|
-|senderKey|	String|	発信キー |
-|templateCode|	String|	テンプレートコード |
-
-[Header]
-```
-{
-  "X-Secret-Key": String
-}
-```
-| 名前 |	タイプ|	必須|	説明|
-|---|---|---|---|
-|X-Secret-Key|	String| O | コンソールで作成できます。  |
-
-* グループプロフィールに登録されたテンプレートは、チャンネルタイプに変換することはできません
-
-<a id="response-20"></a>
-
-#### レスポンス
-```
-{
-  "header" : {
-    "resultCode" :  Integer,
-    "resultMessage" :  String,
-    "isSuccessful" :  boolean
+                  }  
+              ],
+              "status": String,
+              "statusName": String,
+              "securityFlag": Boolean,
+              "categoryCode": String,
+              "createDate": String,
+              "updateDate": String
+          }
+      ],
+      "totalCount": Integer
   }
 }
 ```
 
-| 名前 |	タイプ|	説明|
-|---|---|---|
-|header|	Object|	ヘッダ領域|
-|- resultCode|	Integer|	結果コード|
-|- resultMessage|	String| 結果メッセージ|
-|- isSuccessful|	Boolean| 成否|
+| 名前                       | タイプ      | Not Null | 説明                                                                                                                                                                     |
+|--------------------------|---------|:--------:|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| header                   | Object  |    O     | ヘッダー領域                                                                                                                                                                  |
+| - resultCode             | Integer |    O     | 結果コード                                                                                                                                                                  |
+| - resultMessage          | String  |    O     | 結果メッセージ                                                                                                                                                                 |
+| - isSuccessful           | Boolean |    O     | 成否                                                                                                                                                                  |
+| templateListResponse     | Object  |    X     | 本文領域                                                                                                                                                                  |
+| - templates              | List    |    X     | テンプレートリスト                                                                                                                                                                |
+| -- plusFriendId          | String  |    O     | カカオトークチャンネル検索用 ID または発信プロフィールグループ名                                                                                                                                           |
+| -- senderKey             | String  |    O     | 発信キー                                                                                                                                                                   |
+| -- plusFriendType        | String  |    O     | プラスフレンドタイプ (NORMAL, GROUP)                                                                                                                                                |
+| -- templateCode          | String  |    O     | テンプレートコード                                                                                                                                                                 |
+| -- kakaoTemplateCode     | String  |    O     | 元のテンプレートコード                                                                                                                                                              |
+| -- templateName          | String  |    O     | テンプレート名                                                                                                                                                                   |
+| -- templateMessageType   | String  |    X     | テンプレートメッセージタイプ (BA: 基本型、EX: 付加情報型、AD: チャンネル追加型、MI: 複合型)                                                                                                                   |
+| -- templateEmphasizeType | String  |    X     | テンプレート강조表記型タイプ (NONE: デフォルト、TEXT: 강조表示、IMAGE: 画像型、ITEM_LIST: アイテムリストタイプ)                                                                                                   |
+| -- templateContent       | String  |    X     | テンプレート本文                                                                                                                                                                 |
+| -- templateExtra         | String  |    X     | テンプレート付加情報                                                                                                                                                              |
+| -- templateAd            | String  |    X     | テンプレート内の受信同意要求または簡単な広告文                                                                                                                                            |
+| -- tempalteTitle         | String  |    X     | テンプレートタイトル                                                                                                                                                                 |
+| -- templateSubtitle      | String  |    X     | テンプレート補助文                                                                                                                                                              |
+| - templateHeader         | String  |    X     | テンプレートヘッダー (最大 16 文字)                                                                                                                                                         |
+| - templateItem           | Object  |    X     | アイテム                                                                                                                                                                    |
+| -- list                  | List    |    X     | アイテムリスト (最小 2 個、最大 10 個)                                                                                                                                                 |
+| --- title                | String  |    X     | タイトル (最大 6 文字)                                                                                                                                                             |
+| --- description          | String  |    X     | 説明 (最大 23 文字)                                                                                                                                                          |
+| -- summary               | Object  |    X     | アイテム概要情報                                                                                                                                                              |
+| --- title                | String  |    X     | タイトル (最大 6 文字)                                                                                                                                                             |
+| --- description          | String  |    X     | 説明 (変数および通貨単位、数字、カンマ、ピリオドのみ使用可能、最大 14 文字)                                                                                                                          |
+| - templateItemHighlight  | Object  |    X     | アイテムハイライト                                                                                                                                                              |
+| -- title                 | String  |    X     | タイトル (最大 30 文字、サムネイル画像がある場合は 21 文字)                                                                                                                                        |
+| -- description           | String  |    X     | 説明 (最大 19 文字、サムネイル画像がある場合は 13 文字)                                                                                                                                      |
+| -- imageUrl              | String  |    X     | サムネイル画像 URL                                                                                                                                                             |
+| - templateRepresentLink  | Object  |    X     | 代表リンク                                                                                                                                                                  |
+| -- linkMo                | String  |    X     | モバイル Web リンク (最大 500 文字)                                                                                                                                                      |
+| -- linkPc                | String  |    X     | PC Web リンク (最大 500 文字)                                                                                                                                                       |
+| -- schemeIos             | String  |    X     | iOS アプリリンク (最大 500 文字)                                                                                                                                                      |
+| -- schemeAndroid         | String  |    X     | Android アプリリンク (最大 500 文字)                                                                                                                                                    |
+| -- templateImageName     | String  |    X     | 画像名 (アップロードしたファイル名)                                                                                                                                                         |
+| -- templateImageUrl      | String  |    X     | 画像 URL                                                                                                                                                                |
+| -- buttons               | List    |    X     | ボタンリスト                                                                                                                                                                 |
+| --- ordering             | Integer |    X     | ボタン順序 (1〜5)                                                                                                                                                             |
+| --- type                 | String  |    X     | ボタンタイプ (WL: Web リンク、AL: アプリリンク、DS: 配送照会、BK: ボットキーワード、MD: メッセージ転送、BC: 相談トーク転換、BT: ボット転換、AC: チャンネル追加、BF: ビジネスフォーム、P1: 画像セキュリティ転送プラグイン ID、P2: 個人情報利用プラグイン ID、P3: ワンクリック決済プラグイン ID、TN: 電話をかける) |
+| --- name                 | String  |    X     | ボタン名                                                                                                                                                                  |
+| --- linkMo               | String  |    X     | モバイル Web リンク (WL タイプの場合は必須フィールド)                                                                                                                                              |
+| --- linkPc               | String  |    X     | PC ウェブリンク（WL タイプの場合は選択フィールド）                                                                                                                                               |
+| --- schemeIos            | String  |    X     | iOS アプリリンク（AL タイプの場合は必須フィールド）                                                                                                                                              |
+| --- schemeAndroid        | String  |    X     | Android アプリリンク（AL タイプの場合は必須フィールド）                                                                                                                                            |
+| --- bizFormId            | Integer |    X     | ビジネスフォーム ID（BF タイプの場合は必須）                                                                                                                                                 |
+| --- pluginId             | String  |    X     | プラグイン ID（最大 24 文字）                                                                                                                                                        |
+| --- telNumber            | 	String  | 	X  | TN（電話する）タイプのボタンの場合に送信する電話番号                                                                                                                                    |
+| -- quickReplies          | List    |    X     | クイックリプライリスト（最大 5 件）                                                                                                                                                        |
+| --- ordering             | Integer |    X     | クイックリプライの順序（クイックリプライがある場合は必須）                                                                                                                                                |
+| --- type                 | String  |    X     | クイックリプライタイプ（WL: ウェブリンク、AL: アプリリンク、BK: ボットキーワード、BC: 相談トーク転換、BT: ボット転換、BF: ビジネスフォーム）                                                                                                |
+| --- name                 | String  |    X     | クイックリプライ名（クイックリプライがある場合は必須、最大 14 文字）                                                                                                                                        |
+| --- linkMo               | String  |    X     | モバイルウェブリンク（WL タイプの場合は必須フィールド、最大 500 文字）                                                                                                                                     |
+| --- linkPc               | String  |    X     | PC ウェブリンク（WL タイプの場合は選択フィールド、最大 500 文字）                                                                                                                                      |
+| --- schemeIos            | String  |    X     | iOS アプリリンク（AL タイプの場合は必須フィールド、最大 500 文字）                                                                                                                                     |
+| --- schemeAndroid        | String  |    X     | Android アプリリンク（AL タイプの場合は必須フィールド、最大 500 文字）                                                                                                                                   |
+| --- bizFormId            | Integer |    X     | ビジネスフォーム ID（BF タイプの場合は必須）                                                                                                                                                 |
+| -- comments              | List    |    X     | 検収結果                                                                                                                                                                  |
+| --- id                   | Integer |    X     | お問い合わせ ID                                                                                                                                                                 |
+| --- content              | String  |    X     | お問い合わせ内容                                                                                                                                                                  |
+| --- userName             | String  |    X     | 作成者                                                                                                                                                                    |
+| --- createAt             | String  |    O     | 登録日                                                                                                                                                                  |
+| --- attachment           | List    |    X     | 添付ファイル                                                                                                                                                                  |
+| ---- originalFileName    | String  |    X     | 添付ファイル名                                                                                                                                                                 |
+| ---- filePath            | String  |    X     | 添付ファイルパス                                                                                                                                                               |
+| --- status               | String  |    X     | コメント状態（INQ: 問い合わせ、APR: 承認、REJ: 反映、REP: 返答、REQ: 検収中）                                                                                                                   |
+| -- status                | String  |    O     | テンプレート状態                                                                                                                                                                 |
+| -- statusName            | String  |    X     | テンプレート状態名                                                                                                                                                                |
+| -- securityFlag          | Boolean |    X     | セキュリティテンプレートかどうか                                                                                                                                              |
+| -- categoryCode          | String  |    X     | テンプレートカテゴリコード                                                                                                                                                            |
+| -- createDate            | String  |    O     | 作成日                                                                                                                                                                   |
+| -- updateDate            | String  |    X     | 修正日                                                                                                                                                                   |
+| - totalCount             | Integer |    X     | 総件数                                                                                                                                                                    |
 
 <a id="list-template-modifications"></a>
 
-### テンプレートの修正リスト照会
+### テンプレート修正リスト照会
 
 <a id="request-20"></a>
 
@@ -2667,54 +2860,81 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 値 | タイプ | 説明 |
-|---|---|---|
-| appkey       | String | 固有のアプリキー |
-| plusFriendId | String | プラスフレンドID |
-| templateCode | String | テンプレートコード |
+| 名前           | 	タイプ     | 	説明     |
+|--------------|---------|---------|
+| appkey       | 	String | 	固有のアプリキー |
+| senderKey    | 	String | 	発信キー   |
+| templateCode | 	String | 	テンプレートコード |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| 値    | タイプ | 必須 | 説明                               |
-|---|---|---|---|
-| X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+| 名前           | 	タイプ     | 	必須 | 	説明              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | コンソールで作成できます。 |
 
 [例]
+
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/templates/{templateCode}/modifications"
 ```
 
 <a id="response-21"></a>
 
-#### レスポンス
+#### 応答
+
 ```
 
 {
-  "header" : {
-      "resultCode" :  Integer,
-      "resultMessage" :  String,
-      "isSuccessful" :  boolean
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
   },
   "templateModificationsResponse": {
       "templates": [
           {
               "plusFriendId": String,
+              "senderKey": String,
               "plusFriendType": String,
               "templateCode": String,
               "templateName": String,
-              "templateContent": String,
+              "templateMessageType": String,
               "templateEmphasizeType": String,
-              "templateTitle" : String,
-              "templateSubtitle" : String,
-              "templateImageName" : String,
-              "templateImageUrl" : String,
-              "templateMessageType" : String,
-              "templateExtra" : String,
-              "templateAd" : String,
+              "templateContent": String,
+              "templateExtra": String,
+              "templateAd": String,
+              "templateTitle": String,
+              "templateSubtitle": String,
+              "templateHeader": String,
+              "templateItem": {
+                "list": [{
+                  "title": String,
+                  "description": String
+                }],
+                "summary": {
+                  "title": String,
+                  "description": String
+                }
+              },
+              "templateItemHighlight": {
+                "title": String,
+                "description": String,
+                "imageUrl": String
+              },
+              "templateRepresentLink": {
+                "linkMo": String,
+                "linkPc": String,
+                "schemeIos": String,
+                "schemeAndroid": String,
+              },
+              "templateImageName": String,
+              "templateImageUrl": String,
               "buttons": [
                 {
                     "ordering":Integer,
@@ -2723,10 +2943,23 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
                     "linkMo": String,
                     "linkPc": String,
                     "schemeIos": String,
-                    "schemeAndroid": String
+                    "schemeAndroid": String,
+                    "telNumber": String
                 }
-                ],
-                "comments": [
+              ],
+              "quickReplies": [
+                {
+                    "ordering": Integer,
+                    "type": String,
+                    "name": String,
+                    "linkMo": String,
+                    "linkPc": String,
+                    "schemeIos": String,
+                    "schemeAndroid": String,
+                    "bizFormId": Integer
+                }
+              ],
+              "comments": [
                   {
                       "id": Integer,
                       "content": String,
@@ -2737,69 +2970,105 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
                         "filePath": String
                       }],
                       "status": String
-                    }  
-                ],
-                "status": String,
-                "statusName": String,
-                "activated": boolean,
-                "createDate": String
-            }
-        ],
-        "totalCount": Integer
-    }
+                  }  
+              ],
+              "status": String,
+              "statusName": String,
+              "securityFlag": Boolean,
+              "categoryCode": String,
+              "activated": boolean,
+              "createDate": String,
+              "updateDate": String
+          }
+      ],
+      "totalCount": Integer
+  }
 }
 ```
 
-| 値            | タイプ | 説明                               |
-| -------------------- | ------- | ---------------------------------------- |
-| header               | Object  | ヘッダ領域                            |
-| - resultCode         | Integer | 結果コード                            |
-| - resultMessage      | String  | 結果メッセージ                           |
-| - isSuccessful       | Boolean | 成否                             |
-| templateModificationsResponse | Object  | 本文領域                            |
-| - templates          | List    | テンプレートリスト                          |
-| -- plusFriendId      | String  | プラスフレンドID                                 |
-| -- plusFriendType    | String  | プラスフレンドタイプ(NORMAL、GROUP)                  |
-| -- templateCode      | String  | テンプレートコード                           |
-| -- templateName      | String  | テンプレート名                             |
-| -- templateContent   | String  | テンプレート本文                           |
-| -- templateEmphasizeType| String| テンプレートハイライトタイプ（NONE：基本、TEXT：ハイライト、default：NONE）<br>TEXT：templateTitle、templateSubtitleフィールド必須 |
-| -- tempalteTitle     | String  | テンプレートのタイトル(最大50字、Android:2行、23字以上のコマ処理、iOS:2行、27字以上のコマ処理) |
-| -- templateSubtitle  | String  | テンプレートの補助フレーズ(最大50文字、Android:18字以上のコマを省く、iOS:21字以上のコマを省く) |
-| -- templateImageName | String  | 画像名（アップロードされたファイル名） |
-| -- templateImageUrl  | String  | 画像のURL |
-| -- templateMessageType| String  | テンプレートメッセージタイプ(BA:基本型、EX:付加情報型、AD:広告追加型、MI:複合型)<br>EX：templateExtraフィールド必須<br>MI：templateExtraフィールド必須」 |
-| -- templateExtra     | String  | テンプレート付加情報 |
-| -- templateAd        | String  | テンプレート内の受信同意または簡単な広告文句 |
-| -- buttons           | List    | ボタンリスト                            |
-| --- ordering         | Integer | ボタン順序(1～5)                               |
-| --- type             | String  | ボタンタイプ(WL：Webリンク、AL：アプリリンク、DS：配送照会、BK：Botキーワード、MD：メッセージ伝達、BC：相談トーク転換、BT：Bot転換、AC：チャンネル追加) |
-| --- name             | String  | ボタン名                            |
-| --- linkMo           | String  | モバイルWebリンク(WLタイプの場合は必須フィールド)                |
-| --- linkPc           | String  | PC Webリンク(WLタイプの場合は任意フィールド)                 |
-| --- schemeIos        | String  | iOSアプリリンク(ALタイプの場合は必須フィールド)                |
-| --- schemeAndroid    | String  | Androidアプリリンク(ALタイプの場合は必須フィールド)            |
-| -- comments          | List    | 検収結果                            |
-| --- id               | Integer | お問い合わせID                                   |
-| --- content          | String  | お問い合わせ内容                            |
-| ---userName          | String  | 作成者                               |
-| ---createAt          | String  | 登録日                            |
-| --- attachment        | List | 添付ファイル                           |
-| ---- originalFileName | String | 添付ファイル名                        |
-| ---- filePath         | String | 添付ファイルへのパス                   |
-| ---status            | String  | 応答状態(INQ：お問い合わせ、APR：承認、REJ：差し戻し、REP：返信, REQ : 検査中) |
-| -- status            | String  | テンプレートのステータス                           |
-| -- statusName        | String  | テンプレートのステータス名                           |
-| -- activated         | Boolean  | 有効かどうか                            |
-| -- createDate        | String  | 作成日時                            |
-| - totalCount         | Integer | 総個数                              |
+| 名前                            | タイプ      | Not Null | 説明                                                                                                                                                                     |
+|-------------------------------|---------|:--------:|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| header                        | Object  |    O     | ヘッダー領域                                                                                                                                                                  |
+| - resultCode                  | Integer |    O     | 結果コード                                                                                                                                                                  |
+| - resultMessage               | String  |    O     | 結果メッセージ                                                                                                                                                                 |
+| - isSuccessful                | Boolean |    O     | 成功かどうか                                                                                                                                                                  |
+| templateModificationsResponse | Object  |    X     | 本文領域                                                                                                                                                                  |
+| - templates                   | List    |    X     | テンプレートリスト                                                                                                                                                                |
+| -- plusFriendId               | String  |    O     | カカオトークチャンネル検索用 ID または発信プロフィールグループ名                                                                                                                                           |
+| -- senderKey                  | String  |    O     | 発信キー                                                                                                                                                                   |
+| -- plusFriendType             | String  |    O     | プラスフレンドタイプ (NORMAL, GROUP)                                                                                                                                                |
+| -- templateCode               | String  |    O     | テンプレートコード                                                                                                                                                                 |
+| -- templateName               | String  |    O     | テンプレート名                                                                                                                                                                   |
+| -- templateMessageType        | String  |    X     | テンプレートメッセージタイプ (BA: 基本型、EX: 付加情報型、AD: チャンネル追加型、MI: 複合型)                                                                                                                   |
+| -- templateEmphasizeType      | String  |    X     | テンプレート強調表示タイプ (NONE: 基本、TEXT: 強調表示、IMAGE: 画像型)                                                                                                                     |
+| -- templateContent            | String  |    O     | テンプレート本文                                                                                                                                                                 |
+| -- templateExtra              | String  |    X     | テンプレート付加情報                                                                                                                                                              |
+| -- templateAd                 | String  |    X     | テンプレート内の受信同意要求または簡単な広告文                                                                                                                                            |
+| -- tempalteTitle              | String  |    X     | テンプレートタイトル                                                                                                                                                                 |
+| -- templateSubtitle           | String  |    X     | テンプレート補助文言                                                                                                                                                              |
+| - templateHeader              | String  |    X     | テンプレートヘッダー (最大 16 文字)                                                                                                                                                         |
+| - templateItem                | Object  |    X     | アイテム                                                                                                                                                                    |
+| -- list                       | List    |    X     | アイテムリスト (最小 2 個、最大 10 個)                                                                                                                                                 |
+| --- title                     | String  |    X     | タイトル (最大 6 文字)                                                                                                                                                             |
+| --- description               | String  |    X     | 説明 (最大 23 文字)                                                                                                                                                          |
+| -- summary                    | Object  |    X     | アイテム要約情報                                                                                                                                                              |
+| --- title                     | String  |    X     | タイトル (最大 6 文字)                                                                                                                                                             |
+| --- description               | String  |    X     | 説明 (変数および通貨単位、数字、コンマ、ピリオドのみ使用可能、最大 14 文字)                                                                                                                          |
+| - templateItemHighlight       | Object  |    X     | アイテムハイライト                                                                                                                                                              |
+| -- title                      | String  |    X     | タイトル (最大 30 文字、サムネイル画像がある場合は 21 文字)                                                                                                                                        |
+| -- description                | String  |    X     | 説明 (最大 19 文字、サムネイル画像がある場合は 13 文字)                                                                                                                                      |
+| -- imageUrl                   | String  |    X     | サムネイル画像 URL                                                                                                                                                             |
+| - templateRepresentLink       | Object  |    X     | 代表リンク                                                                                                                                                                  |
+| -- linkMo                     | String  |    X     | モバイル Web リンク (最大 500 文字)                                                                                                                                                      |
+| -- linkPc                     | String  |    X     | PC Web リンク (最大 500 文字)                                                                                                                                                       |
+| -- schemeIos                  | String  |    X     | iOS アプリリンク (最大 500 文字)                                                                                                                                                      |
+| -- schemeAndroid              | String  |    X     | Android アプリリンク (最大 500 文字)                                                                                                                                                    |
+| -- templateImageName          | String  |    X     | 画像名 (アップロードしたファイル名)                                                                                                                                                         |
+| -- templateImageUrl           | String  |    X     | 画像 URL                                                                                                                                                                |
+| -- buttons                    | List    |    X     | ボタンリスト                                                                                                                                                                 |
+| --- ordering                  | Integer |    X     | ボタン順序 (1〜5)                                                                                                                                                             |
+| --- type                      | String  |    X     | ボタンタイプ (WL: Web リンク、AL: アプリリンク、DS: 配送照会、BK: ボットキーワード、MD: メッセージ転送、BC: 相談トーク切替、BT: ボット切替、AC: チャンネル追加、BF: ビジネスフォーム、P1: 画像セキュリティ送信プラグイン ID、P2: 個人情報利用プラグイン ID、P3: ワンクリック決済プラグイン ID、TN: 電話発信) |
+| --- name                      | String  |    X     | ボタン名                                                                                                                                                                  |
+| --- linkMo                    | String  |    X     | モバイル Web リンク (WL タイプの場合は必須フィールド)                                                                                                                                              |
+| --- linkPc                    | String  |    X     | PC ウェブリンク（WL タイプの場合は選択フィールド）                                                                                                                                               |
+| --- schemeIos                 | String  |    X     | iOS アプリリンク（AL タイプの場合は必須フィールド）                                                                                                                                              |
+| --- schemeAndroid             | String  |    X     | Android アプリリンク（AL タイプの場合は必須フィールド）                                                                                                                                            |
+| --- telNumber                 | 	String  | 	X  | TN（電話する）タイプのボタンの場合、送信する電話番号                                                                                    |
+| -- quickReplies               | List    |    X     | クイックリプライリスト（最大 5 件）                                                                                                                                                        |
+| --- ordering                  | Integer |    X     | クイックリプライの順序（クイックリプライがある場合は必須）                                                                                                                                                |
+| --- type                      | String  |    X     | クイックリプライタイプ（WL: ウェブリンク、AL: アプリリンク、BK: ボットキーワード、BC: 相談トーク転換、BT: ボット転換、BF: ビジネスフォーム）                                                                                                |
+| --- name                      | String  |    X     | クイックリプライ名（クイックリプライがある場合は必須、最大 14 文字）                                                                                                                                        |
+| --- linkMo                    | String  |    X     | モバイルウェブリンク（WL タイプの場合は必須フィールド、最大 500 文字）                                                                                                                                     |
+| --- linkPc                    | String  |    X     | PC ウェブリンク（WL タイプの場合は選択フィールド、最大 500 文字）                                                                                                                                      |
+| --- schemeIos                 | String  |    X     | iOS アプリリンク（AL タイプの場合は必須フィールド、最大 500 文字）                                                                                                                                     |
+| --- schemeAndroid             | String  |    X     | Android アプリリンク（AL タイプの場合は必須フィールド、最大 500 文字）                                                                                                                                   |
+| --- bizFormId                 | Integer |    X     | ビジネスフォーム ID（BF タイプの場合は必須）                                                                                                                                                 |
+| -- comments                   | List    |    X     | 検収結果                                                                                                                                                                  |
+| --- id                        | Integer |    X     | 問い合わせ ID                                                                                                                                                                 |
+| --- content                   | String  |    X     | 問い合わせ内容                                                                                                                                                                  |
+| --- userName                  | String  |    X     | 作成者                                                                                                                                                                    |
+| --- createAt                  | String  |    O     | 登録日時                                                                                                                                                                  |
+| --- attachment                | List    |    X     | 添付ファイル                                                                                                                                                                  |
+| ---- originalFileName         | String  |    X     | 添付ファイル名                                                                                                                                                                 |
+| ---- filePath                 | String  |    X     | 添付ファイルパス                                                                                                                                                               |
+| --- status                    | String  |    X     | コメントステータス（INQ: 問い合わせ、APR: 承認、REJ: 反映、REP: 回答、REQ: 検収中）                                                                                                                   |
+| -- status                     | String  |    O     | テンプレート状態                                                                                                                                                                 |
+| -- statusName                 | String  |    O     | テンプレート状態名                                                                                                                                                                |
+| -- securityFlag               | Boolean |    X     | セキュリティテンプレートかどうか                                                                                                                                              |
+| -- categoryCode               | String  |    X     | テンプレートカテゴリコード                                                                                                                                                            |
+| -- activated                  | Boolean |    X     | 有効化かどうか                                                                                                                                                                 |
+| -- createDate                 | String  |    O     | 作成日時                                                                                                                                                                   |
+| -- updateDate                 | String  |    X     | 修正日時                                                                                                                                                                   |
+| - totalCount                  | Integer |    X     | 総件数                                                                                                                                                                    |
 
 <a id="register-template-image"></a>
 
-### テンプレート画像の登録
+### テンプレート画像登録
+
 <a id="request-21"></a>
 
 #### リクエスト
+
 [URL]
 
 ```
@@ -2809,27 +3078,30 @@ Content-Type: multipart/form-data
 
 [Path parameter]
 
-| 値 | タイプ | 説明 |
-|---|---|---|
-| appkey       | String | 固有のアプリキー |
+| 名前     | 	タイプ     | 	説明     |
+|--------|---------|---------|
+| appkey | 	String | 	固有のアプリキー |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
-| 値    | タイプ | 必須 | 説明                               |
-|---|---|---|---|
-| X-Secret-Key | String | O    | コンソールで作成できます。 |
+
+| 名前           | 	タイプ     | 	必須 | 	説明              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | コンソールで作成できます。 |
 
 [Request parameter]
 
-|値|	タイプ|	必須|	説明|
-|---|---|---|---|
-|file|	File|	O |	画像ファイル |
+| 名前   | 	タイプ   | 	必須 | 	説明     |
+|------|-------|-----|---------|
+| file | 	File | 	O  | 	画像ファイル |
 
 [例]
+
 ```
 curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/template-image" -F "file=@alimtalk-template-image.jpeg"
 ```
@@ -2837,12 +3109,13 @@ curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}
 <a id="response-22"></a>
 
 #### レスポンス
+
 ```
 {
-  "header" : {
-    "resultCode" :  Integer,
-    "resultMessage" :  String,
-    "isSuccessful" :  boolean
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
   },
   "templateImage" {
     "templateImageName": String,
@@ -2851,112 +3124,366 @@ curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}
 }
 ```
 
-| 値            | タイプ | 説明                               |
-| -------------------- | ------- | ---------------------------------------- |
-| header               | Object  | ヘッダ領域                            |
-| - resultCode         | Integer | 結果コード                            |
-| - resultMessage      | String  | 結果メッセージ                           |
-| - isSuccessful       | Boolean | 成否                             |
-| templateImage         |	Object |	本文領域|
-|- templateImageName    | String |	画像名（アップロードされたファイル名） |
-|- templateImageUrl     | String |	画像のURL |
+| 名前                  | タイプ      | Not Null | 説明             |
+|---------------------|---------|:--------:|----------------|
+| header              | Object  |    O     | ヘッダ領域          |
+| - resultCode        | Integer |    O     | 結果コード          |
+| - resultMessage     | String  |    O     | 結果メッセージ         |
+| - isSuccessful      | Boolean |    O     | 成否          |
+| templateImage       | Object  |    X     | 本文領域          |
+| - templateImageName | String  |    X     | 画像名（アップロードしたファイル名） |
+| - templateImageUrl  | String  |    X     | 画像 URL        |
 
 <a id="register-template-item-highlight-images"></a>
 
-### 템플릿 아이템 하이라이트 이미지 등록
-
-<!-- TODO: translate body -->
+### テンプレートアイテムハイライト画像登録
 
 <a id="request-22"></a>
 
-#### 요청
+#### リクエスト
 
-<!-- TODO: translate body -->
+[URL]
+
+```
+POST  /alimtalk/v2.3/appkeys/{appkey}/template-image/item-highlight
+Content-Type: multipart/form-data
+```
+
+[Path parameter]
+
+| 名前     | 	タイプ     | 	説明     |
+|--------|---------|---------|
+| appkey | 	String | 	固有のアプリキー |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前           | 	タイプ     | 	必須 | 	説明              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | コンソールで作成できます。 |
+
+[Request parameter]
+
+| 名前   | 	タイプ   | 	必須 | 	説明     |
+|------|-------|-----|---------|
+| file | 	File | 	O  | 	画像ファイル |
+
+[例]
+
+```
+curl -X POST -H "Content-Type: multipart/form-data" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/template-image/item-highlight" -F "file=@alimtalk-template-image.jpeg"
+```
 
 <a id="response-23"></a>
 
-#### 응답
+#### レスポンス
 
-<!-- TODO: translate body -->
+```
+{
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
+  },
+  "templateImage" {
+    "templateImageName": String,
+    "templateImageUrl": String
+  }
+}
+```
+
+| 名前                  | タイプ      | Not Null | 説明             |
+|---------------------|---------|:--------:|----------------|
+| header              | Object  |    O     | ヘッダー領域          |
+| - resultCode        | Integer |    O     | 結果コード          |
+| - resultMessage     | String  |    O     | 結果メッセージ         |
+| - isSuccessful      | Boolean |    O     | 成否          |
+| templateImage       | Object  |    X     | 本文領域          |
+| - templateImageName | String  |    X     | 画像名（アップロードしたファイル名） |
+| - templateImageUrl  | String  |    X     | 画像 URL        |
 
 <a id="register-template-plugin"></a>
 
-### 템플릿 플러그인 등록
-
-<!-- TODO: translate body -->
+### テンプレートプラグイン登録
 
 <a id="request-23"></a>
 
-#### 요청
+#### リクエスト
 
-<!-- TODO: translate body -->
+[URL]
+
+```
+POST  /alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/plugins
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 名前        | 	タイプ   | 	説明      |
+|-----------|---------|---------|
+| appkey    | 	String | 	アプリキー  |
+| senderKey | 	String | 	発信キー   |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前           | 	タイプ   | 	必須 | 	説明                  |
+|--------------|---------|-----|----------------------|
+| X-Secret-Key | 	String | O   | コンソールで生成できます。 |
+
+[Request Body]
+
+```
+{
+  "pluginType": String,
+  "pluginId": String,
+  "callbackUrl": String
+}
+```
+
+| 名前          | 	タイプ   | 	必須 | 	説明                                                                      |
+|-------------|---------|-----|--------------------------------------------------------------------------|
+| pluginType  | 	String | 	O  | プラグインタイプ (SECURE_IMAGE: セキュリティ画像送信、ONE_TIME_PROFILE: 個人情報利用) |
+| pluginId    | 	String | 	O  | プラグイン ID                                                                 |
+| callbackUrl | 	String | 	O  | プラグインボタンクリック時に受信するコールバック URL                                           |
 
 <a id="response-24"></a>
 
-#### 응답
+#### レスポンス
 
-<!-- TODO: translate body -->
+```
+{
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
+  }
+}
+```
+
+| 名前              | タイプ     | Not Null | 説明       |
+|-----------------|---------|:--------:|----------|
+| header          | Object  |    O     | ヘッダー領域   |
+| - resultCode    | Integer |    O     | 結果コード    |
+| - resultMessage | String  |    O     | 結果メッセージ  |
+| - isSuccessful  | Boolean |    O     | 成功かどうか   |
 
 <a id="modify-template-plugin"></a>
 
-### 템플릿 플러그인 수정
-
-<!-- TODO: translate body -->
+### テンプレートプラグインの修正
 
 <a id="request-24"></a>
 
-#### 요청
+#### リクエスト
 
-<!-- TODO: translate body -->
+[URL]
+
+```
+PUT  /alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/plugins/{pluginId}
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 名前        | 	タイプ     | 	説明          |
+|-----------|---------|--------------|
+| appkey    | 	String | 	固有のアプリキー    |
+| senderKey | 	String | 	発信キー        |
+| pluginId  | 	String | 	プラグイン ID    |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前           | 	タイプ     | 	必須 | 	説明                  |
+|--------------|---------|-----|----------------------|
+| X-Secret-Key | 	String | O   | コンソールで作成できます。 |
+
+[Request Body]
+
+```
+{
+  "pluginType": String,
+  "callbackUrl": String
+}
+```
+
+| 名前          | 	タイプ     | 	必須 | 	説明                                                                              |
+|-------------|---------|-----|----------------------------------------------------------------------------------|
+| pluginType  | 	String | 	O  | プラグインタイプ (SECURE_IMAGE: セキュリティ画像送信、ONE_TIME_PROFILE: 個人情報利用) |
+| callbackUrl | 	String | 	O  | プラグインボタンクリック時に受信するコールバック URL                                     |
 
 <a id="response-25"></a>
 
-#### 응답
+#### レスポンス
 
-<!-- TODO: translate body -->
+```
+{
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
+  }
+}
+```
+
+| 名前              | タイプ      | Not Null | 説明       |
+|-----------------|---------|:--------:|----------|
+| header          | Object  |    O     | ヘッダー領域   |
+| - resultCode    | Integer |    O     | 結果コード    |
+| - resultMessage | String  |    O     | 結果メッセージ  |
+| - isSuccessful  | Boolean |    O     | 成否       |
 
 <a id="modify-template-plugin-2"></a>
 
-### 템플릿 플러그인 삭제
-
-<!-- TODO: translate body -->
+### テンプレートプラグイン削除
 
 <a id="request-25"></a>
 
-#### 요청
+#### リクエスト
 
-<!-- TODO: translate body -->
+[URL]
+
+```
+DELETE  /alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/plugins/{pluginId}
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 名前        | 	タイプ   | 	説明          |
+|-----------|---------|--------------|
+| appkey    | 	String | 	固有のアプリキー    |
+| senderKey | 	String | 	発信キー        |
+| pluginId  | 	String | 	プラグイン ID |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前           | 	タイプ   | 	必須 | 	説明                  |
+|--------------|---------|-----|----------------------|
+| X-Secret-Key | 	String | O   | コンソールで作成できます。 |
 
 <a id="response-26"></a>
 
-#### 응답
+#### レスポンス
 
-<!-- TODO: translate body -->
+```
+{
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
+  }
+}
+```
+
+| 名前              | タイプ     | Not Null | 説明       |
+|-----------------|---------|:--------:|----------|
+| header          | Object  |    O     | ヘッダー領域   |
+| - resultCode    | Integer |    O     | 結果コード    |
+| - resultMessage | String  |    O     | 結果メッセージ  |
+| - isSuccessful  | Boolean |    O     | 成功かどうか   |
 
 <a id="retrieve-template-plugin"></a>
 
-### 템플릿 플러그인 조회
-
-<!-- TODO: translate body -->
+### テンプレートプラグイン照会
 
 <a id="request-26"></a>
 
-#### 요청
+#### リクエスト
 
-<!-- TODO: translate body -->
+[URL]
+
+```
+PUT  /alimtalk/v2.3/appkeys/{appkey}/senders/{senderKey}/plugins
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 名前        | 	タイプ     | 	説明     |
+|-----------|---------|---------|
+| appkey    | 	String | 	固有のアプリキー |
+| senderKey | 	String | 	発信キー   |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前           | 	タイプ     | 	必須 | 	説明              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | コンソールで作成できます。 |
 
 <a id="response-27"></a>
 
-#### 응답
+#### レスポンス
 
-<!-- TODO: translate body -->
+```
+{
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
+  },
+  "plugins": [
+    {
+      "pluginId": String,
+      "pluginType": String,
+      "pluginTypeName": String,
+      "callbackUrl": String,
+      "modifiable": boolean,
+      "deletable": boolean
+    }
+  
+  ]
+}
+```
+
+| 名前               | タイプ      | Not Null | 説明                                                         |
+|------------------|---------|:--------:|------------------------------------------------------------|
+| header           | Object  |    O     | ヘッダー領域                                                      |
+| - resultCode     | Integer |    O     | 結果コード                                                      |
+| - resultMessage  | String  |    O     | 結果メッセージ                                                     |
+| - isSuccessful   | Boolean |    O     | 成否                                                      |
+| plugins          | List    |    X     | プラグインリスト                                                   |
+| - pluginId       | String  |    X     | プラグイン ID                                                   |
+| - pluginType     | String  |    X     | プラグインタイプ（SECURE_IMAGE: セキュリティ画像送信、ONE_TIME_PROFILE: 個人情報利用） |
+| - pluginTypeName | String  |    X     | プラグイン名                                                    |
+| - callbackUrl    | String  |    X     | プラグインボタンクリック時に受信するコールバック URL                                  |
+| - modifiable     | Boolean |    X     | 修正可否                                                   |
+| - deletable      | Boolean |    X     | 削除可否                                                   |
 
 <a id="manage-alternative-delivery"></a>
 
 ## 代替送信管理
+
 <a id="register-an-sms-appkey"></a>
 
-### SMS AppKey登録
+### SMS AppKey 登録
 
 [URL]
 
@@ -2967,21 +3494,21 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 値    | タイプ | 説明 |
-| ------------ | ------ | -------- |
-| appkey       | String | 固有のアプリキー |
+| 名前     | 	タイプ     | 	説明     |
+|--------|---------|---------|
+| appkey | 	String | 	固有のアプリキー |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
 
-| 値    | タイプ | 必須 | 説明                               |
-| ------------ | ------ | ---- | ---------------------------------------- |
-| X-Secret-Key | String | O    | コンソールで作成できます。 |
-
+| 名前           | 	タイプ     | 	必須 | 	説明              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | コンソールで生成できます。 |
 
 [Request body]
 
@@ -2991,11 +3518,12 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 値    | タイプ | 必須 | 説明                               |
-|---|---|---|---|
-|resendAppKey|	String|	O | 代替発送に設定するSMS AppKey |
+| 名前           | 	タイプ     | 	必須 | 	説明                    |
+|--------------|---------|-----|------------------------|
+| resendAppKey | 	String | 	O  | 代替送信に設定する SMS サービスアプリキー |
 
 [例]
+
 ```
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/failback/appkey -d '{"resendAppKey": "smsAppKey"}
 ```
@@ -3003,16 +3531,24 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 <a id="response-28"></a>
 
 #### レスポンス
+
 ```
 
 {
-  "header" : {
-      "resultCode" :  Integer,
-      "resultMessage" :  String,
-      "isSuccessful" :  boolean
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
   }
 }
 ```
+
+| 名前              | タイプ      | Not Null | 説明     |
+|-----------------|---------|:--------:|--------|
+| header          | Object  |    O     | ヘッダー領域  |
+| - resultCode    | Integer |    O     | 結果コード  |
+| - resultMessage | String  |    O     | 結果メッセージ |
+| - isSuccessful  | Boolean |    O     | 成否  |
 
 <a id="register-alternative-delivery-settings"></a>
 
@@ -3027,52 +3563,62 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 値    | タイプ | 説明 |
-| ------------ | ------ | -------- |
-| appkey       | String | 固有のアプリキー |
+| 名前     | 	タイプ     | 	説明     |
+|--------|---------|---------|
+| appkey | 	String | 	固有のアプリキー |
 
 [Header]
+
 ```
 {
   "X-Secret-Key": String
 }
 ```
 
-| 値    | タイプ | 必須 | 説明                               |
-| ------------ | ------ | ---- | ---------------------------------------- |
-| X-Secret-Key | String | O    | コンソールで作成できます。 |
+| 名前           | 	タイプ     | 	必須 | 	説明              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | コンソールで生成できます。 |
 
 [Request body]
 
 ```
 {  
-   "plusFriendId": String,
+   "senderKey": String,
    "isResend": Boolean,
    "resendSendNo": String
 }
 ```
 
-| 値               | タイプ | 必須 | 説明                                |
-| ---------------------- | ------- | ---- | ---------------------------------------- |
-| plusFriendId           | String  | O    | プラスフレンドID(最大30文字)                         |
-| isResend             | boolean | O    | 送信失敗時、代替送信するかどうか<br>コンソールで送信失敗設定をした時、デフォルト設定は再送信になっています。 |
-| resendSendNo         | String  | O    | 代替送信発信番号(最大13桁)<br><span style="color:red">(SMSサービスに登録された発信番号ではない場合、代替送信が失敗することがあります。)</span> |
+| 名前           | 	タイプ      | 	必須 | 	説明                                                                                       |
+|--------------|----------|-----|-------------------------------------------------------------------------------------------|
+| senderKey    | 	String  | 	O  | 発信キー                                                                                      |
+| isResend     | 	Boolean | 	O  | 送信失敗時、SMS 代替送信を行うかどうか<br>コンソールで代替送信設定時、デフォルトで代替送信されます。                          |
+| resendSendNo | 	String  | 	O  | 代替送信の発信番号<br><span style="color:red">(SMS サービスに登録された発信番号でない場合、代替送信が失敗する可能性があります。)</span> |
 
 [例]
+
 ```
-curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/failback/appkey -d '{"plusFriendId": "@プラスフレンド","isResend": true,"resendSendNo": "01012341234" }
+curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/failback/appkey -d '{"senderKey": "0be23c29de88d6888798aeda57062516354d74ba","isResend": true,"resendSendNo": "01012341234" }
 ```
 
 <a id="response-29"></a>
 
 #### レスポンス
+
 ```
 
 {
-  "header" : {
-      "resultCode" :  Integer,
-      "resultMessage" :  String,
-      "isSuccessful" :  boolean
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
   }
 }
 ```
+
+| 名前              | タイプ      | Not Null | 説明     |
+|-----------------|---------|:--------:|--------|
+| header          | Object  |    O     | ヘッダー領域  |
+| - resultCode    | Integer |    O     | 結果コード  |
+| - resultMessage | String  |    O     | 結果メッセージ |
+| - isSuccessful  | Boolean |    O     | 成否  |

--- a/ja/alimtalk-api-guide.md
+++ b/ja/alimtalk-api-guide.md
@@ -551,6 +551,8 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | RSC04 | 再送信成功                  |
 | RSC05 | 再送信失敗                  |
 
+<a id="get-messages"></a>
+
 ### メッセージ単件照会
 
 <a id="request-2"></a>
@@ -885,50 +887,6 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","templateParameter":{"{日本語識別子フィールド}":"{置換データ}"}}]}'
 ```
 
-#### レスポンス
-
-```
-{
-  "header": {
-      "resultCode": Integer,
-      "resultMessage": String,
-      "isSuccessful": boolean
-  },
-  "messages": [
-    {
-      "requestId": String,
-      "recipientSeq": Integer,
-      "requestDate": String,
-      "createDate": String,
-      "receiveDate": String,
-      "resendStatus": String,
-      "resendStatusName": String,
-      "resendResultCode": String,
-      "resendRequestId": String,
-      "messageStatus": String,
-      "resultCode": String,
-      "resultCodeName": String
-    }
-  ]
-}
-```
-
-| 値                | タイプ | 説明    |
-| ----------------------- | ------- | ------------ |
-| header                  | Object  | ヘッダ領域 |
-| - resultCode            | Integer | 結果コード |
-| - resultMessage         | String  | 結果メッセージ |
-| - isSuccessful          | Boolean | 成否  |
-| message                 | Object  | 本文領域 |
-| - requestId             | String  | リクエストID        |
-| - senderGroupingKey     | String  | 発信グルーピングキー |
-| - sendResults           | Object  | 送信リクエスト結果 |
-| -- recipientSeq         | Integer | 受信者シーケンス番号 |
-| -- recipientNo          | String  | 受信番号 |
-| -- resultCode           | Integer | 送信リクエスト結果コード |
-| -- resultMessage        | String  | 送信リクエスト結果メッセージ |
-| -- recipientGroupingKey | String  | 受信者グルーピングキー |
-
 <a id="request-of-sending-full-text-2"></a>
 
 ### メッセージ全文送信リクエスト
@@ -1045,56 +1003,11 @@ Content-Type: application/json;charset=UTF-8
 curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/raw-messages -d '{"senderKey":"{発信キー}","templateCode":"{テンプレートコード}","requestDate":"2018-10-01 00:00","recipientList":[{"recipientNo":"{受信番号}","content":"{内容}","buttons":[{"ordering":"{ボタン順序}","type":"{ボタンタイプ}","name":"{ボタン名}","linkMo":"{モバイルWebリンク}"}]}]}'
 ```
 
-#### レスポンス
-
-```
-{
-  "header": {
-    "resultCode": Integer,
-    "resultMessage": String,
-    "isSuccessful": boolean
-  },
-  "body": {
-    "messages": [
-      {
-        "requestId": String,
-        "requestDate": String,
-        "plusFriendId": String,
-        "senderKey": String,
-        "templateCode": String,
-        "masterStatusCode": String,
-        "content": String,
-        "fileId": String,
-        "autoSendYn": String,
-        "statsId": String,
-        "createDate": String,
-        "createUser": String
-      }
-    ],
-    "totalCount": Integer
-  }
-}
-```
-
-| 値                | タイプ | 説明    |
-| ----------------------- | ------- | ------------ |
-| header                  | Object  | ヘッダ領域 |
-| - resultCode            | Integer | 結果コード |
-| - resultMessage         | String  | 結果メッセージ |
-| - isSuccessful          | Boolean | 成否  |
-| message                 | Object  | 本文領域 |
-| - requestId             | String  | リクエストID        |
-| - senderGroupingKey     | String  | 発信グルーピングキー |
-| - sendResults           | Object  | 送信リクエスト結果 |
-| -- recipientSeq         | Integer | 受信者シーケンス番号 |
-| -- recipientNo          | String  | 受信番号 |
-| -- resultCode           | Integer | 送信リクエスト結果コード |
-| -- resultMessage        | String  | 送信リクエスト結果メッセージ |
-| -- recipientGroupingKey | String  | 受信者グルーピングキー |
-
 <a id="list-messages-2"></a>
 
 ### メッセージリストの照会
+
+<a id="request-3"></a>
 
 #### リクエスト
 
@@ -1143,164 +1056,6 @@ Content-Type: application/json;charset=UTF-8
 
 * 90日以上前の送信リクエストデータは照会されません。
 * 送信リクエスト日時の範囲は最大30日です。
-
-#### レスポンス
-```
-{
-  "header" : {
-      "resultCode" :  Integer,
-      "resultMessage" :  String,
-      "isSuccessful" :  boolean
-  },
-  "messageSearchResultResponse" : {
-    "messages" : [
-    {
-      "requestId" :  String,
-      "recipientSeq" : Integer,
-      "plusFriendId" :  String,
-      "senderKey"    :  String,
-      "templateCode" :  String,
-      "recipientNo" :  String,
-      "content" :  String,
-      "requestDate" :  String,
-      "createDate" : String,
-      "receiveDate" : String,
-      "resendStatus" :  String,
-      "resendStatusName" :  String,
-      "messageStatus" :  String,
-      "resultCode" :  String,
-      "resultCodeName" : String,
-      "createUser" : String,
-      "buttons" : [
-        {
-          "ordering" :  Integer,
-          "type" :  String,
-          "name" :  String,
-          "linkMo" :  String,
-          "linkPc": String,
-          "schemeIos": String,
-          "schemeAndroid": String,
-          "chatExtra": String,
-          "chatEvent": String,
-          "target": String
-        }
-      ],
-      "senderGroupingKey": String,
-      "recipientGroupingKey": String
-    }
-    ],
-    "totalCount" :  Integer
-  }
-}
-```
-
-| 値                   | タイプ | 説明                               |
-| --------------------------- | ------- | ---------------------------------------- |
-| header                      | Object  | ヘッダ領域                            |
-| - resultCode                | Integer | 結果コード                            |
-| - resultMessage             | String  | 結果メッセージ                           |
-| - isSuccessful              | Boolean | 成否                             |
-| messageSearchResultResponse | Object  | 本文領域                            |
-| - messages                  | List    | メッセージリスト                           |
-| -- requestId                | String  | リクエストID                                    |
-| -- recipientSeq             | Integer | 受信者シーケンス番号                       |
-| -- plusFriendId             | String  | プラスフレンドID                                 |
-| -- senderKey                | String  | 発信キー                                  |
-| -- templateCode             | String  | テンプレートコード                           |
-| -- recipientNo              | String  | 受信番号                            |
-| -- content                  | String  | 本文                               |
-| -- requestDate              | String  | リクエスト日時                            |
-| -- createDate               | String  | 登録日時                            |
-| -- receiveDate              | String  | 受信日時                            |
-| -- resendStatus             | String  | 再送信ステータスコード                        |
-| -- resendStatusName         | String  | 再送信ステータスコード名                        |
-| -- messageStatus            | String  | リクエストステータス(COMPLETED -> 成功、FAILED -> 失敗、CANCEL -> キャンセル) |
-| -- resultCode               | String  | 受信結果コード                         |
-| -- resultCodeName           | String  | 受信結果コード名                         |
-| -- createUser               | String  | 登録者(コンソールから送信する場合、ユーザーUUIDとして保存)|
-| -- buttons                  | List    | ボタンリスト                            |
-| --- ordering                | Integer | ボタン順序                            |
-| --- type                    | String  | ボタンタイプ(WL：Webリンク、AL：アプリリンク、DS：配送照会、BK：Botキーワード、MD：メッセージ伝達、BC：相談トーク転換、BT：Bot転換、AC：チャンネル追加) |
-| --- name                    | String  | ボタン名                            |
-| --- linkMo                  | String  | モバイルWebリンク(WLタイプの場合は必須フィールド)                |
-| --- linkPc                  | String  | PC Webリンク(WLタイプの場合は任意フィールド)                 |
-| --- schemeIos               | String  | iOSアプリリンク(ALタイプの場合は必須フィールド)                |
-| --- schemeAndroid           | String  | Androidアプリリンク(ALタイプの場合は必須フィールド)            |
-| --- chatExtra               | String  | BC(相談トークに切替) / BT(Botに切替)タイプボタンの時、伝達するメタ情報 |
-| --- chatEvent               | String  | BT(Botに切替)タイプボタンの時、接続するBotイベント名 |
-| --- target                  | String  | Webリンクボタンの場合、 "target":"out"プロパティ追加時のアウトリンク<br>基本インアプリリンクで送信 |
-| -- senderGroupingKey        | String  | 発信グルーピングキー                            |
-| -- recipientGroupingKey     | String  | 受信者グルーピングキー                           |
-| - totalCount                | Integer | 総個数                              |
-
-[例]
-```
-curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/auth/messages?startRequestDate=2018-05-01%20:00&endRequestDate=2018-05-30%20:59"
-```
-
-### メッセージ結果アップデート件数の照会
-
-#### リクエスト
-
-[URL]
-
-```
-GET  /alimtalk/v2.3/appkeys/{appkey}/message-results/count
-Content-Type: application/json;charset=UTF-8
-```
-
-[Path parameter]
-
-| 名前    | 	タイプ    | 	説明    |
-|--------|---------|---------|
-| appkey | 	String | 	固有のアプリキー |
-
-[Header]
-
-```
-{
-  "X-Secret-Key": String
-}
-```
-
-| 名前          | 	タイプ    | 	必須 | 	説明             |
-|--------------|---------|-----|------------------|
-| X-Secret-Key |	String | O | コンソールで作成できます。 |
-
-[Query parameter]
-
-| 名前                 | 	タイプ     | 	必須 | 	説明                                |
-|---------------------|----------|-----|-------------------------------------|
-| startUpdateDate     | 	String  | 	O  | 結果アップデート照会開始時間(yyyy-MM-dd HH:mm)  |
-| endUpdateDate       | 	String  | O   | 	結果アップデート照会終了時間(yyyy-MM-dd HH:mm) |
-| alimtalkMessageType | 	String  | X   | 	お知らせトークのメッセージタイプ(NORMAL, AUTH)           |
-
-#### レスポンス
-
-```
-{
-  "header": {
-    "resultCode": Integer,
-    "resultMessage": String,
-    "isSuccessful": boolean
-  },
-  "totalCount": Integer
-}
-```
-
-| 名前             | タイプ     | Not Null | 説明    |
-|-----------------|---------|:--------:|--------|
-| header          | Object  |    O     | ヘッダ領域 |
-| - resultCode    | Integer |    O     | 結果コード |
-| - resultMessage | String  |    O     | 結果メッセージ |
-| - isSuccessful  | Boolean |    O     | 成否 |
-| totalCount      | Integer |    O     | 総件数  |
-
-[例]
-
-```
-curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/message-results/count?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
-```
 
 <a id="request-3"></a>
 

--- a/ja/alimtalk-api-guide.md
+++ b/ja/alimtalk-api-guide.md
@@ -1,4 +1,4 @@
-## Notification > KakaoTalk Bizmessage > 알림톡 > API v2.3 Guide
+## Notification > KakaoTalk Bizmessage > お知らせトーク > API v2.3 Guide
 
 <a id="alimtalk"></a>
 
@@ -976,7 +976,7 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 
 <a id="request-5"></a>
 
-#### 요청
+#### リクエスト
 
 [URL]
 
@@ -987,7 +987,7 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 이름        | 	타입     | 	설명     |
+| 名前        | 	タイプ     | 	説明     |
 |-----------|---------|---------|
 | appkey    | 	String | 	固有のアプリキー |
 | requestId | String  | リクエスト ID   |
@@ -1000,13 +1000,13 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 이름           | 	타입     | 	필수 | 	설명              |
+| 名前           | 	タイプ     | 	必須 | 	説明              |
 |--------------|---------|-----|------------------|
 | X-Secret-Key | 	String | O   | コンソールで作成できます。 |
 
 [Query parameter]
 
-| 이름           | 	타입     | 	필수 | 	설명                                         |
+| 名前           | 	タイプ     | 	必須 | 	説明                                         |
 |--------------|---------|-----|---------------------------------------------|
 | recipientSeq | 	String | 	X  | 受信者シーケンス番号<br>(入力しない場合、リクエスト ID のすべての送信件を取消) |
 
@@ -1014,7 +1014,7 @@ Content-Type: application/json;charset=UTF-8
 
 <a id="response-6"></a>
 
-#### 응답
+#### レスポンス
 
 ```
 {
@@ -1026,14 +1026,14 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 이름              | 타입      | Not Null | 설명     |
+| 名前              | タイプ      | Not Null | 説明     |
 |-----------------|---------|:--------:|--------|
 | header          | Object  |    O     | ヘッダー領域  |
 | - resultCode    | Integer |    O     | 結果コード  |
 | - resultMessage | String  |    O     | 結果メッセージ |
 | - isSuccessful  | Boolean |    O     | 成否  |
 
-[예시]
+[例]
 
 ```
 curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
@@ -1045,7 +1045,7 @@ curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Ke
 
 <a id="request-6"></a>
 
-#### 요청
+#### リクエスト
 
 [URL]
 
@@ -1056,7 +1056,7 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 이름     | 	타입     | 	설명     |
+| 名前     | 	タイプ     | 	説明     |
 |--------|---------|---------|
 | appkey | 	String | 	固有のアプリキー |
 
@@ -1068,13 +1068,13 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 이름           | 	타입     | 	필수 | 	설명              |
+| 名前           | 	タイプ     | 	必須 | 	説明              |
 |--------------|---------|-----|------------------|
 | X-Secret-Key | 	String | O   | コンソールで作成できます。 |
 
 [Query parameter]
 
-| 이름                  | 	타입      | 	필수 | 	설명                                 |
+| 名前                  | 	タイプ      | 	必須 | 	説明                                 |
 |---------------------|----------|-----|-------------------------------------|
 | startUpdateDate     | 	String  | 	O  | 結果アップデート照会開始時間(yyyy-MM-dd HH:mm)  |
 | endUpdateDate       | 	String  | O   | 	結果アップデート照会終了時間(yyyy-MM-dd HH:mm) |
@@ -1084,7 +1084,7 @@ Content-Type: application/json;charset=UTF-8
 
 <a id="response-7"></a>
 
-#### 응답
+#### レスポンス
 
 ```
 {
@@ -1112,7 +1112,7 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 이름                 | 타입      | Not Null | 설명                                                                                                                                                                     |
+| 名前                 | タイプ      | Not Null | 説明                                                                                                                                                                     |
 |--------------------|---------|:--------:|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | header             | Object  |    O     | ヘッダー領域                                                                                                                                                                  |
 | - resultCode       | Integer |    O     | 結果コード                                                                                                                                                                  |
@@ -1132,7 +1132,7 @@ Content-Type: application/json;charset=UTF-8
 | - resultCode       | String  |    X     | 受信結果コード                                                                                                                                                               |
 | - resultCodeName   | String  |    X     | 受信結果コード名                                                                                                                                                              |
 
-[예시]
+[例]
 
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/message-results?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
@@ -1144,7 +1144,7 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 
 <a id="request-7"></a>
 
-#### 요청
+#### リクエスト
 
 [URL]
 
@@ -1155,7 +1155,7 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 이름     | 	타입     | 	설명     |
+| 名前     | 	タイプ     | 	説明     |
 |--------|---------|---------|
 | appkey | 	String | 	固有のアプリキー |
 
@@ -1167,13 +1167,13 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 이름           | 	타입     | 	필수 | 	설명              |
+| 名前           | 	タイプ     | 	必須 | 	説明              |
 |--------------|---------|-----|------------------|
 | X-Secret-Key | 	String | O   | コンソールで作成できます。 |
 
 [Query parameter]
 
-| 이름                  | 	타입      | 	필수 | 	설명                                 |
+| 名前                  | 	タイプ      | 	必須 | 	説明                                 |
 |---------------------|----------|-----|-------------------------------------|
 | startUpdateDate     | 	String  | 	O  | 結果アップデート照会開始時間(yyyy-MM-dd HH:mm)  |
 | endUpdateDate       | 	String  | O   | 	結果アップデート照会終了時間(yyyy-MM-dd HH:mm) |
@@ -1181,7 +1181,7 @@ Content-Type: application/json;charset=UTF-8
 
 <a id="response-8"></a>
 
-#### 응답
+#### レスポンス
 
 ```
 {
@@ -1194,7 +1194,7 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 이름              | 타입      | Not Null | 설명     |
+| 名前              | タイプ      | Not Null | 説明     |
 |-----------------|---------|:--------:|--------|
 | header          | Object  |    O     | ヘッダー領域  |
 | - resultCode    | Integer |    O     | 結果コード  |
@@ -1202,7 +1202,7 @@ Content-Type: application/json;charset=UTF-8
 | - isSuccessful  | Boolean |    O     | 成否  |
 | totalCount      | Integer |    O     | 総件数   |
 
-[예시]
+[例]
 
 ```
 curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/alimtalk/v2.3/appkeys/{appkey}/message-results/count?startUpdateDate=2018-05-01%20:00&endUpdateDate=2018-05-30%20:59"
@@ -1212,7 +1212,7 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 
 ### SMS/LMS 代替送信ステータスコード
 
-| 이름    | 	설명                                  |
+| 名前    | 	説明                                  |
 |-------|--------------------------------------|
 | RSC01 | 	代替送信対象外                           |
 | RSC02 | 	代替送信対象(送信結果が失敗の場合、代替送信が進行されます。) |
@@ -1762,7 +1762,7 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 이름        | 	타입     | 	설명     |
+| 名前        | 	タイプ     | 	説明     |
 |-----------|---------|---------|
 | appkey    | 	String | 	固有のアプリキー |
 | senderKey | 	String | 	発信キー   |
@@ -1775,7 +1775,7 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 이름           | 	타입     | 	필수 | 	설명              |
+| 名前           | 	タイプ     | 	必須 | 	説明              |
 |--------------|---------|-----|------------------|
 | X-Secret-Key | 	String | O   | コンソールで作成できます。 |
 
@@ -2781,7 +2781,7 @@ curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{
 | -- kakaoTemplateCode     | String  |    O     | 元のテンプレートコード                                                                                                                                                              |
 | -- templateName          | String  |    O     | テンプレート名                                                                                                                                                                   |
 | -- templateMessageType   | String  |    X     | テンプレートメッセージタイプ (BA: 基本型、EX: 付加情報型、AD: チャンネル追加型、MI: 複合型)                                                                                                                   |
-| -- templateEmphasizeType | String  |    X     | テンプレート강조表記型タイプ (NONE: デフォルト、TEXT: 강조表示、IMAGE: 画像型、ITEM_LIST: アイテムリストタイプ)                                                                                                   |
+| -- templateEmphasizeType | String  |    X     | テンプレート強調表記型タイプ (NONE: デフォルト、TEXT: 強調表示、IMAGE: 画像型、ITEM_LIST: アイテムリストタイプ)                                                                                                   |
 | -- templateContent       | String  |    X     | テンプレート本文                                                                                                                                                                 |
 | -- templateExtra         | String  |    X     | テンプレート付加情報                                                                                                                                                              |
 | -- templateAd            | String  |    X     | テンプレート内の受信同意要求または簡単な広告文                                                                                                                                            |

--- a/ja/friendtalkupgrade-api-guide.md
+++ b/ja/friendtalkupgrade-api-guide.md
@@ -6,31 +6,31 @@
 
 <a id="api-domain"></a>
 
-#### [APIドメイン]
+#### [API ドメイン]
 
-| ドメイン                                                                        |
+| ドメイン                                                                          |
 |------------------------------------------------------------------------------|
 | [https://kakaotalk-bizmessage.api.nhncloudservice.com](https://kakaotalk-bizmessage.api.nhncloudservice.com) |
 
 <a id="introduce-v10-api"></a>
 
-## v1.0 API紹介
+## v1.0 API 紹介
 
 <a id="manage-non-friend-message-sending-targeting-m-n"></a>
 
-## 非友だちメッセージ送信(ターゲティングM、N)管理
+## 非フレンドメッセージ送信（ターゲティング M、N）管理
 
-非友だちメッセージ送信(ターゲティングM、N)は、以下の条件を全て満たす場合に送信できます。
+非フレンドメッセージ送信（ターゲティング M、N）は、以下の条件をすべて満たす場合に送信できます。
 
 - ビジネス認証チャンネル
-  - 事業者番号の登録
-  - チャンネルカスタマーセンターの電話番号登録
-  - チャンネルの友だち数が5万以上
-  - 3か月以内にお知らせトークの送信成功履歴を保有
+- 事業者番号の登録
+- チャンネルカスタマーセンター電話番号の登録
+- チャンネルフレンド数 5万以上
+- 3か月以内にお知らせトークの送信成功履歴があること
 
 <a id="upload-marketing-consent-records"></a>
 
-### マーケティング受信同意の証明資料のアップロード
+### マーケティング受信同意証跡資料のアップロード
 
 <a id="requested"></a>
 
@@ -45,10 +45,10 @@ Content-Type: multipart/form-data
 
 [Path parameter]
 
-| 名前      | タイプ   | 説明   |
-|-----------|--------|--------|
-| appkey    | String | 固有のアプリキー |
-| senderKey | String | 発信キー |
+| 名前        | タイプ    | 説明          |
+|-----------|--------|-------------|
+| appkey    | String | 固有のアプリキー    |
+| senderKey | String | 発信キー        |
 
 [Header]
 
@@ -58,15 +58,15 @@ Content-Type: multipart/form-data
 }
 ```
 
-| 名前         | タイプ   | 必須 | 説明             |
+| 名前           | タイプ    | 必須 | 説明               |
 |--------------|--------|----|------------------|
-| X-Secret-Key | String | O  | コンソールで作成できます。 |
+| X-Secret-Key | String | O  | コンソールで生成できます。 |
 
 [Request parameter]
 
-| 名前 | タイプ | 必須 | 説明          |
-|------|------|----|---------------|
-| file | File | O | マーケティング受信同意の証明資料 |
+| 名前   | タイプ  | 必須 | 説明                    |
+|------|------|----|----------------------|
+| file | File | O  | マーケティング受信同意証跡資料 |
 
 <a id="response"></a>
 
@@ -82,16 +82,16 @@ Content-Type: multipart/form-data
 }
 ```
 
-| 名前            | タイプ    | Not Null | 説明   |
-|:----------------|:--------|:---------|:-------|
-| header          | Object  | O        | ヘッダ領域 |
-| - resultCode    | Integer | O        | 結果コード |
-| - resultMessage | String  | O        | 結果メッセージ |
-| - isSuccessful  | boolean | O        | 成否 |
+| 名前              | タイプ     | Not Null | 説明       |
+|:----------------|:--------|:---------|:---------|
+| header          | Object  | O        | ヘッダー領域   |
+| - resultCode    | Integer | O        | 結果コード    |
+| - resultMessage | String  | O        | 結果メッセージ  |
+| - isSuccessful  | boolean | O        | 成功かどうか   |
 
 <a id="apply-for-using-non-friend-message-sending-targeting-m-n"></a>
 
-### 非友だちメッセージ送信(ターゲティングM、N)の使用申請
+### 非フレンドメッセージ送信（ターゲティング M、N）の利用申請
 
 <a id="requested-2"></a>
 
@@ -106,10 +106,10 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 名前      | タイプ   | 説明   |
-|-----------|--------|--------|
+| 名前        | タイプ    | 説明       |
+|-----------|--------|----------|
 | appkey    | String | 固有のアプリキー |
-| senderKey | String | 発信キー |
+| senderKey | String | 発信キー     |
 
 [Header]
 
@@ -119,9 +119,9 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前         | タイプ   | 必須 | 説明             |
+| 名前           | タイプ    | 必須 | 説明               |
 |--------------|--------|----|------------------|
-| X-Secret-Key | String | O  | コンソールで作成できます。 |
+| X-Secret-Key | String | O  | コンソールで生成できます。 |
 
 <a id="response-2"></a>
 
@@ -137,36 +137,36 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前            | タイプ    | Not Null | 説明   |
-|:----------------|:--------|:---------|:-------|
-| header          | Object  | O        | ヘッダ領域 |
-| - resultCode    | Integer | O        | 結果コード |
-| - resultMessage | String  | O        | 結果メッセージ |
-| - isSuccessful  | boolean | O        | 成否 |
+| 名前              | タイプ     | Not Null | 説明       |
+|:----------------|:--------|:---------|:---------|
+| header          | Object  | O        | ヘッダー領域   |
+| - resultCode    | Integer | O        | 結果コード    |
+| - resultMessage | String  | O        | 結果メッセージ  |
+| - isSuccessful  | boolean | O        | 成功かどうか   |
 
 <a id="request-to-send-a-free-form-message"></a>
 
-## メッセージ自由形送信リクエスト
+## メッセージ自由形式送信リクエスト
 
-* マーケティング受信同意ユーザーへの送信を利用できます。
-  * targetingフィールドを指定して、メッセージ対象のタイプを指定できます。
-        * M: 顧客企業の広告性情報受信に同意したユーザー(カカオトークでの受信に同意)
-        * N: 顧客企業の広告性情報受信に同意したユーザー(カカオトークでの受信に同意) - チャネルの友だち
-        * I: 顧客企業の送信リクエスト対象 ∩ チャネルの友だち
-* 従来のカカともへのメッセージの8つのメッセージタイプを全て使用できます。
-* BT、ACボタンタイプを使用できます。
-* AC(チャンネル追加)ボタンの使用時、以下の制約事項があります。
-    * 強調型ボタン(黄色)で表記されます。
-    * ボタンが複数ある場合、指定された位置で使用する必要があります。
-        * TEXT、IMAGE：最初のボタン(最上段)
-        * その他：2番目のボタン(右側)
-    * ボタン名(name)は「チャンネル追加」に固定されます。
-    * カルーセル型は、カルーセル全体を通して1つのみ使用可能です。
-    * ターゲティングM、Nのみ使用可能です。
-* BFボタンの使用時、カカオから発行されたビジネスフォームIDを入力して使用できます。
-* 代替送信は、受信者ごとにresendParameterを介して設定できます。
-* 代替送信をご利用になる場合、代替送信管理APIを介してSMS AppKeyの登録及び送信設定が必要です。
-* **夜間送信制限(20:50～翌日08:00)**
+* マーケティング受信同意送信を使用できます。
+    * targeting フィールドを指定してメッセージ対象のタイプを指定できます。
+        * M: 顧客企業の広告性情報受信同意ユーザー（カカオトーク受信同意）
+        * N: 顧客企業の広告性情報受信同意ユーザー（カカオトーク受信同意）- チャンネルフレンド
+        * I: 顧客企業の送信リクエスト対象 ∩ チャンネルフレンド
+* 既存のフレンドトークの8種類のメッセージタイプをすべて使用できます。
+* BT、AC ボタンタイプを使用できます。
+* AC（チャンネル追加）ボタンを使用する場合、次の制約事項があります。
+    * 強調型ボタン（黄色）として表示されます。
+    * ボタンが複数ある場合は、指定された位置に配置する必要があります。
+        * TEXT、IMAGE: 最初のボタン（最上部）
+        * その他: 2番目のボタン（右側）
+    * ボタン名（name）は「채널 추가」に固定されます。
+    * カルーセル型は全カルーセルを通じて1つのみ使用できます。
+    * ターゲティング M、N のみ使用できます。
+* BF ボタンを使用する場合、カカオから発行されたビジネスフォーム ID を入力して使用できます。
+* 代替送信は受信者ごとの resendParameter で設定できます。
+    * 代替送信を利用する場合、代替送信管理 API で SMS AppKey の登録および送信設定が必要です。
+* **夜間送信制限（20:50〜翌日 08:00）**
 
 <a id="requested-3"></a>
 
@@ -181,8 +181,8 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 名前   | タイプ   | 説明   |
-|--------|--------|--------|
+| 名前     | タイプ     | 説明         |
+|--------|--------|------------|
 | appkey | String | 固有のアプリキー |
 
 [Header]
@@ -193,8 +193,8 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前         | タイプ   | 必須 | 説明             |
-|--------------|--------|----|------------------|
+| 名前           | タイプ     | 必須 | 説明                   |
+|--------------|--------|----|----------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
 
 <a id="request-text-type-sending"></a>
@@ -208,6 +208,9 @@ Content-Type: application/json;charset=UTF-8
   "senderKey": String,
   "chatBubbleType": "TEXT",
   "pushAlarm": boolean,
+  "requestDate": String,
+  "unsubscribeNo": String,
+  "unsubscribeAuthNo": String,
   "adult": boolean,
   "content": String,
   "buttons": [
@@ -241,54 +244,68 @@ Content-Type: application/json;charset=UTF-8
           "resendContent": String,
           "resendSendNo": String,
           "resendUnsubscribeNo": String
-      }
+      },
+      "targeting": String,
+      "unsubscribeNo": String,
+      "unsubscribeAuthNo": String,
+      "recipientGroupingKey": String, 
     }
   ],
+  "senderGroupingKey": String,
+  "resellerCode": String,
   "createUser": String,
   "statsId": String
 }
 ```
 
-| 名前                   | タイプ    | 必須 | 説明                                                                                                                                                                                                                                                                          |
+| 名前 | タイプ | 必須 | 説明 |
 |------------------------|---------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| senderKey              | String  | O  | 発信キー(40文字). グループ発信キーは使用不可                                                                                                                                                                                                                                                     |
-| chatBubbleType         | String  | O  | メッセージタイプ(TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)                                                                                                                                                                         |
-| pushAlarm | boolean | X | メッセージプッシュ通知の送信有無(デフォルト: true) |
-| adult                  | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                                                                       |
-| unsubscribeAuthNo | String | X | 080無料受信拒否の認証番号(全て未入力の場合は送信プロフィールに登録された無料受信拒否情報で送信されます)<br>unsubscribeNoなしでunsubscribeAuthNoのみの入力不可<br>例: 1234 |
-| content | String | O | - TEXTタイプの場合、最大1,300文字(改行:最大99個、URL形式の入力が可能)<br>- IMAGEタイプの場合、最大400文字(改行:最大29回、URL形式の入力が可能)<br>- WIDEタイプの場合、最大76文字(改行:最大1回)<br>- PREMIUM_VIDEOタイプの場合、このフィールドをオプションとして使用可能。最大76文字(改行:最大1回)<br>- その他のタイプの場合、このフィールドは使用しません |
-| buttons | List | X | ボタンリスト<br>- TEXT、IMAGEタイプの場合、クーポン適用時は最大4件、それ以外は最大5件<br>- WIDE、WIDE_ITEM_LISTタイプの場合、最大2件<br>- PREMIUM_VIDEOタイプの場合、最大1件<br>- COMMERCEタイプの場合、最小1件、最大2件 |
-| - name | String | O | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字 |
-| - type | String | O | ボタンタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- BTタイプはカカオオープンビルダーのチャットボットを使用するチャンネルのみ利用可能<br>- BFタイプは最初のボタンとしてのみ使用でき、nameには以下の3つのフレーズのみ使用可能<br> - トークで予約する<br> - トークでアンケートする<br> - トークで応募する |
-| - linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド)、1,000文字制限 |
-| - linkPc | String | X | PCWebリンク(WLタイプの場合、任意フィールド)、1,000文字制限 |
-| - schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限 |
-| - schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限 |
-| - chatExtra | String | X | BTタイプのボタンの場合、伝達するメタ情報 |
-| - chatEvent | String | X | BTタイプのボタンの場合、連携するボットイベント名 |
-| - bizFormKey | String | X | BFタイプのボタンの場合、ビズフォームキー |
-| coupon                 | Object  | X  | クーポン要素                                                                                                                                                                                                                                                                       |
-| - title | String | O | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」 |
-| - description | String | O | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字。改行:不可<br>- その他のタイプの場合、最大12文字。改行:不可 |
-| - linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
-| - linkPc | String | X | PCWebリンク(WLタイプの場合、任意フィールド)、1,000文字制限 |
-| - schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
-| - schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
-| recipientList          | List    | O  | 受信者リスト(最大1,000人)                                                                                                                                                                                                                                                             |
-| - recipientNo          | String  | O  | 受信番号                                                                                                                                                                                                                                                                       |
-| - resendParameter      | Object  | X  | 代替送信情報                                                                                                                                                                                                                                                                    |
-| -- isResend | boolean | X | 送信に失敗した場合、メッセージを代替送信するかどうか<br>コンソールで代替送信を設定した場合、基本設定として代替送信されます。 |
-| -- resendType | String | X | 代替送信タイプ(SMS、LMS)<br>値がない場合、テンプレート本文の長さに応じてタイプが区分されます。 |
-| -- resendTitle | String | X | LMS代替送信の件名<br>(値がない場合、プラスフレンドIDで代替送信されます。) |
-| -- resendContent | String | X | 代替送信の内容<br>(値がない場合、[メッセージ本文]で代替送信されます。) |
-| -- resendSendNo | String | X | 代替送信の送信者番号<br><span style="color:red">(SMSサービスに登録されている送信者番号ではない場合、代替送信に失敗することがあります。)</span> |
-| -- resendUnsubscribeNo | String | X | 代替送信080受信拒否番号<br><span style="color:red">(SMSサービスに登録された080受信拒否番号ではない場合、代替送信に失敗することがあります。)</span> |
-| createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
-| statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
+| senderKey | String | O | 発信キー（40文字）。グループ発信キーは使用不可 |
+| chatBubbleType | String | O | メッセージタイプ（TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE） |
+| pushAlarm | boolean | X | メッセージのプッシュ通知送信有無（デフォルト値: true） |
+| requestDate | String | X | リクエスト日時（yyyy-MM-dd HH:mm）<br>（入力しない場合は即時送信）<br>最大60日後まで予約可能 |
+| unsubscribeNo | String | X | 080受信拒否無料電話番号（すべて未入力の場合、発信プロフィールに登録された受信拒否情報で送信されます）<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx |
+| unsubscribeAuthNo | String | X | 080受信拒否認証番号（最大10文字、すべて未入力の場合、発信プロフィールに登録された受信拒否情報で送信されます）<br>unsubscribeNo なしで unsubscribeAuthNo のみの入力は不可<br>例: 1234 |
+| adult | boolean | X | 成人向けメッセージ有無（デフォルト値: false） |
+| content | String | O | - TEXT タイプの場合、最大1,300文字（改行: 最大99個、URL形式入力可能）<br>- IMAGE タイプの場合、最大1,300文字（改行: 最大99個、URL形式入力可能）<br>- WIDE タイプの場合、最大76文字（改行: 最大5個）<br>- PREMIUM_VIDEO タイプの場合、このフィールドは任意で使用できます。最大76文字（改行: 最大5個）<br>- その他のタイプの場合、このフィールドは使用しません |
+| buttons | List | X | ボタンリスト<br>- TEXT、IMAGE タイプの場合、クーポン適用時は最大4個、それ以外は最大5個<br>- WIDE、WIDE_ITEM_LIST タイプの場合、最大2個<br>- PREMIUM_VIDEO タイプの場合、最大1個<br>- COMMERCE タイプの場合、最小1個、最大2個 |
+| - name | String | O | ボタンタイトル<br>- TEXT、IMAGE タイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字 |
+| - type | String | O | ボタンタイプ（WL: Webリンク、AL: アプリリンク、BK: ボットキーワード、MD: メッセージ転送、AC: チャンネル追加、BT: チャットボット切替、BF: ビジネスフォーム）<br>- BT タイプはカカオオープンビルダーのチャットボットを使用するチャンネルのみ利用可能<br>- BF タイプは最初のボタンとしてのみ使用でき、name には次の3つの文言のみ使用可能<br>  - トークで予約する<br>  - トークでアンケートに答える<br>  - トークで応募する |
+| - linkMo | String | X | モバイルWebリンク（WL タイプの場合は必須フィールド）、1,000文字制限 |
+| - linkPc | String | X | PC Webリンク（WL タイプの場合は任意フィールド）、1,000文字制限 |
+| - schemeAndroid | String | X | Android アプリリンク（AL タイプの場合は必須フィールド）、1,000文字制限 |
+| - schemeIos | String | X | iOS アプリリンク（AL タイプの場合は必須フィールド）、1,000文字制限 |
+| - chatExtra | String | X | BT タイプボタンの場合、転送するメタ情報 |
+| - chatEvent | String | X | BT タイプボタンの場合、連携するボットイベント名 |
+| - bizFormKey | String | X | BF タイプボタンの場合、ビズフォームキー |
+| coupon | Object | X | クーポン要素 |
+| - title | String | O | title は5種類の形式に限定されます<br>- 「${数字}円割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内} UP クーポン」 |
+| - description | String | O | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO タイプの場合、最大18文字。改行: 不可<br>- その他のタイプの場合、最大12文字。改行: 不可 |
+| - linkMo | String | X | モバイルWebリンク（WL タイプの場合は必須フィールド）、1,000文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）になります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）になります。 |
+| - linkPc | String | X | PC Webリンク（WL タイプの場合は任意フィールド）、1,000文字制限 |
+| - schemeAndroid | String | X | Android アプリリンク（AL タイプの場合は必須フィールド）、1,000文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）になります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）になります。 |
+| - schemeIos | String | X | iOS アプリリンク（AL タイプの場合は必須フィールド）、1,000文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）になります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）になります。 |
+| recipientList | List | O | 受信者リスト（最大1,000名） |
+| - recipientNo | String | O | 受信番号 |
+| - resendParameter | Object | X | 代替送信情報 |
+| -- isResend | boolean | X | 送信失敗時、SMS代替送信有無<br>コンソールで代替送信設定を行った場合、デフォルト値として代替送信されます。 |
+| -- resendType | String | X | 代替送信タイプ（SMS、LMS）<br>値がない場合、テンプレート本文の長さに応じてタイプが決定されます。 |
+| -- resendTitle         | String  | X  | LMS 代替送信タイトル<br>(値がない場合、プラスフレンド ID で代替送信されます。)                                                                                                                                                                                                                               |
+| -- resendContent       | String  | X  | 代替送信内容<br>(値がない場合、[メッセージ本文] で代替送信されます。)                                                                                                                                                                                                                                  |
+| -- resendSendNo        | String  | X  | 代替送信の発信番号<br><span style="color:red">(SMS サービスに登録されている発信番号でない場合、代替送信に失敗する可能性があります。)</span>                                                                                                                                                                                 |
+| -- resendUnsubscribeNo | String  | X  | 代替送信の 080 受信拒否番号<br><span style="color:red">(SMS サービスに登録されている 080 受信拒否番号でない場合、代替送信に失敗する可能性があります。)</span>                                                                                                                                                                       |
+| - targeting         | String  | X  | メッセージ対象のタイプ(M: マーケティング受信同意ユーザー、N: フレンドではないマーケティング受信同意ユーザーのみ、I: フレンドのユーザー)                                                                |
+| - unsubscribeNo       | String  | X  | 080 無料受信拒否電話番号(すべて未入力の場合、発信プロフィールに登録されている無料受信拒否情報で送信されます)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx         |
+| - unsubscribeAuthNo   | String  | X  | 080 無料受信拒否認証番号(最大 10 文字、すべて未入力の場合、発信プロフィールに登録されている無料受信拒否情報で送信されます)<br>unsubscribeNo なしで unsubscribeAuthNo のみ入力不可<br>例: 1234        |
+| - recipientGroupingKey | String  | X  | 受信者グルーピングキー(受信者ごとにグルーピングキーを指定できます。最大 100 文字)                                                                                                                                                                                                                   |
+| senderGroupingKey    | String  | X  | 発信者グルーピングキー(発信者ごとにグルーピングキーを指定できます。最大 100 文字)                                                                                                                                                                                                                   |
+| resellerCode          | String  | X  | リセラーコード(リセラーが送信する際に使用)                                                                                                                                                                                                                                                       |
+| createUser             | String  | X  | 登録者(コンソールから送信する際にユーザー UUID で保存)                                                                                                                                                                                                                                                   |
+| statsId                | String  | 	X | 統計 ID(発信検索条件には含まれません。最大 8 文字)                                                                                                                                                                                                                                            |
 
 <a id="request-image-type-sending"></a>
 
-#### 画像形式の送信リクエスト
+#### 画像型送信リクエスト
 
 [Request body]
 
@@ -297,6 +314,9 @@ Content-Type: application/json;charset=UTF-8
   "senderKey": String,
   "chatBubbleType": "IMAGE",
   "pushAlarm": boolean,
+  "requestDate": String,
+  "unsubscribeNo": String,
+  "unsubscribeAuthNo": String,
   "adult": boolean,
   "content": String,
   "image": {
@@ -334,56 +354,71 @@ Content-Type: application/json;charset=UTF-8
           "resendContent": String,
           "resendSendNo": String,
           "resendUnsubscribeNo": String
-      }
+      },
+      "targeting": String,
+      "unsubscribeNo": String,
+      "unsubscribeAuthNo": String,
+      "recipientGroupingKey": String
     }
   ],
+  "senderGroupingKey": String,
+  "resellerCode": String,
   "createUser": String,
   "statsId": String
 }
 ```
 
-| 名前                   | タイプ    | 必須 | 説明                                                                                                                                                                                                                                                                          |
+| 名前                     | タイプ      | 必須 | 説明                                                                                                                                                                                                                                                                            |
 |------------------------|---------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| senderKey              | String  | O  | 発信キー(40文字). グループ発信キーは使用不可                                                                                                                                                                                                                                                     |
-| chatBubbleType         | String  | O  | メッセージタイプ(TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)                                                                                                                                                                         |
-| pushAlarm | boolean | X | メッセージプッシュ通知の送信有無(デフォルト: true) |
-| adult                  | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                                                                       |
-| content | String | O | - TEXTタイプの場合、最大1,300文字(改行:最大99個、URL形式の入力が可能)<br>- IMAGEタイプの場合、最大400文字(改行:最大29回、URL形式の入力が可能)<br>- WIDEタイプの場合、最大76文字(改行:最大1回)<br>- PREMIUM_VIDEOタイプの場合、このフィールドをオプションとして使用可能。最大76文字(改行:最大1回)<br>- その他のタイプの場合、このフィールドは使用しません |
-| image | Object | O | 画像要素<br>- IMAGE、WIDE、COMMERCEタイプの場合、必須フィールド |
-| - imageUrl | String | O | 画像URL。一般画像としてアップロードされた画像URLを使用 |
-| - imageLink | String | X | 画像をクリックしたときに移動するURL。1,000文字制限<br>未設定の場合、カカオトーク内の画像ビューアを使用 |
-| buttons | List | X | ボタンリスト<br>- TEXT、IMAGEタイプの場合、クーポン適用時は最大4件、それ以外は最大5件<br>- WIDE、WIDE_ITEM_LISTタイプの場合、最大2件<br>- PREMIUM_VIDEOタイプの場合、最大1件<br>- COMMERCEタイプの場合、最小1件、最大2件 |
-| - name | String | O | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字 |
-| - type | String | O | ボタンタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- BTタイプはカカオオープンビルダーのチャットボットを使用するチャンネルのみ利用可能<br>- BFタイプは最初のボタンとしてのみ使用でき、nameには以下の3つのフレーズのみ使用可能<br> - トークで予約する<br> - トークでアンケートする<br> - トークで応募する |
-| - linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド)、1,000文字制限 |
-| - linkPc | String | X | PCWebリンク(WLタイプの場合、任意フィールド)、1,000文字制限 |
-| - schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限 |
-| - schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限 |
-| - chatExtra | String | X | BTタイプのボタンの場合、伝達するメタ情報 |
-| - chatEvent | String | X | BTタイプのボタンの場合、連携するボットイベント名 |
-| - bizFormKey | String | X | BFタイプのボタンの場合、ビズフォームキー |
-| coupon                 | Object  | X  | クーポン要素                                                                                                                                                                                                                                                                       |
-| - title | String | O | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」 |
-| - description | String | O | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字。改行:不可<br>- その他のタイプの場合、最大12文字。改行:不可 |
-| - linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
-| - linkPc | String | X | PCWebリンク(WLタイプの場合、任意フィールド)、1,000文字制限 |
-| - schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
-| - schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
-| recipientList          | List    | O  | 受信者リスト(最大1,000人)                                                                                                                                                                                                                                                             |
-| - recipientNo          | String  | O  | 受信番号                                                                                                                                                                                                                                                                       |
-| - resendParameter      | Object  | X  | 代替送信情報                                                                                                                                                                                                                                                                    |
-| -- isResend | boolean | X | 送信に失敗した場合、メッセージを代替送信するかどうか<br>コンソールで代替送信を設定した場合、基本設定として代替送信されます。 |
-| -- resendType | String | X | 代替送信タイプ(SMS、LMS)<br>値がない場合、テンプレート本文の長さに応じてタイプが区分されます。 |
-| -- resendTitle | String | X | LMS代替送信の件名<br>(値がない場合、プラスフレンドIDで代替送信されます。) |
-| -- resendContent | String | X | 代替送信の内容<br>(値がない場合、[メッセージ本文]で代替送信されます。) |
-| -- resendSendNo | String | X | 代替送信の送信者番号<br><span style="color:red">(SMSサービスに登録されている送信者番号ではない場合、代替送信に失敗することがあります。)</span> |
-| -- resendUnsubscribeNo | String | X | 代替送信080受信拒否番号<br><span style="color:red">(SMSサービスに登録された080受信拒否番号ではない場合、代替送信に失敗することがあります。)</span> |
-| createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
+| senderKey              | String  | O  | 発信キー（40文字）。グループ発信キーは使用不可                                                                                                                                                                                                                                                       |
+| chatBubbleType         | String  | O  | メッセージタイプ（TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE）                                                                                                                                                                         |
+| pushAlarm              | boolean | X  | メッセージプッシュ通知の送信有無（デフォルト値: true）                                                                                                                                                                                                                                                   |
+| requestDate            | String  | X  | リクエスト日時（yyyy-MM-dd HH:mm）<br>（入力しない場合は即時送信）<br>最大60日後まで予約可能                                                                                                                                                                                                                                                   |
+| unsubscribeNo       | String  | X  | 080受信拒否無料電話番号（すべて未入力の場合は発信プロフィールに登録された受信拒否情報で送信されます）<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx         |
+| unsubscribeAuthNo   | String  | X  | 080受信拒否認証番号（最大10文字、すべて未入力の場合は発信プロフィールに登録された受信拒否情報で送信されます）<br>unsubscribeNo なしで unsubscribeAuthNo のみ入力不可<br>例: 1234        |
+| adult                  | boolean | X  | 成人向けメッセージかどうか（デフォルト値: false）                                                                                                                                                                                                                                                       |
+| content                | String  | O  | - TEXT タイプの場合、最大1,300文字（改行: 最大99個、URL形式の入力可能）<br>- IMAGE タイプの場合、最大1,300文字（改行: 最大99個、URL形式の入力可能）<br>- WIDE タイプの場合、最大76文字（改行: 最大5個）<br>- PREMIUM_VIDEO タイプの場合、このフィールドを任意で使用できます。最大76文字（改行: 最大5個）<br>- その他のタイプの場合、このフィールドは使用しません                           |
+| image                  | Object  | O  | 画像要素<br>- IMAGE、WIDE、COMMERCE タイプの場合は必須フィールド                                                                                                                                                                                                                                |
+| - imageUrl             | String  | O  | 画像URL。通常の画像としてアップロードされた画像URLを使用                                                                                                                                                                                                                                              |
+| - imageLink            | String  | X  | 画像クリック時に移動するURL。1,000文字制限<br>未設定の場合はカカオトーク内画像ビューアーを使用                                                                                                                                                                                                                            |
+| buttons                | List    | X  | ボタンリスト<br>- TEXT、IMAGE タイプの場合、クーポン適用時は最大4個、それ以外は最大5個<br>- WIDE、WIDE_ITEM_LIST タイプの場合、最大2個<br>- PREMIUM_VIDEO タイプの場合、最大1個<br>- COMMERCE タイプの場合、最小1個、最大2個                                                                                                                 |
+| - name                 | String  | O  | ボタンタイトル<br>- TEXT、IMAGE タイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字                                                                                                                                                                                                                    |
+| - type                 | String  | O  | ボタンタイプ（WL: Webリンク、AL: アプリリンク、BK: ボットキーワード、MD: メッセージ転達、AC: チャンネル追加、BT: チャットボット切替、BF: ビジネスフォーム）<br>- BT タイプはカカオオープンビルダーのチャットボットを使用するチャンネルのみ利用可能<br>- BF タイプは最初のボタンとしてのみ使用でき、name には以下の3種類の文言のみ使用可能<br>  - トークで予約する<br>  - トークでアンケートに答える<br>  - トークで応募する |
+| - linkMo               | String  | X  | モバイルWebリンク（WL タイプの場合は必須フィールド）、1,000文字制限                                                                                                                                                                                                                                         |
+| - linkPc               | String  | X  | PC Webリンク（WL タイプの場合は任意フィールド）、1,000文字制限                                                                                                                                                                                                                                          |
+| - schemeAndroid        | String  | X  | Android アプリリンク（AL タイプの場合は必須フィールド）、1,000文字制限                                                                                                                                                                                                                                       |
+| - schemeIos            | String  | X  | iOS アプリリンク（AL タイプの場合は必須フィールド）、1,000文字制限                                                                                                                                                                                                                                         |
+| - chatExtra            | String  | X  | BT タイプのボタンの場合に転達するメタ情報                                                                                                                                                                                                                                                   |
+| - chatEvent            | String  | X  | BT タイプのボタンの場合に連携するボットイベント名                                                                                                                                                                                                                                                       |
+| - bizFormKey           | String  | X  | BF タイプのボタンの場合のビズフォームキー                                                                                                                                                                                                                                                            |
+| coupon                 | Object  | X  | クーポン要素                                                                                                                                                                                                                                                                         |
+| - title                | String  | O  | title は5種類の形式のみ使用可能<br>- 「${数字}円割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」                                                                                                            |
+| - description          | String  | O  | クーポン詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO タイプの場合、最大18文字。改行: 不可<br>- その他のタイプの場合、最大12文字。改行: 不可                                                                                                                                                                      |
+| - linkMo               | String  | X  | モバイルWebリンク（WL タイプの場合は必須フィールド）、1,000文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポンURL（形式: alimtalk=coupon://）を入力した場合も、残りのフィールドが任意（オプション）となります。                                                                                   |
+| - linkPc               | String  | X  | PC Webリンク（WL タイプの場合は任意フィールド）、1,000文字制限                                                                                                                                                                                                                                          |
+| - schemeAndroid        | String  | X  | Android アプリリンク（AL タイプの場合は必須フィールド）、1,000文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポンURL（形式: alimtalk=coupon://）を入力した場合も、残りのフィールドが任意（オプション）となります。                                                                                 |
+| - schemeIos            | String  | X  | iOS アプリリンク（AL タイプの場合は必須フィールド）、1,000文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポンURL（形式: alimtalk=coupon://）を入力した場合も、残りのフィールドが任意（オプション）となります。                                                                                   |
+| recipientList          | List    | O  | 受信者リスト（最大1,000名）                                                                                                                                                                                                                                                             |
+| - recipientNo          | String  | O  | 受信番号                                                                                                                                                                                                                                                                         |
+| - resendParameter      | Object  | X  | 代替送信情報                                                                                                                                                                                                                                                                      |
+| -- isResend            | boolean | X  | 送信失敗時、SMS代替送信を行うかどうか<br>コンソールで代替送信設定時、デフォルト値で代替送信されます。                                                                                                                                                                                                                       |
+| -- resendType          | String  | X  | 代替送信タイプ(SMS、LMS)<br>値がない場合、テンプレート本文の長さによってタイプが決まります。                                                                                                                                                                                                                       |
+| -- resendTitle         | String  | X  | LMS代替送信タイトル<br>(値がない場合、プラスフレンドIDで代替送信されます。)                                                                                                                                                                                                                               |
+| -- resendContent       | String  | X  | 代替送信内容<br>(値がない場合、[メッセージ本文]で代替送信されます。)                                                                                                                                                                                                                                  |
+| -- resendSendNo        | String  | X  | 代替送信の発信番号<br><span style="color:red">(SMSサービスに登録された発信番号でない場合、代替送信に失敗する可能性があります。)</span>                                                                                                                                                                                 |
+| -- resendUnsubscribeNo | String  | X  | 代替送信の080受信拒否番号<br><span style="color:red">(SMSサービスに登録された080受信拒否番号でない場合、代替送信に失敗する可能性があります。)</span>                                                                                                                                                                       |
+| - targeting         | String  | X  | メッセージ対象のタイプ(M: マーケティング受信同意ユーザー、N: フレンドではないマーケティング受信同意ユーザーのみ、I: フレンドであるユーザー)                                                                |
+| - unsubscribeNo       | String  | X  | 080無料受信拒否電話番号(すべて未入力の場合、発信プロフィールに登録された無料受信拒否情報で送信されます)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx         |
+| - unsubscribeAuthNo   | String  | X  | 080無料受信拒否認証番号(最大10文字、すべて未入力の場合、発信プロフィールに登録された無料受信拒否情報で送信されます)<br>unsubscribeNoなしでunsubscribeAuthNoのみの入力は不可<br>例: 1234        |
+| - recipientGroupingKey | String  | X  | 受信者グループキー(受信者ごとにグループキーを指定できます。最大100文字)                                                                                                                                                                                                                   |
+| senderGroupingKey    | String  | X  | 発信者グループキー(発信者ごとにグループキーを指定できます。最大100文字)                                                                                                                                                                                                                   |
+| resellerCode          | String  | X  | リセラーコード(リセラーが送信時に使用)                                                                                                                                                                                                                                                       |
+| createUser             | String  | X  | 登録者(コンソールから送信時、ユーザーUUIDで保存)                                                                                                                                                                                                                                                   |
 | statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
 
 <a id="request-wide-image-type-sending"></a>
 
-#### ワイド画像形式の送信リクエスト
+#### ワイド画像型送信リクエスト
 
 [Request body]
 
@@ -392,6 +427,9 @@ Content-Type: application/json;charset=UTF-8
   "senderKey": String,
   "chatBubbleType": "WIDE",
   "pushAlarm": boolean,
+  "requestDate": String,
+  "unsubscribeNo": String,
+  "unsubscribeAuthNo": String,
   "adult": boolean,
   "content": String,
   "image": {
@@ -429,56 +467,71 @@ Content-Type: application/json;charset=UTF-8
           "resendContent": String,
           "resendSendNo": String,
           "resendUnsubscribeNo": String
-      }
+      },
+      "targeting": String,
+      "unsubscribeNo": String,
+      "unsubscribeAuthNo": String,
+      "recipientGroupingKey": String
     }
   ],
+  "senderGroupingKey": String
+  "resellerCode": String,
   "createUser": String,
   "statsId": String
 }
 ```
 
-| 名前                   | タイプ    | 必須 | 説明                                                                                                                                                                                                                                                                          |
+| 名前                     | タイプ      | 必須 | 説明                                                                                                                                                                                                                                                                            |
 |------------------------|---------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| senderKey              | String  | O  | 発信キー(40文字). グループ発信キーは使用不可                                                                                                                                                                                                                                                     |
-| chatBubbleType         | String  | O  | メッセージタイプ(TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)                                                                                                                                                                         |
-| pushAlarm | boolean | X | メッセージプッシュ通知の送信有無(デフォルト: true) |
-| adult                  | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                                                                       |
-| content | String | O | - TEXTタイプの場合、最大1,300文字(改行:最大99個、URL形式の入力が可能)<br>- IMAGEタイプの場合、最大400文字(改行:最大29回、URL形式の入力が可能)<br>- WIDEタイプの場合、最大76文字(改行:最大1回)<br>- PREMIUM_VIDEOタイプの場合、このフィールドをオプションとして使用可能。最大76文字(改行:最大1回)<br>- その他のタイプの場合、このフィールドは使用しません |
-| image | Object | O | 画像要素<br>- IMAGE、WIDE、COMMERCEタイプの場合、必須フィールド |
-| - imageUrl | String | O | 画像URL、ワイド画像としてアップロードされた画像URLを使用 |
-| - imageLink | String | X | 画像をクリックしたときに移動するURL。1,000文字制限<br>未設定の場合、カカオトーク内の画像ビューアを使用 |
-| buttons | List | X | ボタンリスト<br>- TEXT、IMAGEタイプの場合、クーポン適用時は最大4件、それ以外は最大5件<br>- WIDE、WIDE_ITEM_LISTタイプの場合、最大2件<br>- PREMIUM_VIDEOタイプの場合、最大1件<br>- COMMERCEタイプの場合、最小1件、最大2件 |
-| - name | String | O | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字 |
-| - type | String | O | ボタンタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- BTタイプはカカオオープンビルダーのチャットボットを使用するチャンネルのみ利用可能<br>- BFタイプは最初のボタンとしてのみ使用でき、nameには以下の3つのフレーズのみ使用可能<br> - トークで予約する<br> - トークでアンケートする<br> - トークで応募する |
-| - linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド)、1,000文字制限 |
-| - linkPc | String | X | PCWebリンク(WLタイプの場合、任意フィールド)、1,000文字制限 |
-| - schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限 |
-| - schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限 |
-| - chatExtra | String | X | BTタイプのボタンの場合、伝達するメタ情報 |
-| - chatEvent | String | X | BTタイプのボタンの場合、連携するボットイベント名 |
-| - bizFormKey | String | X | BFタイプのボタンの場合、ビズフォームキー |
-| coupon                 | Object  | X  | クーポン要素                                                                                                                                                                                                                                                                       |
-| - title | String | O | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」 |
-| - description | String | O | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字。改行:不可<br>- その他のタイプの場合、最大12文字。改行:不可 |
-| - linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
-| - linkPc | String | X | PCWebリンク(WLタイプの場合、任意フィールド)、1,000文字制限 |
-| - schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
-| - schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
-| recipientList          | List    | O  | 受信者リスト(最大1,000人)                                                                                                                                                                                                                                                             |
-| - recipientNo          | String  | O  | 受信番号                                                                                                                                                                                                                                                                       |
-| - resendParameter      | Object  | X  | 代替送信情報                                                                                                                                                                                                                                                                    |
-| -- isResend | boolean | X | 送信に失敗した場合、メッセージを代替送信するかどうか<br>コンソールで代替送信を設定した場合、基本設定として代替送信されます。 |
-| -- resendType | String | X | 代替送信タイプ(SMS、LMS)<br>値がない場合、テンプレート本文の長さに応じてタイプが区分されます。 |
-| -- resendTitle | String | X | LMS代替送信の件名<br>(値がない場合、プラスフレンドIDで代替送信されます。) |
-| -- resendContent | String | X | 代替送信の内容<br>(値がない場合、[メッセージ本文]で代替送信されます。) |
-| -- resendSendNo | String | X | 代替送信の送信者番号<br><span style="color:red">(SMSサービスに登録されている送信者番号ではない場合、代替送信に失敗することがあります。)</span> |
-| -- resendUnsubscribeNo | String | X | 代替送信080受信拒否番号<br><span style="color:red">(SMSサービスに登録された080受信拒否番号ではない場合、代替送信に失敗することがあります。)</span> |
-| createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
+| senderKey              | String  | O  | 発信キー（40文字）。グループ発信キーは使用不可                                                                                                                                                                                                                                                       |
+| chatBubbleType         | String  | O  | メッセージタイプ（TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE）                                                                                                                                                                         |
+| pushAlarm              | boolean | X  | メッセージのプッシュ通知送信有無（デフォルト値: true）                                                                                                                                                                                                                                                   |
+| requestDate            | String  | X  | リクエスト日時（yyyy-MM-dd HH:mm）<br>（入力しない場合は即時送信）<br>最大60日後まで予約可能                                                                                                                                                                                                                                                   |
+| unsubscribeNo       | String  | X  | 080受信拒否無料電話番号（すべて未入力の場合、発信プロフィールに登録された受信拒否情報で送信）<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx         |
+| unsubscribeAuthNo   | String  | X  | 080受信拒否認証番号（最大10文字、すべて未入力の場合、発信プロフィールに登録された受信拒否情報で送信）<br>unsubscribeNo なしで unsubscribeAuthNo のみの入力は不可<br>例: 1234        |
+| adult                  | boolean | X  | 成人向けメッセージかどうか（デフォルト値: false）                                                                                                                                                                                                                                                       |
+| content                | String  | O  | - TEXT タイプの場合、最大1,300文字（改行: 最大99個、URL形式での入力可能）<br>- IMAGE タイプの場合、最大1,300文字（改行: 最大99個、URL形式での入力可能）<br>- WIDE タイプの場合、最大76文字（改行: 最大5個）<br>- PREMIUM_VIDEO タイプの場合、当該フィールドを任意で使用可能。最大76文字（改行: 最大5個）<br>- その他のタイプの場合、当該フィールドは使用しない                           |
+| image                  | Object  | O  | 画像要素<br>- IMAGE、WIDE、COMMERCE タイプの場合、必須フィールド                                                                                                                                                                                                                                |
+| - imageUrl             | String  | O  | 画像 URL。ワイド画像としてアップロードされた画像 URL を使用                                                                                                                                                                                                                                             |
+| - imageLink            | String  | X  | 画像クリック時に移動する URL。1,000文字制限<br>未設定の場合、カカオトーク内の画像ビューワーを使用                                                                                                                                                                                                                            |
+| buttons                | List    | X  | ボタンリスト<br>- TEXT、IMAGE タイプの場合、クーポン適用時は最大4個、それ以外は最大5個<br>- WIDE、WIDE_ITEM_LIST タイプの場合、最大2個<br>- PREMIUM_VIDEO タイプの場合、最大1個<br>- COMMERCE タイプの場合、最小1個、最大2個                                                                                                                 |
+| - name                 | String  | O  | ボタンタイトル<br>- TEXT、IMAGE タイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字                                                                                                                                                                                                                    |
+| - type                 | String  | O  | ボタンタイプ（WL: Webリンク、AL: アプリリンク、BK: ボットキーワード、MD: メッセージ転送、AC: チャンネル追加、BT: チャットボット切替、BF: ビジネスフォーム）<br>- BT タイプはカカオオープンビルダーのチャットボットを使用するチャンネルのみ利用可能<br>- BF タイプは最初のボタンとしてのみ使用でき、name には次の3つの文言のみ使用可能<br>  - トークで予約する<br>  - トークでアンケートに答える<br>  - トークで応募する |
+| - linkMo               | String  | X  | モバイル Web リンク（WL タイプの場合、必須フィールド）、1,000文字制限                                                                                                                                                                                                                                         |
+| - linkPc               | String  | X  | PC Web リンク（WL タイプの場合、任意フィールド）、1,000文字制限                                                                                                                                                                                                                                          |
+| - schemeAndroid        | String  | X  | Android アプリリンク（AL タイプの場合、必須フィールド）、1,000文字制限                                                                                                                                                                                                                                       |
+| - schemeIos            | String  | X  | iOS アプリリンク（AL タイプの場合、必須フィールド）、1,000文字制限                                                                                                                                                                                                                                         |
+| - chatExtra            | String  | X  | BT タイプのボタンの場合、転送するメタ情報                                                                                                                                                                                                                                                   |
+| - chatEvent            | String  | X  | BT タイプのボタンの場合、連携するボットイベント名                                                                                                                                                                                                                                                       |
+| - bizFormKey           | String  | X  | BF タイプのボタンの場合、ビズフォームキー                                                                                                                                                                                                                                                            |
+| coupon                 | Object  | X  | クーポン要素                                                                                                                                                                                                                                                                         |
+| - title                | String  | O  | title は5種類の形式のみ使用可能<br>- 「${数字}円割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内} UPクーポン」                                                                                                            |
+| - description          | String  | O  | クーポン詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO タイプの場合、最大18文字。改行: 不可<br>- その他のタイプの場合、最大12文字。改行: 不可                                                                                                                                                                      |
+| - linkMo               | String  | X  | モバイル Web リンク（WL タイプの場合、必須フィールド）、1,000文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意項目（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意項目（オプション）となります。                                                                                   |
+| - linkPc               | String  | X  | PC Web リンク（WL タイプの場合、任意フィールド）、1,000文字制限                                                                                                                                                                                                                                          |
+| - schemeAndroid        | String  | X  | Android アプリリンク（AL タイプの場合、必須フィールド）、1,000文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意項目（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意項目（オプション）となります。                                                                                 |
+| - schemeIos            | String  | X  | iOS アプリリンク（AL タイプの場合、必須フィールド）、1,000文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意項目（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意項目（オプション）となります。                                                                                   |
+| recipientList          | List    | O  | 受信者リスト（最大1,000名）                                                                                                                                                                                                                                                             |
+| - recipientNo          | String  | O  | 受信番号                                                                                                                                                                                                                                                                         |
+| - resendParameter      | Object  | X  | 代替送信情報                                                                                                                                                                                                                                                                      |
+| -- isResend            | boolean | X  | 送信失敗時、SMS代替送信を行うかどうか<br>コンソールで代替送信設定を行った場合、デフォルト値として代替送信されます。                                                                                                                                                                                                                       |
+| -- resendType          | String  | X  | 代替送信タイプ(SMS、LMS)<br>値がない場合、テンプレート本文の長さによってタイプが決定されます。                                                                                                                                                                                                                       |
+| -- resendTitle         | String  | X  | LMS代替送信タイトル<br>(値がない場合、プラスフレンドIDで代替送信されます。)                                                                                                                                                                                                                               |
+| -- resendContent       | String  | X  | 代替送信内容<br>(値がない場合、[メッセージ本文]で代替送信されます。)                                                                                                                                                                                                                                  |
+| -- resendSendNo        | String  | X  | 代替送信の発信番号<br><span style="color:red">(SMSサービスに登録された発信番号でない場合、代替送信に失敗する可能性があります。)</span>                                                                                                                                                                                 |
+| -- resendUnsubscribeNo | String  | X  | 代替送信の080受信拒否番号<br><span style="color:red">(SMSサービスに登録された080受信拒否番号でない場合、代替送信に失敗する可能性があります。)</span>                                                                                                                                                                       |
+| - targeting         | String  | X  | メッセージ対象のタイプ(M: マーケティング受信同意ユーザー、N: フレンドではないマーケティング受信同意ユーザーのみ、I: フレンドであるユーザー)                                                                |
+| - unsubscribeNo       | String  | X  | 080無料受信拒否電話番号(すべて未入力の場合、発信プロフィールに登録された無料受信拒否情報で送信されます)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx         |
+| - unsubscribeAuthNo   | String  | X  | 080無料受信拒否認証番号(最大10文字、すべて未入力の場合、発信プロフィールに登録された無料受信拒否情報で送信されます)<br>unsubscribeNoなしでunsubscribeAuthNoのみ入力不可<br>例: 1234        |
+| - recipientGroupingKey | String  | X  | 受信者グルーピングキー(受信者ごとにグルーピングキーを指定できます。最大100文字)                                                                                                                                                                                                                   |
+| senderGroupingKey    | String  | X  | 発信者グルーピングキー(発信者ごとにグルーピングキーを指定できます。最大100文字)                                                                                                                                                                                                                   |
+| resellerCode          | String  | X  | リセラーコード(リセラーが送信時に使用)                                                                                                                                                                                                                                                       |
+| createUser             | String  | X  | 登録者(コンソールから送信時にユーザーUUIDで保存)                                                                                                                                                                                                                                                   |
 | statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
 
 <a id="request-to-send-wide-item-list-type"></a>
 
-#### ワイドアイテムリスト形式の送信リクエスト
+#### ワイドアイテムリストタイプ送信リクエスト
 
 [Request body]
 
@@ -487,6 +540,9 @@ Content-Type: application/json;charset=UTF-8
   "senderKey": String,
   "chatBubbleType": "WIDE_ITEM_LIST",
   "pushAlarm": boolean,
+  "requestDate": String,
+  "unsubscribeNo": String,
+  "unsubscribeAuthNo": String,
   "adult": boolean,
   "header": String,
   "item": {
@@ -548,61 +604,76 @@ Content-Type: application/json;charset=UTF-8
           "resendContent": String,
           "resendSendNo": String,
           "resendUnsubscribeNo": String
-      }
+      },
+      "targeting": String,
+      "unsubscribeNo": String,
+      "unsubscribeAuthNo": String,
+      "recipientGroupingKey": String
     }
   ],
+  "senderGroupingKey": String,
+  "resellerCode": String,
   "createUser": String,
   "statsId": String
 }
 ```
 
-| 名前                   | タイプ    | 必須 | 説明                                                                                                                                                                                                                                                                          |
+| 名前                     | タイプ      | 必須 | 説明                                                                                                                                                                                                                                                                            |
 |------------------------|---------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| senderKey              | String  | O  | 発信キー(40文字). グループ発信キーは使用不可                                                                                                                                                                                                                                                     |
-| chatBubbleType         | String  | O  | メッセージタイプ(TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)                                                                                                                                                                         |
-| pushAlarm | boolean | X | メッセージプッシュ通知の送信有無(デフォルト: true) |
-| adult                  | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                                                                       |
-| header | String | O | ヘッダ<br>- WIDE_ITEM_LISTタイプの場合、必須フィールドで最大20文字(改行:不可)<br>- PREMIUM_VIDEOタイプの場合、任意フィールドで最大20文字(改行:不可) |
-| item | Object | O | ワイドリスト要素(WIDE_ITEM_LISTタイプでのみ使用可能) |
-| - list                 | List    | O  | ワイドリスト(最小: 3、最大4)                                                                                                                                                                                                                                                         |
-| -- title | String | O | アイテムのタイトル<br>- 1番目のアイテムは最大25文字制限(改行:最大1回、1番目のアイテムの場合、titleは必須値ではありません)<br>- 2～4番目のアイテムは最大30文字制限(改行:最大1回) |
-| -- imageUrl | String | O | アイテムの画像URL<br>- 1番目のアイテムには、最初のワイドアイテムリスト画像としてアップロードされた画像URLを使用<br>- 2～4番目のアイテムは、一般ワイドアイテムリスト画像としてアップロードされた画像URLを使用 |
-| -- linkMo              | String  | O  | モバイルWebリンク、1,000文字制限                                                                                                                                                                                                                                                         |
-| -- linkPc              | String  | X  | PC Webリンク、1,000文字制限                                                                                                                                                                                                                                                          |
-| -- schemeAndroid       | String  | X  | Androidアプリリンク、1,000文字制限                                                                                                                                                                                                                                                       |
-| -- schemeIos           | String  | X  | iOSアプリリンク、1,000文字制限                                                                                                                                                                                                                                                         |
-| buttons | List | X | ボタンリスト<br>- TEXT、IMAGEタイプの場合、クーポン適用時は最大4件、それ以外は最大5件<br>- WIDE、WIDE_ITEM_LISTタイプの場合、最大2件<br>- PREMIUM_VIDEOタイプの場合、最大1件<br>- COMMERCEタイプの場合、最小1件、最大2件 |
-| - name | String | O | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字 |
-| - type | String | O | ボタンタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- BTタイプはカカオオープンビルダーのチャットボットを使用するチャンネルのみ利用可能<br>- BFタイプは最初のボタンとしてのみ使用でき、nameには以下の3つのフレーズのみ使用可能<br> - トークで予約する<br> - トークでアンケートする<br> - トークで応募する |
-| - linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド)、1,000文字制限 |
-| - linkPc | String | X | PCWebリンク(WLタイプの場合、任意フィールド)、1,000文字制限 |
-| - schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限 |
-| - schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限 |
-| - chatExtra | String | X | BTタイプのボタンの場合、伝達するメタ情報 |
-| - chatEvent | String | X | BTタイプのボタンの場合、連携するボットイベント名 |
-| - bizFormKey | String | X | BFタイプのボタンの場合、ビズフォームキー |
-| coupon                 | Object  | X  | クーポン要素                                                                                                                                                                                                                                                                       |
-| - title | String | O | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」 |
-| - description | String | O | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字。改行:不可<br>- その他のタイプの場合、最大12文字。改行:不可 |
-| - linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
-| - linkPc | String | X | PCWebリンク(WLタイプの場合、任意フィールド)、1,000文字制限 |
-| - schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
-| - schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
-| recipientList          | List    | O  | 受信者リスト(最大1,000人)                                                                                                                                                                                                                                                             |
-| - recipientNo          | String  | O  | 受信番号                                                                                                                                                                                                                                                                       |
-| - resendParameter      | Object  | X  | 代替送信情報                                                                                                                                                                                                                                                                    |
-| -- isResend | boolean | X | 送信に失敗した場合、メッセージを代替送信するかどうか<br>コンソールで代替送信を設定した場合、基本設定として代替送信されます。 |
-| -- resendType | String | X | 代替送信タイプ(SMS、LMS)<br>値がない場合、テンプレート本文の長さに応じてタイプが区分されます。 |
-| -- resendTitle | String | X | LMS代替送信の件名<br>(値がない場合、プラスフレンドIDで代替送信されます。) |
-| -- resendContent | String | X | 代替送信の内容<br>(値がない場合、[メッセージ本文]で代替送信されます。) |
-| -- resendSendNo | String | X | 代替送信の送信者番号<br><span style="color:red">(SMSサービスに登録されている送信者番号ではない場合、代替送信に失敗することがあります。)</span> |
-| -- resendUnsubscribeNo | String | X | 代替送信080受信拒否番号<br><span style="color:red">(SMSサービスに登録された080受信拒否番号ではない場合、代替送信に失敗することがあります。)</span> |
-| createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
-| statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
+| senderKey              | String  | O  | 発信キー（40文字）。グループ発信キーは使用不可                                                                                                                                                                                                                                                       |
+| chatBubbleType         | String  | O  | メッセージタイプ（TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE）                                                                                                                                                                         |
+| pushAlarm              | boolean | X  | メッセージプッシュ通知の送信有無（デフォルト値: true）                                                                                                                                                                                                                                                   |
+| requestDate            | String  | X  | リクエスト日時（yyyy-MM-dd HH:mm）<br>（入力しない場合は即時送信）<br>最大60日後まで予約可能                                                                                                                                                                                                                                                   |
+| unsubscribeNo       | String  | X  | 080受信拒否無料電話番号（すべて未入力の場合は発信プロフィールに登録された受信拒否情報で送信されます）<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx         |
+| unsubscribeAuthNo   | String  | X  | 080受信拒否認証番号（最大10文字、すべて未入力の場合は発信プロフィールに登録された受信拒否情報で送信されます）<br>unsubscribeNo なしで unsubscribeAuthNo のみの入力は不可<br>例: 1234        |
+| adult                  | boolean | X  | 成人向けメッセージかどうか（デフォルト値: false）                                                                                                                                                                                                                                                       |
+| header                 | String  | O  | ヘッダー<br>- WIDE_ITEM_LIST タイプの場合は必須フィールドで最大20文字（改行: 不可）<br>- PREMIUM_VIDEO タイプの場合は任意フィールドで最大20文字（改行: 不可）                                                                                                                                                                     |
+| item                   | Object  | O  | ワイドリスト要素（WIDE_ITEM_LIST タイプでのみ使用可能）                                                                                                                                                                                                                                       |
+| - list                 | List    | O  | ワイドリスト（最小: 3、最大: 4）                                                                                                                                                                                                                                                         |
+| -- title               | String  | O  | アイテムタイトル<br>- 1番目のアイテムは最大25文字制限（改行: 最大1個、1番目のアイテムの場合 title は必須値ではありません）<br>- 2〜4番目のアイテムは最大30文字制限（改行: 最大1個）                                                                                                                                                                |
+| -- imageUrl            | String  | O  | アイテム画像URL<br>- 1番目のアイテムには1番目のワイドアイテムリスト画像としてアップロードされた画像URLを使用<br>- 2〜4番目のアイテムは通常のワイドアイテムリスト画像としてアップロードされた画像URLを使用                                                                                                                                                             |
+| -- linkMo              | String  | O  | モバイルWebリンク、1,000文字制限                                                                                                                                                                                                                                                           |
+| -- linkPc              | String  | X  | PC Webリンク、1,000文字制限                                                                                                                                                                                                                                                            |
+| -- schemeAndroid       | String  | X  | Android アプリリンク、1,000文字制限                                                                                                                                                                                                                                                         |
+| -- schemeIos           | String  | X  | iOS アプリリンク、1,000文字制限                                                                                                                                                                                                                                                           |
+| buttons                | List    | X  | ボタンリスト<br>- TEXT、IMAGE タイプの場合、クーポン適用時は最大4個、それ以外は最大5個<br>- WIDE、WIDE_ITEM_LIST タイプの場合は最大2個<br>- PREMIUM_VIDEO タイプの場合は最大1個<br>- COMMERCE タイプの場合は最小1個、最大2個                                                                                                                 |
+| - name                 | String  | O  | ボタンタイトル<br>- TEXT、IMAGE タイプの場合は最大14文字<br>- その他のタイプの場合は最大8文字                                                                                                                                                                                                                    |
+| - type                 | String  | O  | ボタンタイプ（WL: Webリンク、AL: アプリリンク、BK: ボットキーワード、MD: メッセージ転送、AC: チャンネル追加、BT: チャットボット切替、BF: ビジネスフォーム）<br>- BT タイプはカカオオープンビルダーのチャットボットを使用するチャンネルのみ利用可能<br>- BF タイプは1番目のボタンとしてのみ使用でき、name には次の3つの文言のみ使用可能<br>  - トークで予約する<br>  - トークでアンケートに回答する<br>  - トークで応募する |
+| - linkMo               | String  | X  | モバイルWebリンク（WL タイプの場合は必須フィールド）、1,000文字制限                                                                                                                                                                                                                                         |
+| - linkPc               | String  | X  | PC Webリンク（WL タイプの場合は任意フィールド）、1,000文字制限                                                                                                                                                                                                                                          |
+| - schemeAndroid        | String  | X  | Android アプリリンク（AL タイプの場合は必須フィールド）、1,000文字制限                                                                                                                                                                                                                                       |
+| - schemeIos            | String  | X  | iOS アプリリンク（AL タイプの場合は必須フィールド）、1,000文字制限                                                                                                                                                                                                                                         |
+| - chatExtra            | String  | X  | BT タイプボタンの場合に転送するメタ情報                                                                                                                                                                                                                                                   |
+| - chatEvent            | String  | X  | BT タイプボタンの場合に連携するボットイベント名                                                                                                                                                                                                                                                       |
+| - bizFormKey           | String  | X  | BF タイプボタンの場合のビズフォームキー                                                                                                                                                                                                                                                            |
+| coupon                 | Object  | X  | クーポン要素                                                                                                                                                                                                                                                                         |
+| - title                | String  | O  | title は5種類の形式に制限されます<br>- 「${数字}円割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内} UPクーポン」                                                                                                            |
+| - description          | String  | O  | クーポン詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO タイプの場合は最大18文字。改行: 不可<br>- その他のタイプの場合は最大12文字。改行: 不可                                                                                                                                                                      |
+| - linkMo               | String  | X  | モバイルWebリンク（WL タイプの場合は必須フィールド）、1,000文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）となります。                                                                                   |
+| - linkPc               | String  | X  | PC ウェブリンク（WL タイプの場合は選択フィールド）、1,000 文字制限                                                                                                                                                                                                                                          |
+| - schemeAndroid        | String  | X  | Android アプリリンク（AL タイプの場合は必須フィールド）、1,000 文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）となります。                                                                                 |
+| - schemeIos            | String  | X  | iOS アプリリンク（AL タイプの場合は必須フィールド）、1,000 文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）となります。                                                                                   |
+| recipientList          | List    | O  | 受信者リスト（最大 1,000 名）                                                                                                                                                                                                                                                             |
+| - recipientNo          | String  | O  | 受信番号                                                                                                                                                                                                                                                                         |
+| - resendParameter      | Object  | X  | 代替送信情報                                                                                                                                                                                                                                                                      |
+| -- isResend            | boolean | X  | 送信失敗時、SMS 代替送信を行うかどうか<br>コンソールで代替送信設定を行った場合、デフォルト値として代替送信されます。                                                                                                                                                                                                                       |
+| -- resendType          | String  | X  | 代替送信タイプ（SMS、LMS）<br>値がない場合、テンプレート本文の長さによってタイプが決まります。                                                                                                                                                                                                                       |
+| -- resendTitle         | String  | X  | LMS 代替送信タイトル<br>（値がない場合、プラスフレンド ID で代替送信されます。）                                                                                                                                                                                                                               |
+| -- resendContent       | String  | X  | 代替送信内容<br>（値がない場合、[メッセージ本文] で代替送信されます。）                                                                                                                                                                                                                                  |
+| -- resendSendNo        | String  | X  | 代替送信の発信番号<br><span style="color:red">（SMS サービスに登録された発信番号でない場合、代替送信に失敗する可能性があります。）</span>                                                                                                                                                                                 |
+| -- resendUnsubscribeNo | String  | X  | 代替送信の 080 受信拒否番号<br><span style="color:red">（SMS サービスに登録された 080 受信拒否番号でない場合、代替送信に失敗する可能性があります。）</span>                                                                                                                                                                       |
+| - targeting         | String  | X  | メッセージ対象のタイプ（M: マーケティング受信同意ユーザー、N: フレンドではないマーケティング受信同意ユーザーのみ、I: フレンドであるユーザー）                                                                |
+| - unsubscribeNo       | String  | X  | 080 無料受信拒否電話番号（すべて未入力の場合、発信プロフィールに登録された無料受信拒否情報で送信されます）<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx         |
+| - unsubscribeAuthNo   | String  | X  | 080 無料受信拒否認証番号（最大 10 文字、すべて未入力の場合、発信プロフィールに登録された無料受信拒否情報で送信されます）<br>unsubscribeNo なしで unsubscribeAuthNo のみの入力は不可<br>例: 1234        |
+| - recipientGroupingKey | String  | X  | 受信者グルーピングキー（受信者ごとにグルーピングキーを指定できます。最大 100 文字）                                                                                                                                                                                                                   |
+| senderGroupingKey    | String  | X  | 発信者グルーピングキー（発信者ごとにグルーピングキーを指定できます。最大 100 文字）                                                                                                                                                                                                                   |
+| resellerCode          | String  | X  | リセラーコード（リセラーが送信する際に使用）                                                                                                                                                                                                                                                       |
+| createUser             | String  | X  | 登録者（コンソールから送信する際にユーザー UUID として保存）                                                                                                                                                                                                                                                   |
+| statsId                | String  | 	X | 統計 ID（発信検索条件には含まれません。最大 8 文字）                                                                                                                                                                                                                                            |
 
 <a id="request-to-send-premium-video-type"></a>
 
-#### プレミアム動画形式の送信リクエスト
+#### プレミアム動画型送信リクエスト
 
 [Request body]
 
@@ -611,6 +682,9 @@ Content-Type: application/json;charset=UTF-8
   "senderKey": String,
   "chatBubbleType": "PREMIUM_VIDEO",
   "pushAlarm": boolean,
+  "requestDate": String,
+  "unsubscribeNo": String,
+  "unsubscribeAuthNo": String,
   "adult": boolean,
   "content": String,
   "header": String,
@@ -649,57 +723,72 @@ Content-Type: application/json;charset=UTF-8
           "resendContent": String,
           "resendSendNo": String,
           "resendUnsubscribeNo": String
-      }
+      },
+      "targeting": String,
+      "unsubscribeNo": String,
+      "unsubscribeAuthNo": String,
+      "recipientGroupingKey": String
     }
   ],
+  "senderGroupingKey": String,
+  "resellerCode": String,
   "createUser": String,
   "statsId": String
 }
 ```
 
-| 名前                   | タイプ    | 必須 | 説明                                                                                                                                                                                                                                                                          |
+| 名前                     | タイプ      | 必須 | 説明                                                                                                                                                                                                                                                                            |
 |------------------------|---------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| senderKey              | String  | O  | 発信キー(40文字). グループ発信キーは使用不可                                                                                                                                                                                                                                                     |
-| chatBubbleType         | String  | O  | メッセージタイプ(TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)                                                                                                                                                                         |
-| pushAlarm | boolean | X | メッセージプッシュ通知の送信有無(デフォルト: true) |
-| adult                  | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                                                                       |
-| content | String | X | - TEXTタイプの場合、最大1,300文字(改行:最大99個、URL形式の入力が可能)<br>- IMAGEタイプの場合、最大1,300文字(改行:最大99回、URL形式の入力が可能)<br>- WIDEタイプの場合、最大76文字(改行:最大5回)<br>- PREMIUM_VIDEOタイプの場合、このフィールドをオプションとして使用可能、最大76文字(改行:最大5回)<br>- その他のタイプの場合、このフィールドは使用しません |
-| header | String | X | ヘッダ<br>- WIDE_ITEM_LISTタイプの場合、必須フィールドで最大20文字(改行:不可)<br>- PREMIUM_VIDEOタイプの場合、任意フィールドで最大20文字(改行:不可) |
-| video | Object | O | 動画要素(PREMIUM_VIDEOタイプのみ使用可能) |
-| - videoUrl | String | O | カカオTV動画URL (カカオTVにアップロードされた動画アドレスのみ使用可能)、最大500文字制限 |
-| - thumbnailUrl | String | X | 動画サムネイル用画像URL、一般画像としてアップロードされたURLのみ使用可能(ない場合、カカオTV動画の基本サムネイルを使用) 、最大500文字制限 |
-| buttons | List | X | ボタンリスト<br>- TEXT、IMAGEタイプの場合、クーポン適用時は最大4件、それ以外は最大5件<br>- WIDE、WIDE_ITEM_LISTタイプの場合、最大2件<br>- PREMIUM_VIDEOタイプの場合、最大1件<br>- COMMERCEタイプの場合、最小1件、最大2件 |
-| - name | String | O | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字 |
-| - type | String | O | ボタンタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- BTタイプはカカオオープンビルダーのチャットボットを使用するチャンネルのみ利用可能<br>- BFタイプは最初のボタンとしてのみ使用でき、nameには以下の3つのフレーズのみ使用可能<br> - トークで予約する<br> - トークでアンケートする<br> - トークで応募する |
-| - linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド)、1,000文字制限 |
-| - linkPc | String | X | PCWebリンク(WLタイプの場合、任意フィールド)、1,000文字制限 |
-| - schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限 |
-| - schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限 |
-| - chatExtra | String | X | BTタイプのボタンの場合、伝達するメタ情報 |
-| - chatEvent | String | X | BTタイプのボタンの場合、連携するボットイベント名 |
-| - bizFormKey | String | X | BFタイプのボタンの場合、ビズフォームキー |
-| coupon                 | Object  | X  | クーポン要素                                                                                                                                                                                                                                                                       |
-| - title | String | O | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」 |
-| - description | String | O | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字。改行:不可<br>- その他のタイプの場合、最大12文字。改行:不可 |
-| - linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
-| - linkPc | String | X | PCWebリンク(WLタイプの場合、任意フィールド)、1,000文字制限 |
-| - schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
-| - schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
-| recipientList          | List    | O  | 受信者リスト(最大1,000人)                                                                                                                                                                                                                                                             |
-| - recipientNo          | String  | O  | 受信番号                                                                                                                                                                                                                                                                       |
-| - resendParameter      | Object  | X  | 代替送信情報                                                                                                                                                                                                                                                                    |
-| -- isResend | boolean | X | 送信に失敗した場合、メッセージを代替送信するかどうか<br>コンソールで代替送信を設定した場合、基本設定として代替送信されます。 |
-| -- resendType | String | X | 代替送信タイプ(SMS、LMS)<br>値がない場合、テンプレート本文の長さに応じてタイプが区分されます。 |
-| -- resendTitle | String | X | LMS代替送信の件名<br>(値がない場合、プラスフレンドIDで代替送信されます。) |
-| -- resendContent | String | X | 代替送信の内容<br>(値がない場合、[メッセージ本文]で代替送信されます。) |
-| -- resendSendNo | String | X | 代替送信の送信者番号<br><span style="color:red">(SMSサービスに登録されている送信者番号ではない場合、代替送信に失敗することがあります。)</span> |
-| -- resendUnsubscribeNo | String | X | 代替送信080受信拒否番号<br><span style="color:red">(SMSサービスに登録された080受信拒否番号ではない場合、代替送信に失敗することがあります。)</span> |
-| createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
-| statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
+| senderKey              | String  | O  | 発信キー（40文字）。グループ発信キーは使用不可                                                                                                                                                                                                                                                       |
+| chatBubbleType         | String  | O  | メッセージタイプ（TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE）                                                                                                                                                                         |
+| pushAlarm              | boolean | X  | メッセージプッシュ通知の送信有無（デフォルト値: true）                                                                                                                                                                                                                                                   |
+| requestDate            | String  | X  | リクエスト日時（yyyy-MM-dd HH:mm）<br>（入力しない場合は即時送信）<br>最大60日後まで予約可能                                                                                                                                                                                                                                                   |
+| unsubscribeNo       | String  | X  | 080受信拒否無料電話番号（すべて未入力の場合、発信プロフィールに登録された受信拒否情報で送信されます）<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx         |
+| unsubscribeAuthNo   | String  | X  | 080受信拒否認証番号（最大10文字、すべて未入力の場合、発信プロフィールに登録された受信拒否情報で送信されます）<br>unsubscribeNo なしに unsubscribeAuthNo のみ入力不可<br>例: 1234        |
+| adult                  | boolean | X  | 成人向けメッセージかどうか（デフォルト値: false）                                                                                                                                                                                                                                                       |
+| content                | String  | X  | - TEXT タイプの場合、最大1,300文字（改行: 最大99個、URL形式の入力可能）<br>- IMAGE タイプの場合、最大1,300文字（改行: 最大99個、URL形式の入力可能）<br>- WIDE タイプの場合、最大76文字（改行: 最大5個）<br>- PREMIUM_VIDEO タイプの場合、このフィールドは任意で使用可能、最大76文字（改行: 最大5個）<br>- その他のタイプの場合、このフィールドは使用しません                           |
+| header                 | String  | X  | ヘッダー<br>- WIDE_ITEM_LIST タイプの場合、必須フィールドで最大20文字（改行: 不可）<br>- PREMIUM_VIDEO タイプの場合、任意フィールドで最大20文字（改行: 不可）                                                                                                                                                                     |
+| video                  | Object  | O  | 動画要素（PREMIUM_VIDEO タイプのみ使用可能）                                                                                                                                                                                                                                              |
+| - videoUrl             | String  | O  | カカオTV動画URL（カカオTVにアップロードされた動画のURLのみ使用可能）、最大500文字制限                                                                                                                                                                                                                         |
+| - thumbnailUrl         | String  | X  | 動画サムネイル用画像URL、通常の画像としてアップロードされたURLのみ使用可能（ない場合はカカオTV動画のデフォルトサムネイルを使用）、最大500文字制限                                                                                                                                                                                            |
+| buttons                | List    | X  | ボタンリスト<br>- TEXT、IMAGE タイプの場合、クーポン適用時は最大4個、それ以外は最大5個<br>- WIDE、WIDE_ITEM_LIST タイプの場合、最大2個<br>- PREMIUM_VIDEO タイプの場合、最大1個<br>- COMMERCE タイプの場合、最小1個、最大2個                                                                                                                 |
+| - name                 | String  | O  | ボタンタイトル<br>- TEXT、IMAGE タイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字                                                                                                                                                                                                                    |
+| - type                 | String  | O  | ボタンタイプ（WL: Webリンク、AL: アプリリンク、BK: ボットキーワード、MD: メッセージ転送、AC: チャンネル追加、BT: チャットボット切替、BF: ビジネスフォーム）<br>- BT タイプはカカオオープンビルダーのチャットボットを使用するチャンネルのみ利用可能<br>- BF タイプは最初のボタンとしてのみ使用可能で、name には次の3つの文言のみ使用可能<br>  - トークで予約する<br>  - トークでアンケートする<br>  - トークで応募する |
+| - linkMo               | String  | X  | モバイルWebリンク（WL タイプの場合は必須フィールド）、1,000文字制限                                                                                                                                                                                                                                         |
+| - linkPc               | String  | X  | PC Webリンク（WL タイプの場合は任意フィールド）、1,000文字制限                                                                                                                                                                                                                                          |
+| - schemeAndroid        | String  | X  | Android アプリリンク（AL タイプの場合は必須フィールド）、1,000文字制限                                                                                                                                                                                                                                       |
+| - schemeIos            | String  | X  | iOS アプリリンク（AL タイプの場合は必須フィールド）、1,000文字制限                                                                                                                                                                                                                                         |
+| - chatExtra            | String  | X  | BT タイプのボタンの場合、転送するメタ情報                                                                                                                                                                                                                                                   |
+| - chatEvent            | String  | X  | BT タイプのボタンの場合、連携するボットイベント名                                                                                                                                                                                                                                                       |
+| - bizFormKey           | String  | X  | BF タイプのボタンの場合、ビズフォームキー                                                                                                                                                                                                                                                            |
+| coupon                 | Object  | X  | クーポン要素                                                                                                                                                                                                                                                                         |
+| - title                | String  | O  | title は5種類の形式に限定されます<br>- 「${数字}円割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内} UP クーポン」                                                                                                            |
+| - description          | String  | O  | クーポン詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO タイプの場合、最大18文字。改行: 不可<br>- その他のタイプの場合、最大12文字。改行: 不可                                                                                                                                                                      |
+| - linkMo               | String  | X  | モバイルWebリンク（WL タイプの場合は必須フィールド）、1,000文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポンURL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）となります。                                                                                   |
+| - linkPc               | String  | X  | PC Webリンク（WL タイプの場合は任意フィールド）、1,000文字制限                                                                                                                                                                                                                                          |
+| - schemeAndroid        | String  | X  | Android アプリリンク（AL タイプの場合は必須フィールド）、1,000文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポンURL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）となります。                                                                                 |
+| - schemeIos            | String  | X  | iOS アプリリンク（AL タイプの場合は必須フィールド）、1,000文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポンURL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）となります。                                                                                   |
+| recipientList          | List    | O  | 受信者リスト（最大1,000名）                                                                                                                                                                                                                                                             |
+| - recipientNo          | String  | O  | 受信番号                                                                                                                                                                                                                                                                         |
+| - resendParameter      | Object  | X  | 代替送信情報                                                                                                                                                                                                                                                                      |
+| -- isResend            | boolean | X  | 送信失敗時、SMS代替送信を行うかどうか<br>コンソールで代替送信設定をした場合、デフォルトで代替送信されます。                                                                                                                                                                                                                       |
+| -- resendType          | String  | X  | 代替送信タイプ（SMS、LMS）<br>値がない場合、テンプレート本文の長さに応じてタイプが決定されます。                                                                                                                                                                                                                       |
+| -- resendTitle         | String  | X  | LMS代替送信タイトル<br>（値がない場合、プラスフレンドIDで代替送信されます。）                                                                                                                                                                                                                               |
+| -- resendContent       | String  | X  | 代替送信内容<br>（値がない場合、[メッセージ本文]で代替送信されます。）                                                                                                                                                                                                                                  |
+| -- resendSendNo        | String  | X  | 代替送信の発信番号<br><span style="color:red">（SMSサービスに登録された発信番号でない場合、代替送信に失敗する可能性があります。）</span>                                                                                                                                                                                 |
+| -- resendUnsubscribeNo | String  | X  | 代替送信080受信拒否番号<br><span style="color:red">（SMSサービスに登録された080受信拒否番号でない場合、代替送信に失敗する可能性があります。）</span>                                                                                                                                                                       |
+| - targeting         | String  | X  | メッセージ対象のタイプ（M: マーケティング受信同意ユーザー、N: フレンドではないマーケティング受信同意ユーザーのみ、I: フレンドであるユーザー）                                                |
+| - unsubscribeNo       | String  | X  | 080無料受信拒否電話番号（すべて未入力の場合、発信プロフィールに登録された無料受信拒否情報で送信されます）<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx         |
+| - unsubscribeAuthNo   | String  | X  | 080無料受信拒否認証番号（最大10文字、すべて未入力の場合、発信プロフィールに登録された無料受信拒否情報で送信されます）<br>unsubscribeNoなしでunsubscribeAuthNoのみ入力不可<br>例: 1234        |
+| - recipientGroupingKey | String  | X  | 受信者グルーピングキー（受信者ごとにグルーピングキーを指定できます。最大100文字）                                                                                                                                                                                                                   |
+| senderGroupingKey    | String  | X  | 発信者グルーピングキー（発信者ごとにグルーピングキーを指定できます。最大100文字）                                                                                                                                                                                                                   |
+| resellerCode          | String  | X  | リセラーコード（リセラーが送信する際に使用）                                                                                                                                                                                                                                                       |
+| createUser             | String  | X  | 登録者（コンソールから送信する場合、ユーザーのUUIDで保存されます）                                                                                                                                                                                                                                                   |
+| statsId                | String  | 	X | 統計ID（発信検索条件には含まれません。最大8文字）                                                                                                                                                                                                                                            |
 
 <a id="request-to-send-commerce"></a>
 
-#### コマース形式の送信リクエスト
+#### コマース型送信リクエスト
 
 [Request body]
 
@@ -708,6 +797,9 @@ Content-Type: application/json;charset=UTF-8
   "senderKey": String,
   "chatBubbleType": "COMMERCE",
   "pushAlarm": boolean,
+  "requestDate": String,
+  "unsubscribeNo": String,
+  "unsubscribeAuthNo": String,
   "adult": boolean,
   "additionalContent": String,
   "image": {
@@ -752,62 +844,98 @@ Content-Type: application/json;charset=UTF-8
           "resendContent": String,
           "resendSendNo": String,
           "resendUnsubscribeNo": String
-      }
+      },
+      "targeting": String,
+      "unsubscribeNo": String,
+      "unsubscribeAuthNo": String,
+      "recipientGroupingKey": String
     }
   ],
+  "senderGroupingKey": String,
+  "resellerCode": String,
   "createUser": String,
   "statsId": String
 }
 ```
 
-| 名前                   | タイプ    | 必須 | 説明                                                                                                                                                                                                                                                                          |
+| 名前                     | タイプ      | 必須 | 説明                                                                                                                                                                                                                                                                            |
 |------------------------|---------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| senderKey              | String  | O  | 発信キー(40文字). グループ発信キーは使用不可                                                                                                                                                                                                                                                     |
-| chatBubbleType         | String  | O  | メッセージタイプ(TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)                                                                                                                                                                         |
-| pushAlarm | boolean | X | メッセージプッシュ通知の送信有無(デフォルト: true) |
-| adult                  | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                                                                       |
-| additionalContent | String | X | 付加情報(最大34文字、改行:最大1回)、コマース形式でのみ使用可能 |
-| image | Object | O | 画像要素<br>- IMAGE、WIDE、COMMERCEタイプの場合、必須フィールド |
-| - imageUrl | String | O | 画像URL。一般画像としてアップロードされた画像URLを使用 |
-| - imageLink | String | X | 画像をクリックしたときに移動するURL。1,000文字制限<br>未設定の場合、カカオトーク内の画像ビューアを使用 |
-| commerce | Object | O | コマース(COMMERCEタイプでのみ使用可能) |
-| title | String | O | 商品名(最大30文字、改行:不可) |
-| regularPrice | Integer | O | 通常価格(0～99,999,999) |
-| discountPrice | Integer | X | 割引価格(0～99,999,999) |
-| discountRate | Integer | X | 割引率(0～100)、割引価格が存在する場合、割引率、定額割引価格のいずれかは必須 |
-| discountFixed | Integer | X | 定額割引価格(0 ～ 999,999)、割引価格が存在する場合、割引率、定額割引価格のいずれかは必須 |
-| buttons | List | O | ボタンリスト<br>- TEXT、IMAGEタイプの場合、クーポン適用時は最大4件、それ以外は最大5件<br>- WIDE、WIDE_ITEM_LISTタイプの場合、最大2件<br>- PREMIUM_VIDEOタイプの場合、最大1件<br>- COMMERCEタイプの場合、最小1件、最大2件 |
-| - name | String | O | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字 |
-| - type | String | O | ボタンタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- BTタイプはカカオオープンビルダーのチャットボットを使用するチャンネルのみ利用可能<br>- BFタイプは最初のボタンとしてのみ使用でき、nameには以下の3つのフレーズのみ使用可能<br> - トークで予約する<br> - トークでアンケートする<br> - トークで応募する |
-| - linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド)、1,000文字制限 |
-| - linkPc | String | X | PCWebリンク(WLタイプの場合、任意フィールド)、1,000文字制限 |
-| - schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限 |
-| - schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限 |
-| - chatExtra | String | X | BTタイプのボタンの場合、伝達するメタ情報 |
-| - chatEvent | String | X | BTタイプのボタンの場合、連携するボットイベント名 |
-| - bizFormKey | String | X | BFタイプのボタンの場合、ビズフォームキー |
-| coupon                 | Object  | X  | クーポン要素                                                                                                                                                                                                                                                                       |
-| - title | String | O | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」 |
-| - description | String | O | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字。改行:不可<br>- その他のタイプの場合、最大12文字。改行:不可 |
-| - linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
-| - linkPc | String | X | PCWebリンク(WLタイプの場合、任意フィールド)、1,000文字制限 |
-| - schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
-| - schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
-| recipientList          | List    | O  | 受信者リスト(最大1,000人)                                                                                                                                                                                                                                                             |
-| - recipientNo          | String  | O  | 受信番号                                                                                                                                                                                                                                                                       |
-| - resendParameter      | Object  | X  | 代替送信情報                                                                                                                                                                                                                                                                    |
-| -- isResend | boolean | X | 送信に失敗した場合、メッセージを代替送信するかどうか<br>コンソールで代替送信を設定した場合、基本設定として代替送信されます。 |
-| -- resendType | String | X | 代替送信タイプ(SMS、LMS)<br>値がない場合、テンプレート本文の長さに応じてタイプが区分されます。 |
-| -- resendTitle | String | X | LMS代替送信の件名<br>(値がない場合、プラスフレンドIDで代替送信されます。) |
-| -- resendContent | String | X | 代替送信の内容<br>(値がない場合、[メッセージ本文]で代替送信されます。) |
-| -- resendSendNo | String | X | 代替送信の送信者番号<br><span style="color:red">(SMSサービスに登録されている送信者番号ではない場合、代替送信に失敗することがあります。)</span> |
-| -- resendUnsubscribeNo | String | X | 代替送信080受信拒否番号<br><span style="color:red">(SMSサービスに登録された080受信拒否番号ではない場合、代替送信に失敗することがあります。)</span> |
-| createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
-| statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
+| senderKey              | String  | O  | 発信キー（40文字）。グループ発信キーは使用不可                                                                                                                                                                                                                                                       |
+| chatBubbleType         | String  | O  | メッセージタイプ（TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE）                                                                                                                                                                         |
+| pushAlarm              | boolean | X  | メッセージのプッシュ通知送信有無（デフォルト値: true）                                                                                                                                                                                                                                                   |
+| requestDate            | String  | X  | リクエスト日時（yyyy-MM-dd HH:mm）<br>（入力しない場合は即時送信）<br>最大60日後まで予約可能                                                                                                                                                                                                                                                   |
+| unsubscribeNo       | String  | X  | 080受信拒否無料電話番号（すべて未入力の場合、発信プロフィールに登録された受信拒否情報で送信されます）<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx         |
+| unsubscribeAuthNo   | String  | X  | 080受信拒否認証番号（最大10文字、すべて未入力の場合、発信プロフィールに登録された受信拒否情報で送信されます）<br>unsubscribeNo なしで unsubscribeAuthNo のみの入力は不可<br>例: 1234        |
+| adult                  | boolean | X  | 成人向けメッセージかどうか（デフォルト値: false）                                                                                                                                                                                                                                                       |
+| additionalContent      | String  | X  | 付加情報（最大34文字、改行: 最大1個）、コマース型のみ使用可能                                                                                                                                                                                                                                      |
+| image                  | Object  | O  | 画像要素<br>- IMAGE、WIDE、COMMERCE タイプの場合は必須フィールド                                                                                                                                                                                                                                |
+| - imageUrl             | String  | O  | 画像 URL。通常画像としてアップロードされた画像 URL を使用                                                                                                                                                                                                                                              |
+| - imageLink            | String  | X  | 画像クリック時の遷移先 URL。1,000文字制限<br>未設定の場合はカカオトーク内画像ビューワーを使用                                                                                                                                                                                                                            |
+| commerce               | Object  | O  | コマース（COMMERCE タイプのみ使用可能）                                                                                                                                                                                                                                                    |
+| title                  | String  | O  | 商品タイトル（最大30文字、改行: 不可）                                                                                                                                                                                                                                                       |
+| regularPrice           | Integer | O  | 通常価格（0〜99,999,999）                                                                                                                                                                                                                                                        |
+| discountPrice          | Integer | X  | 割引価格（0〜99,999,999）                                                                                                                                                                                                                                                          |
+| discountRate           | Integer | X  | 割引率（0〜100）。割引価格が存在する場合、割引率と定額割引価格のいずれか一方は必須                                                                                                                                                                                                                                   |
+| discountFixed          | Integer | X  | 定額割引価格（0〜999,999）。割引価格が存在する場合、割引率と定額割引価格のいずれか一方は必須                                                                                                                                                                                                                            |
+| buttons                | List    | O  | ボタンリスト<br>- TEXT、IMAGE タイプの場合、クーポン適用時は最大4個、それ以外は最大5個<br>- WIDE、WIDE_ITEM_LIST タイプの場合は最大2個<br>- PREMIUM_VIDEO タイプの場合は最大1個<br>- COMMERCE タイプの場合は最小1個・最大2個                                                                                                                 |
+| - name                 | String  | O  | ボタンタイトル<br>- TEXT、IMAGE タイプの場合は最大14文字<br>- その他のタイプの場合は最大8文字                                                                                                                                                                                                                    |
+| - type                 | String  | O  | ボタンタイプ（WL: Webリンク、AL: アプリリンク、BK: Botキーワード、MD: メッセージ転送、AC: チャンネル追加、BT: チャットボット切替、BF: ビジネスフォーム）<br>- BT タイプはカカオオープンビルダーのチャットボットを使用するチャンネルのみ利用可能<br>- BF タイプは最初のボタンとしてのみ使用可能で、name には次の3種類の文言のみ使用可能<br>  - トークで予約する<br>  - トークでアンケートする<br>  - トークで応募する |
+| - linkMo               | String  | X  | モバイル Web リンク（WL タイプの場合は必須フィールド）、1,000文字制限                                                                                                                                                                                                                                         |
+| - linkPc               | String  | X  | PC Web リンク（WL タイプの場合は任意フィールド）、1,000文字制限                                                                                                                                                                                                                                          |
+| - schemeAndroid        | String  | X  | Android アプリリンク（AL タイプの場合は必須フィールド）、1,000文字制限                                                                                                                                                                                                                                       |
+| - schemeIos            | String  | X  | iOS アプリリンク（AL タイプの場合は必須フィールド）、1,000文字制限                                                                                                                                                                                                                                         |
+| - chatExtra            | String  | X  | BT タイプボタンの場合に転送するメタ情報                                                                                                                                                                                                                                                   |
+| - chatEvent            | String  | X  | BT タイプボタンの場合に接続するBotイベント名                                                                                                                                                                                                                                                       |
+| - bizFormKey           | String  | X  | BF タイプボタンの場合のビズフォームキー                                                                                                                                                                                                                                                            |
+| coupon                 | Object  | X  | クーポン要素                                                                                                                                                                                                                                                                         |
+| - title                | String  | O  | title は5種類の形式のみ使用可能<br>- 「${数字}円割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内} UP クーポン」                                                                                                            |
+| - description          | String  | O  | クーポン詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO タイプの場合は最大18文字。改行: 不可<br>- その他のタイプの場合は最大12文字。改行: 不可                                                                                                                                                                      |
+| - linkMo               | String  | X  | モバイル Web リンク（WL タイプの場合は必須フィールド）、1,000 文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）になります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）になります。                                                                                   |
+| - linkPc               | String  | X  | PC Web リンク（WL タイプの場合は任意フィールド）、1,000 文字制限                                                                                                                                                                                                                          |
+| - schemeAndroid        | String  | X  | Android アプリリンク（AL タイプの場合は必須フィールド）、1,000 文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）になります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）になります。                                                                                 |
+| - schemeIos            | String  | X  | iOS アプリリンク（AL タイプの場合は必須フィールド）、1,000 文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）になります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）になります。                                                                                   |
+| recipientList          | List    | O  | 受信者リスト（最大 1,000 名）                                                                                                                                                                                                                                                             |
+| - recipientNo          | String  | O  | 受信番号                                                                                                                                                                                                                                                                         |
+| - resendParameter      | Object  | X  | 代替送信情報                                                                                                                                                                                                                                                                      |
+| -- isResend            | boolean | X  | 送信失敗時、SMS 代替送信の有無<br>コンソールで代替送信設定時、デフォルト値として代替送信されます。                                                                                                                                                                                                                       |
+| -- resendType          | String  | X  | 代替送信タイプ（SMS、LMS）<br>値がない場合、テンプレート本文の長さによってタイプが決定されます。                                                                                                                                                                                                                       |
+| -- resendTitle         | String  | X  | LMS 代替送信タイトル<br>（値がない場合、プラスフレンド ID で代替送信されます。）                                                                                                                                                                                                                               |
+| -- resendContent       | String  | X  | 代替送信内容<br>（値がない場合、[メッセージ本文] で代替送信されます。）                                                                                                                                                                                                                                  |
+| -- resendSendNo        | String  | X  | 代替送信の発信番号<br><span style="color:red">（SMS サービスに登録された発信番号でない場合、代替送信に失敗する可能性があります。）</span>                                                                                                                                                                                 |
+| -- resendUnsubscribeNo | String  | X  | 代替送信の 080 受信拒否番号<br><span style="color:red">（SMS サービスに登録された 080 受信拒否番号でない場合、代替送信に失敗する可能性があります。）</span>                                                                                                                                                                       |
+| - targeting         | String  | X  | メッセージ対象のタイプ（M: マーケティング受信同意ユーザー、N: フレンドではないマーケティング受信同意ユーザーのみ、I: フレンドであるユーザー）                                                |
+| - unsubscribeNo       | String  | X  | 080 無料受信拒否電話番号（すべて未入力の場合、発信プロフィールに登録された無料受信拒否情報で送信されます）<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx         |
+| - unsubscribeAuthNo   | String  | X  | 080 無料受信拒否認証番号（最大 10 文字、すべて未入力の場合、発信プロフィールに登録された無料受信拒否情報で送信されます）<br>unsubscribeNo なしで unsubscribeAuthNo のみ入力不可<br>例: 1234        |
+| - recipientGroupingKey | String  | X  | 受信者グループキー（受信者ごとにグループキーを指定できます。最大 100 文字）                                                                                                                                                                                                                   |
+| senderGroupingKey    | String  | X  | 発信者グループキー（発信者ごとにグループキーを指定できます。最大 100 文字）                                                                                                                                                                                                                   |
+| resellerCode          | String  | X  | リセラーコード（リセラーが送信時に使用）                                                                                                                                                                                                                                                       |
+| createUser             | String  | X  | 登録者（コンソールから送信時、ユーザー UUID として保存）                                                                                                                                                                                                                                                   |
+| statsId                | String  | 	X | 統計 ID（発信検索条件には含まれません。最大 8 文字）                                                                                                                                                                                                                                            |
 
 <a id="request-to-send-carousel-feed-type"></a>
 
-#### カルーセルフィード形式の送信リクエスト
+#### カルーセルフィード型送信リクエスト
+
+##### カルーセル固定置換変数（path ベースのテンプレートパラメータ）
+
+カルーセルタイプでは、各アイテムに異なる置換変数の値を適用できます。
+
+* **使用形式**: `キー@$.carousel.list[インデックス]`（例: `productName@$.carousel.list[0]`）
+* head（カルーセルイントロ）がある場合、head が `list[0]` を占め、実際のアイテムは `list[1]` から始まります。
+* path ベースのキーで値が見つからない場合、通常のキーにフォールバックされます。
+
+| 区分 | 置換可能フィールド | path 形式 |
+|------|----------------|----------|
+| カルーセルイントロ（head） | header, content, linkMo, linkPc, schemeAndroid, schemeIos | `キー@$.carousel.list[0]`（head が存在する場合） |
+| カルーセルアイテム | header, message, additionalContent | `キー@$.carousel.list[インデックス]` |
+| カルーセルアイテムボタン | linkMo, linkPc, schemeAndroid, schemeIos | `キー@$.carousel.list[インデックス]` |
+| カルーセルアイテムクーポン | title, description, linkMo, linkPc, schemeAndroid, schemeIos | `キー@$.carousel.list[インデックス]` |
+| カルーセルアイテムコマース | title | `キー@$.carousel.list[インデックス]` |
+
+* **Tail**: 置換変数は使用できません。
+* ボタンのインデックスは path に含まれません。同じアイテム内のボタンは、同一の path 値で置換されます。
+
+> **注意** 置換変数キー（`#{key}`）には `@` 文字を使用できません。`@` はシステムで path の区切り文字として使用されます。
 
 [Request body]
 
@@ -816,6 +944,9 @@ Content-Type: application/json;charset=UTF-8
   "senderKey": String,
   "chatBubbleType": "CAROUSEL_FEED",
   "pushAlarm": boolean,
+  "requestDate": String,
+  "unsubscribeNo": String,
+  "unsubscribeAuthNo": String,
   "adult": boolean,
   "carousel": {
     "list": [
@@ -891,84 +1022,78 @@ Content-Type: application/json;charset=UTF-8
           "resendContent": String,
           "resendSendNo": String,
           "resendUnsubscribeNo": String
-      }
+      },
+      "targeting": String,
+      "unsubscribeNo": String,
+      "unsubscribeAuthNo": String,
+      "recipientGroupingKey": String
     }
   ],
+  "senderGroupingKey": String,
+  "resellerCode": String,
   "createUser": String,
   "statsId": String
 }
 ```
 
-| 名前                   | タイプ    | 必須 | 説明                                                                                                                                                                                                                                                                          |
+| 名前                     | タイプ      | 必須 | 説明                                                                                                                                                                                                                                                                            |
 |------------------------|---------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| senderKey              | String  | O  | 発信キー(40文字). グループ発信キーは使用不可                                                                                                                                                                                                                                                     |
-| chatBubbleType         | String  | O  | メッセージタイプ(TEXT, IMAGE, WIDE, WIDE_ITEM_LIST, PREMIUM_VIDEO, COMMERCE, CAROUSEL_FEED, CAROUSEL_COMMERCE)                                                                                                                                                                         |
-| pushAlarm | boolean | X | メッセージプッシュ通知の送信有無(デフォルト: true) |
-| adult                  | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                                                                       |
-| carousel               | Object  | O  | カルーセル                                                                                                                                                                                                                                                                         |
-| - list | List | O | カルーセルリスト(最小2件、最大6件) |
-| -- header | String | O | カルーセルアイテムのタイトル(最大20文字)。カルーセルフィード形式でのみ使用可能 |
-| -- message | String | O | カルーセルアイテムのタイトル(最大20文字)、カルーセルアイテムのメッセージ(最大180文字)。カルーセルフィード形式でのみ使用可能 |
-| -- imageUrl | String | O | 画像URL(カルーセルフィード形式の画像としてアップロードされた画像のみ使用可能) |
-| -- imageLink           | String  | X  | 画像リンク、1,000文字制限                                                                                                                                                                                                                                                            |
-| -- buttons | List | O | カルーセルリストのボタンリスト最小1件、最大2件 |
-| --- name | String | O | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字 |
-| --- type | String | O | ボタンタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- BTタイプはカカオオープンビルダーのチャットボットを使用するチャンネルのみ利用可能<br>- BFタイプは最初のボタンとしてのみ使用でき、nameには以下の3つのフレーズのみ使用可能<br> - トークで予約する<br> - トークでアンケートする<br> - トークで応募する |
-| --- linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド)、1,000文字制限 |
-| --- linkPc | String | X | PC Webリンク(WLタイプの場合、任意フィールド)、1,000文字制限 |
-| --- schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限 |
-| --- schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限 |
-| --- chatExtra          | String  | X  | BTタイプのボタンの場合、伝達するメタ情報                                                                                                                                                                                                                                                 |
-| --- chatEvent          | String  | X  | BTタイプのボタンの場合、接続するボットイベント名                                                                                                                                                                                                                                                     |
-| --- bizFormKey | String | X | BFタイプのボタンの場合、ビズフォームキー |
-| -- coupon              | Object  | X  | クーポン要素                                                                                                                                                                                                                                                                       |
-| --- title | String | O | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」 |
-| --- description | String | O | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字、改行:不可<br>- その他のタイプの場合、最大12文字、改行:不可 |
-| --- linkMo | String | X | モバイルWebリンク(WLタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
-| --- linkPc | String | X | PC Webリンク(WLタイプの場合、任意フィールド)、1,000文字制限 |
-| --- schemeAndroid | String | X | Androidアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
-| --- schemeIos | String | X | iOSアプリリンク(ALタイプの場合、必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。 |
-| - tail | Object | X | もっと見るボタン情報 |
-| -- linkMo              | String  | O  | モバイルWebリンク、1,000文字制限                                                                                                                                                                                                                                                         |
-| -- linkPc              | String  | X  | PC Webリンク、1,000文字制限                                                                                                                                                                                                                                                          |
-| -- schemeAndroid       | String  | X  | Androidアプリリンク、1,000文字制限                                                                                                                                                                                                                                                       |
-| -- schemeIos           | String  | X  | iOSアプリリンク、1,000文字制限                                                                                                                                                                                                                                                         |
-| recipientList          | List    | O  | 受信者リスト(最大1,000人)                                                                                                                                                                                                                                                             |
-| - recipientNo          | String  | O  | 受信番号                                                                                                                                                                                                                                                                       |
-| - resendParameter      | Object  | X  | 代替送信情報                                                                                                                                                                                                                                                                    |
-| -- isResend | boolean | X | 送信に失敗した場合、メッセージを代替送信するかどうか<br>コンソールで代替送信を設定した場合、基本設定として代替送信されます。 |
-| -- resendType | String | X | 代替送信タイプ(SMS、LMS)<br>値がない場合、テンプレート本文の長さに応じてタイプが区分されます。 |
-| -- resendTitle | String | X | LMS代替送信の件名<br>(値がない場合、プラスフレンドIDで代替送信されます。) |
-| -- resendContent | String | X | 代替送信の内容<br>(値がない場合、[メッセージ本文]で代替送信されます。) |
-| -- resendSendNo | String | X | 代替送信の送信者番号<br><span style="color:red">(SMSサービスに登録されている送信者番号ではない場合、代替送信に失敗することがあります。)</span> |
-| -- resendUnsubscribeNo | String | X | 代替送信080受信拒否番号<br><span style="color:red">(SMSサービスに登録された080受信拒否番号ではない場合、代替送信に失敗することがあります。)</span> |
-| createUser | String | X | 登録者(コンソールから送信した場合、ユーザーUUIDで保存) |
-| statsId                | String  | 	X | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                                                            |
+| senderKey              | String  | O  | 発信キー（40文字）。グループ発信キーは使用不可                                                                                                                                                                                                                                                       |
+| chatBubbleType         | String  | O  | メッセージタイプ（TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE）                                                                                                                                                                         |
+| pushAlarm              | boolean | X  | メッセージプッシュ通知送信有無（デフォルト値: true）                                                                                                                                                                                                                                                   |
+| requestDate            | String  | X  | リクエスト日時（yyyy-MM-dd HH:mm）<br>（入力しない場合は即時送信）<br>最大60日後まで予約可能                                                                                                                                                                                                                                                   |
+| unsubscribeNo       | String  | X  | 080受信拒否無料電話番号（すべて未入力の場合、発信プロフィールに登録された受信拒否情報で送信されます）<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx         |
+| unsubscribeAuthNo   | String  | X  | 080受信拒否認証番号（最大10文字、すべて未入力の場合、発信プロフィールに登録された受信拒否情報で送信されます）<br>unsubscribeNoなしでunsubscribeAuthNoのみの入力は不可<br>例: 1234        |
+| adult                  | boolean | X  | 成人向けメッセージ有無（デフォルト値: false）                                                                                                                                                                                                                                                       |
+| carousel               | Object  | O  | カルーセル                                                                                                                                                                                                                                                                           |
+| - list                 | List    | O  | カルーセルリスト（最小2個、最大6個）                                                                                                                                                                                                                                                        |
+| -- header              | String  | O  | カルーセルアイテムタイトル（最大20文字）。カルーセルフィードタイプでのみ使用可能                                                                                                                                                                                                                                          |
+| -- message             | String  | O  | カルーセルアイテムタイトル（最大20文字）、カルーセルアイテムメッセージ（最大180文字）。カルーセルフィードタイプでのみ使用可能                                                                                                                                                                                                                    |
+| -- imageUrl            | String  | O  | 画像URL（カルーセルフィードタイプの画像としてアップロードされた画像のみ使用可能）                                                                                                                                                                                                                                        |
+| -- imageLink           | String  | X  | 画像リンク、1,000文字制限                                                                                                                                                                                                                                                              |
+| -- buttons             | List    | O  | カルーセルリストボタンリスト 最小1個、最大2個                                                                                                                                                                                                                                                    |
+| --- name               | String  | O  | ボタンタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字                                                                                                                                                                                                                    |
+| --- type               | String  | O  | ボタンタイプ（WL: Webリンク、AL: アプリリンク、BK: ボットキーワード、MD: メッセージ転送、AC: チャンネル追加、BT: チャットボット切替、BF: ビジネスフォーム）<br>- BTタイプはカカオオープンビルダーのチャットボットを使用するチャンネルのみ利用可能<br>- BFタイプは最初のボタンとしてのみ使用でき、nameには以下の3つの文言のみ使用可能<br>  - トークで予約する<br>  - トークでアンケートする<br>  - トークで応募する |
+| --- linkMo             | String  | X  | モバイルWebリンク（WLタイプの場合は必須フィールド）、1,000文字制限                                                                                                                                                                                                                                         |
+| --- linkPc             | String  | X  | PC Webリンク（WLタイプの場合は選択フィールド）、1,000文字制限                                                                                                                                                                                                                                          |
+| --- schemeAndroid      | String  | X  | Android アプリリンク（ALタイプの場合は必須フィールド）、1,000文字制限                                                                                                                                                                                                                                       |
+| --- schemeIos          | String  | X  | iOS アプリリンク（ALタイプの場合は必須フィールド）、1,000文字制限                                                                                                                                                                                                                                         |
+| --- chatExtra          | String  | X  | BTタイプのボタンの場合、転送するメタ情報                                                                                                                                                                                                                                                   |
+| --- chatEvent          | String  | X  | BTタイプのボタンの場合、連携するボットイベント名                                                                                                                                                                                                                                                       |
+| --- bizFormKey         | String  | X  | BFタイプのボタンの場合、ビジネスフォームキー                                                                                                                                                                                                                                                            |
+| -- coupon              | Object  | X  | クーポン要素                                                                                                                                                                                                                                                                         |
+| --- title              | String  | O  | titleは5種類の形式に限定<br>- 「${数字}円割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内} UPクーポン」                                                                                                            |
+| --- description        | String  | O  | クーポン詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字、改行: 不可<br>- その他のタイプの場合、最大12文字、改行: 不可                                                                                                                                                                      |
+| --- linkMo             | String  | X  | モバイルWebリンク（WLタイプの場合は必須フィールド）、1,000文字制限<br>クーポンにlinkMoフィールドを入力した場合、残りのフィールドは任意（オプション）になります。<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）になります。                                                                                   |
+| --- linkPc             | String  | X  | PC Webリンク（WLタイプの場合は選択フィールド）、1,000文字制限                                                                                                                                                                                                                                          |
+| --- schemeAndroid      | String  | X  | Android アプリリンク（ALタイプの場合は必須フィールド）、1,000文字制限<br>クーポンにlinkMoフィールドを入力した場合、残りのフィールドは任意（オプション）になります。<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）になります。                                                                                 |
+| --- schemeIos          | String  | X  | iOS アプリリンク（ALタイプの場合は必須フィールド）、1,000文字制限<br>クーポンにlinkMoフィールドを入力した場合、残りのフィールドは任意（オプション）になります。<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）になります。                                                                                   |
+| - tail                 | Object  | X  | もっと見るボタン情報                                                                                                                                                                                                                                                                     |
+| -- linkMo              | String  | O  | モバイル Web リンク、1,000文字制限                                                                                                                                                                                                                                                           |
+| -- linkPc              | String  | X  | PC Web リンク、1,000文字制限                                                                                                                                                                                                                                                            |
+| -- schemeAndroid       | String  | X  | Android アプリリンク、1,000文字制限                                                                                                                                                                                                                                                         |
+| -- schemeIos           | String  | X  | iOS アプリリンク、1,000文字制限                                                                                                                                                                                                                                                           |
+| recipientList          | List    | O  | 受信者リスト（最大1,000名）                                                                                                                                                                                                                                                             |
+| - recipientNo          | String  | O  | 受信番号                                                                                                                                                                                                                                                                         |
+| - resendParameter      | Object  | X  | 代替送信情報                                                                                                                                                                                                                                                                      |
+| -- isResend            | boolean | X  | 送信失敗時、SMS代替送信を行うかどうか<br>コンソールで代替送信設定を行った場合、デフォルト値として代替送信されます。                                                                                                                                                                                                                       |
+| -- resendType          | String  | X  | 代替送信タイプ（SMS、LMS）<br>値がない場合、テンプレート本文の長さによってタイプが決まります。                                                                                                                                                                                                                       |
+| -- resendTitle         | String  | X  | LMS代替送信タイトル<br>（値がない場合、プラスフレンドIDで代替送信されます。）                                                                                                                                                                                                                               |
+| -- resendContent       | String  | X  | 代替送信内容<br>（値がない場合、[メッセージ本文]で代替送信されます。）                                                                                                                                                                                                                                  |
+| -- resendSendNo        | String  | X  | 代替送信の発信番号<br><span style="color:red">（SMSサービスに登録された発信番号でない場合、代替送信に失敗する可能性があります。）</span>                                                                                                                                                                                 |
+| -- resendUnsubscribeNo | String  | X  | 代替送信の080受信拒否番号<br><span style="color:red">（SMSサービスに登録された080受信拒否番号でない場合、代替送信に失敗する可能性があります。）</span>                                                                                                                                                                       |
+| - targeting         | String  | X  | メッセージ対象のタイプ（M: マーケティング受信同意ユーザー、N: フレンドではないマーケティング受信同意ユーザーのみ、I: フレンドであるユーザー）                                                |
+| - unsubscribeNo       | String  | X  | 080無料受信拒否電話番号（すべて未入力の場合、発信プロフィールに登録された無料受信拒否情報で送信されます）<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx         |
+| - unsubscribeAuthNo   | String  | X  | 080無料受信拒否認証番号（最大10文字、すべて未入力の場合、発信プロフィールに登録された無料受信拒否情報で送信されます）<br>unsubscribeNoなしでunsubscribeAuthNoのみの入力は不可<br>例: 1234        |
+| - recipientGroupingKey | String  | X  | 受信者グルーピングキー（受信者ごとにグルーピングキーを指定できます。最大100文字）                                                                                                                                                                                                                   |
+| senderGroupingKey    | String  | X  | 発信者グルーピングキー（発信者ごとにグルーピングキーを指定できます。最大100文字）                                                                                                                                                                                                                   |
+| resellerCode          | String  | X  | リセラーコード（リセラーが送信時に使用）                                                                                                                                                                                                                                                       |
+| createUser             | String  | X  | 登録者（コンソールから送信時にユーザーUUIDで保存）                                                                                                                                                                                                                                                   |
+| statsId                | String  | 	X | 統計ID（発信検索条件には含まれません。最大8文字）                                                                                                                                                                                                                                            |
 
 <a id="request-to-send-carousel-commerce-type"></a>
 
-#### カルーセルコマース形式の送信リクエスト
-
-##### カルーセル固定置換パラメータ(pathベースのテンプレートパラメータ)
-
-カルーセルタイプにおいて、各アイテムに異なる置換パラメータ値を適用できます。
-
-* **使用形式**：`キー@$.carousel.list[インデックス]`(例：`productName@$.carousel.list[0]`)
-* head(カルーセルイントロ)がある場合、headが`list[0]`を占め、実際のアイテムは`list[1]`から開始します。
-* pathベースのキーで値が見つからない場合、一般的なキーにフォールバックされます。
-
-| 区分 | 置換可能なフィールド | path形式 |
-|------|--------------|----------|
-| カルーセルイントロ(head) | header, content, linkMo, linkPc, schemeAndroid, schemeIos | `キー@$.carousel.list[0]`(head存在時) |
-| カルーセルアイテム | header, message, additionalContent | `キー@$.carousel.list[インデックス]` |
-| カルーセルアイテムのボタン | linkMo, linkPc, schemeAndroid, schemeIos | `キー@$.carousel.list[インデックス]` |
-| カルーセルアイテムのクーポン | title, description, linkMo, linkPc, schemeAndroid, schemeIos | `キー@$.carousel.list[インデックス]` |
-| カルーセルアイテムのコマース | title | `キー@$.carousel.list[インデックス]` |
-
-* **Tail**：置換パラメータ使用不可
-* ボタンのインデックスはpathに含まれません。同じアイテム内のボタンは同じpath値で置換されます。
-
-> **注意** 置換パラメータのキー(`#{key}`)には`@`文字を使用できません。`@`はシステムでpathの区切り文字として使用されます。
+#### カルーセルコマース型送信リクエスト
 
 [Request body]
 
@@ -977,6 +1102,9 @@ Content-Type: application/json;charset=UTF-8
   "senderKey": String,
   "chatBubbleType": "CAROUSEL_COMMERCE",
   "pushAlarm": boolean,
+  "requestDate": String,
+  "unsubscribeNo": String,
+  "unsubscribeAuthNo": String,
   "adult": boolean,
   "carousel": {
     "head": {
@@ -1040,75 +1168,90 @@ Content-Type: application/json;charset=UTF-8
           "resendContent": String,
           "resendSendNo": String,
           "resendUnsubscribeNo": String
-      }
+      },
+      "targeting": String,
+      "unsubscribeNo": String,
+      "unsubscribeAuthNo": String,
+      "recipientGroupingKey": String
     }
   ],
+  "senderGroupingKey": String,
+  "resellerCode": String,
   "createUser": String,
   "statsId": String
 }
 ```
 
-| 名前                 | タイプ    | 必須 | 説明                                                                                                                                                                                                                                                                          |
+| 名前                   | タイプ      | 必須 | 説明                                                                                                                                                                                                                                                                            |
 |----------------------|---------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| senderKey | String | O  | 送信キー(40文字)、グループ送信キーは使用不可 |
-| chatBubbleType | String | O  | メッセージタイプ(TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE) |
-| pushAlarm | boolean | X  | メッセージプッシュ通知の送信有無(デフォルト: true) |
-| adult                | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                                                                       |
-| carousel             | Object  | O  | カルーセル                                                                                                                                                                                                                                                                         |
-| - head               | Object  | X  | カルーセルイントロ                                                                                                                                                                                                                                                                     |
-| -- header            | String  | O  | カルーセルイントロヘッダ(最大20文字)                                                                                                                                                                                                                                                            |
-| -- content           | String  | O  | カルーセルイントロ内容(最大50文字)                                                                                                                                                                                                                                                            |
-| -- imageUrl | String | O  | カルーセルイントロ画像アドレス(カルーセルコマース形式の画像としてアップロードされた画像を使用、使用される画像はカルーセルの画像と比率が同じである必要があります) |
-| -- linkMo | String | X  | モバイルWebリンク(linkMo、linkPc、schemeAndroid、schemeIosのいずれかを使用する場合、linkMoは必須値)、1,000文字制限 |
-| -- linkPc            | String  | X  | PC Webリンク、1,000文字制限                                                                                                                                                                                                                                                         |
-| -- schemeAndroid     | String  | X  | Androidアプリリンク、1,000文字制限                                                                                                                                                                                                                                                       |
-| -- schemeIos         | String  | X  | iOSアプリリンク、1,000文字制限                                                                                                                                                                                                                                                         |
-| - list | List | O  | カルーセルリスト(headが存在する場合、最小1件、最大5件 / それ以外は最小2件、最大6件) |
-| -- additionalContent | String | X  | 付加情報(最大34文字)、カルーセルコマース形式でのみ使用可能 |
-| -- imageUrl | String | O  | 画像URL (カルーセルコマース形式の画像としてアップロードされた画像を使用) |
-| -- imageLink         | String  | X  | 画像リンク、1,000文字制限                                                                                                                                                                                                                                                            |
-| -- commerce | Object | O  | コマース(CAROUSEL_COMMERCEタイプでのみ使用可能) |
-| --- title            | String  | O  | 商品名(最大30文字、改行:不可)                                                                                                                                                                                                                                                       |
-| --- regularPrice | Integer | O  | 通常価格(0～99,999,999) |
-| --- discountPrice | Integer | X  | 割引価格(0 ～ 99,999,999) |
-| --- discountRate | Integer | X  | 割引率(0 ～ 100)、割引価格が存在する場合、割引率、定額割引価格のいずれかは必須 |
-| --- discountFixed | Integer | X  | 定額割引価格(0 ～ 999,999)、割引価格が存在する場合、割引率、定額割引価格のいずれかは必須 |
-| -- buttons           | List    | O  | カルーセルリストボタンリスト最小1件、最大2件                                                                                                                                                                                                                                                  |
-| --- name | String | O  | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合は最大14文字<br>- それ以外のタイプの場合は最大8文字 |
-| --- type | String | O  | ボタンのタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- BTタイプはカカオオープンビルダーのチャットボットを使用するチャンネルのみ利用可能<br>- BFタイプは最初のボタンとしてのみ使用でき、nameには次の3つの文言のみ使用可能<br> - トークで予約する<br> - トークでアンケートする<br> - トークで応募する |
-| --- linkMo | String | X  | モバイルWebリンク(WLタイプの場合は必須フィールド)、1,000文字制限 |
-| --- linkPc | String | X  | PC Webリンク(WLタイプの場合は任意フィールド)、1,000文字制限 |
-| --- schemeAndroid | String | X  | Androidアプリリンク(ALタイプの場合は必須フィールド)、1,000文字制限 |
-| --- schemeIos | String | X  | iOSアプリリンク(ALタイプの場合は必須フィールド)、1,000文字制限 |
-| --- chatExtra | String | X  | BTタイプのボタンの場合に転送するメタ情報 |
-| --- chatEvent | String | X  | BTタイプのボタンの場合に接続するボットのイベント名 |
-| --- bizFormKey | String | X  | BFタイプのボタンの場合のビズフォームキー |
-| -- coupon            | Object  | X  | クーポン要素                                                                                                                                                                                                                                                                       |
-| --- title | String | O  | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」 |
-| --- description | String | O  | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合は最大18文字、改行：不可<br>- それ以外のタイプの場合は最大12文字、改行：不可 |
-| --- linkMo | String | X  | モバイルWebリンク(WLタイプの場合は必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは選択事項(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式：alimtalk=coupon://)を入力する場合、残りのフィールドが選択事項(オプション)になります。 |
-| --- linkPc | String | X  | PC Webリンク(WLタイプの場合は任意フィールド)、1,000文字制限 |
-| --- schemeAndroid | String | X  | Androidアプリリンク(ALタイプの場合は必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは選択事項(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式：alimtalk=coupon://)を入力する場合、残りのフィールドが選択事項(オプション)になります。 |
-| --- schemeIos | String | X  | iOSアプリリンク(ALタイプの場合は必須フィールド)、1,000文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは選択事項(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式：alimtalk=coupon://)を入力する場合、残りのフィールドが選択事項(オプション)になります。 |
-| - tail | Object | X  | もっと見るボタンの情報 |
-| -- linkMo            | String  | O  | モバイルWebリンク、1,000文字制限                                                                                                                                                                                                                                                         |
-| -- linkPc            | String  | X  | PC Webリンク、1,000文字制限                                                                                                                                                                                                                                                          |
-| -- schemeAndroid     | String  | X  | Androidアプリリンク、1,000文字制限                                                                                                                                                                                                                                                       |
-| -- schemeIos         | String  | X  | iOSアプリリンク、1,000文字制限                                                                                                                                                                                                                                                         |
-| recipientList        | List    | O  | 受信者リスト(最大1,000人)                                                                                                                                                                                                                                                             |
-| - recipientNo        | String  | O  | 受信番号                                                                                                                                                                                                                                                                       |
-| - resendParameter    | Object  | X  | 代替送信情報                                                                                                                                                                                                                                                                    |
-| -- isResend | boolean | X  | 送信失敗時に、テキストメッセージで代替送信するかどうか<br>コンソールで代替送信を設定した場合、デフォルトで代替送信されます。 |
-| -- resendType | String | X  | 代替送信タイプ(SMS、LMS)<br>値がない場合、テンプレートの本文の長さに応じてタイプが区別されます。 |
-| -- resendTitle | String | X  | LMS代替送信の件名<br>(値がない場合、プラスフレンドIDで代替送信されます。) |
-| -- resendContent | String | X  | 代替送信の内容<br>(値がない場合、[メッセージ本文]で代替送信されます。) |
-| -- resendSendNo | String | X  | 代替送信の送信者番号<br><span style="color:red">(SMSサービスに登録された送信者番号でない場合、代替送信に失敗することがあります。)</span> |
-| createUser | String | X  | 登録者(コンソールで送信時にユーザーUUIDとして保存) |
-| statsId | String | X  | 統計ID(送信検索条件には含まれません、最大8文字) |
+| senderKey            | String  | O  | 発信キー（40文字）、グループ発信キーは使用不可                                                                                                                                                                                                                                                       |
+| chatBubbleType       | String  | O  | メッセージタイプ（TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE）                                                                                                                                                                         |
+| pushAlarm            | boolean | X  | メッセージプッシュ通知の送信有無（デフォルト値: true）                                                                                                                                                                                                                                                   |
+| requestDate          | String  | X  | リクエスト日時（yyyy-MM-dd HH:mm）<br>（入力しない場合は即時送信）<br>最大60日後まで予約可能                                                                                                                                                                                                                                                   |
+| unsubscribeNo       | String  | X  | 080受信拒否無料電話番号（すべて未入力の場合、発信プロフィールに登録された受信拒否情報で送信されます）<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx         |
+| unsubscribeAuthNo   | String  | X  | 080受信拒否無料認証番号（最大10文字、すべて未入力の場合、発信プロフィールに登録された受信拒否情報で送信されます）<br>unsubscribeNo なしで unsubscribeAuthNo のみの入力は不可<br>例: 1234        |
+| adult                | boolean | X  | 成人向けメッセージかどうか（デフォルト値: false）                                                                                                                                                                                                                                                       |
+| carousel             | Object  | O  | カルーセル                                                                                                                                                                                                                                                                           |
+| - head               | Object  | X  | カルーセルイントロ                                                                                                                                                                                                                                                                       |
+| -- header            | String  | O  | カルーセルイントロヘッダー（最大20文字）                                                                                                                                                                                                                                                            |
+| -- content           | String  | O  | カルーセルイントロ内容（最大50文字）                                                                                                                                                                                                                                                            |
+| -- imageUrl          | String  | O  | カルーセルイントロ画像URL（カルーセルコマース型画像としてアップロードされた画像を使用。使用する画像はカルーセルの画像と同じ比率である必要があります）                                                                                                                                                                                                    |
+| -- linkMo            | String  | X  | モバイルWebリンク（linkMo、linkPc、schemeAndroid、schemeIos のいずれかを使用する場合、linkMo は必須）、1,000文字制限                                                                                                                                                                                    |
+| -- linkPc            | String  | X  | PC Webリンク、1,000文字制限                                                                                                                                                                                                                                                           |
+| -- schemeAndroid     | String  | X  | Android アプリリンク、1,000文字制限                                                                                                                                                                                                                                                         |
+| -- schemeIos         | String  | X  | iOS アプリリンク、1,000文字制限                                                                                                                                                                                                                                                           |
+| - list               | List    | O  | カルーセルリスト（head が存在する場合は最小1個、最大5個 / その他は最小2個、最大6個）                                                                                                                                                                                                                      |
+| -- additionalContent | String  | X  | 付加情報（最大34文字）、カルーセルコマース型でのみ使用可能                                                                                                                                                                                                                                              |
+| -- imageUrl          | String  | O  | 画像URL（カルーセルコマース型画像としてアップロードされた画像を使用）                                                                                                                                                                                                                                           |
+| -- imageLink         | String  | X  | 画像リンク、1,000文字制限                                                                                                                                                                                                                                                              |
+| -- commerce          | Object  | O  | コマース（CAROUSEL_COMMERCE タイプでのみ使用可能）                                                                                                                                                                                                                                           |
+| --- title            | String  | O  | 商品タイトル（最大30文字、改行: 不可）                                                                                                                                                                                                                                                       |
+| --- regularPrice     | Integer | O  | 通常価格（0〜99,999,999）                                                                                                                                                                                                                                                        |
+| --- discountPrice    | Integer | X  | 割引価格（0〜99,999,999）                                                                                                                                                                                                                                                          |
+| --- discountRate     | Integer | X  | 割引率（0〜100）、割引価格が存在する場合、割引率または定額割引価格のいずれかが必須                                                                                                                                                                                                                                   |
+| --- discountFixed    | Integer | X  | 定額割引価格（0〜999,999）、割引価格が存在する場合、割引率または定額割引価格のいずれかが必須                                                                                                                                                                                                                            |
+| -- buttons           | List    | O  | カルーセルリストボタン一覧（最小1個、最大2個）                                                                                                                                                                                                                                                    |
+| --- name             | String  | O  | ボタンタイトル<br>- TEXT、IMAGE タイプの場合は最大14文字<br>- それ以外のタイプの場合は最大8文字                                                                                                                                                                                                                    |
+| --- type             | String  | O  | ボタンタイプ（WL: Webリンク、AL: アプリリンク、BK: Botキーワード、MD: メッセージ転送、AC: チャンネル追加、BT: チャットボット切替、BF: ビジネスフォーム）<br>- BT タイプはカカオオープンビルダーのチャットボットを使用するチャンネルのみ利用可能<br>- BF タイプは最初のボタンとしてのみ使用でき、name には以下の3つの文言のみ使用可能<br>  - トークで予約する<br>  - トークでアンケートする<br>  - トークで応募する |
+| --- linkMo           | String  | X  | モバイルWebリンク（WL タイプの場合は必須フィールド）、1,000文字制限                                                                                                                                                                                                                                         |
+| --- linkPc           | String  | X  | PC ウェブリンク（WL タイプの場合は選択フィールド）、1,000 文字制限                                                                                                                                                                                                                                          |
+| --- schemeAndroid    | String  | X  | Android アプリリンク（AL タイプの場合は必須フィールド）、1,000 文字制限                                                                                                                                                                                                                                       |
+| --- schemeIos        | String  | X  | iOS アプリリンク（AL タイプの場合は必須フィールド）、1,000 文字制限                                                                                                                                                                                                                                         |
+| --- chatExtra        | String  | X  | BT タイプボタンの場合に転送するメタ情報                                                                                                                                                                                                                                                   |
+| --- chatEvent        | String  | X  | BT タイプボタンの場合に連結するボットイベント名                                                                                                                                                                                                                                                       |
+| --- bizFormKey       | String  | X  | BF タイプボタンの場合のビズフォームキー                                                                                                                                                                                                                                                            |
+| -- coupon            | Object  | X  | クーポン要素                                                                                                                                                                                                                                                                         |
+| --- title            | String  | O  | title は 5 種類の形式に制限されます<br>- "${数字}円割引クーポン" 数字は 1 以上 99,999,999 以下<br>- "${数字}% 割引クーポン" 数字は 1 以上 100 以下<br>- "送料割引クーポン"<br>- "${7 文字以内} 無料クーポン"<br>- "${7 文字以内} UP クーポン"                                                                                                            |
+| --- description      | String  | O  | クーポン詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO タイプの場合は最大 18 文字、改行不可<br>- その他のタイプの場合は最大 12 文字、改行不可                                                                                                                                                                      |
+| --- linkMo           | String  | X  | モバイルウェブリンク（WL タイプの場合は必須フィールド）、1,000 文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）となります。                                                                                   |
+| --- linkPc           | String  | X  | PC ウェブリンク（WL タイプの場合は選択フィールド）、1,000 文字制限                                                                                                                                                                                                                                          |
+| --- schemeAndroid    | String  | X  | Android アプリリンク（AL タイプの場合は必須フィールド）、1,000 文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）となります。                                                                                 |
+| --- schemeIos        | String  | X  | iOS アプリリンク（AL タイプの場合は必須フィールド）、1,000 文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）となります。                                                                                   |
+| - tail               | Object  | X  | もっと見るボタン情報                                                                                                                                                                                                                                                                     |
+| -- linkMo            | String  | O  | モバイルウェブリンク、1,000 文字制限                                                                                                                                                                                                                                                           |
+| -- linkPc            | String  | X  | PC ウェブリンク、1,000 文字制限                                                                                                                                                                                                                                                            |
+| -- schemeAndroid     | String  | X  | Android アプリリンク、1,000 文字制限                                                                                                                                                                                                                                                         |
+| -- schemeIos         | String  | X  | iOS アプリリンク、1,000 文字制限                                                                                                                                                                                                                                                           |
+| recipientList        | List    | O  | 受信者リスト（最大 1,000 人）                                                                                                                                                                                                                                                             |
+| - recipientNo        | String  | O  | 受信番号                                                                                                                                                                                                                                                                         |
+| - resendParameter    | Object  | X  | 代替送信情報                                                                                                                                                                                                                                                                      |
+| -- isResend          | boolean | X  | 送信失敗時、SMS 代替送信を行うかどうか<br>コンソールで代替送信設定を行った場合、デフォルトで代替送信されます。                                                                                                                                                                                                                       |
+| -- resendType        | String  | X  | 代替送信タイプ（SMS、LMS）<br>値がない場合、テンプレート本文の長さによってタイプが決定されます。                                                                                                                                                                                                                       |
+| -- resendTitle       | String  | X  | LMS 代替送信タイトル<br>（値がない場合、プラスフレンド ID で代替送信されます。）                                                                                                                                                                                                                               |
+| -- resendContent     | String  | X  | 代替送信内容<br>（値がない場合、[メッセージ本文] で代替送信されます。）                                                                                                                                                                                                                                  |
+| -- resendSendNo      | String  | X  | 代替送信の発信番号<br><span style="color:red">（SMS サービスに登録された発信番号でない場合、代替送信が失敗する可能性があります。）</span>                                                                                                                                                                                 |
+| - targeting         | String  | X  | メッセージ対象のタイプ（M: マーケティング受信同意ユーザー、N: フレンドではないマーケティング受信同意ユーザーのみ、I: フレンドであるユーザー）                                                                |
+| - unsubscribeNo       | String  | X  | 080 無料受信拒否電話番号（すべて未入力の場合、発信プロフィールに登録された無料受信拒否情報で送信されます）<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx         |
+| - unsubscribeAuthNo   | String  | X  | 080 無料受信拒否認証番号（最大 10 文字、すべて未入力の場合、発信プロフィールに登録された無料受信拒否情報で送信されます）<br>unsubscribeNo なしで unsubscribeAuthNo のみ入力不可<br>例: 1234        |
+| - recipientGroupingKey | String  | X  | 受信者グルーピングキー（受信者ごとにグルーピングキーを指定できます。最大 100 文字）                                                                                                                                                                                                                   |
+| senderGroupingKey    | String  | X  | 発信者グルーピングキー（発信者ごとにグルーピングキーを指定できます。最大 100 文字）                                                                                                                                                                                                                   |
+| resellerCode          | String  | X  | リセラーコード（リセラーが送信する際に使用）                                                                                                                                                                                                                                                       |
+| createUser           | String  | X  | 登録者（コンソールから送信する際にユーザー UUID として保存）                                                                                                                                                                                                                                                   |
+| statsId              | String  | 	X | 統計 ID（発信検索条件には含まれません。最大 8 文字）                                                                                                                                                                                                                                                        |
 
 <a id="response-3"></a>
 
-#### レスポンス
+#### 応答
 
 ```
 {
@@ -1131,46 +1274,46 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前             | タイプ    | Not Null | 説明                                                         |
+| 名前               | タイプ      | Not Null | 説明                                                           |
 |:-----------------|:--------|:---------|:-------------------------------------------------------------|
-| header           | Object  | O        | レスポンスヘッダ情報                                                   |
-| - isSuccessful   | boolean | O        | API呼び出し成否                                               |
-| - resultCode | Integer | O | API呼び出し結果コード(成功：0、失敗時はエラーコード) |
-| - resultMessage | String | O | API呼び出し結果メッセージ(成功時は「success」または関連する成功メッセージ、失敗時は失敗原因の詳細メッセージ) |
-| message | Object | X | メッセージ送信結果情報(送信リクエストがある場合にのみ存在) |
-| - requestId | String | X | 送信リクエストID(各送信リクエストを一意に識別するID) |
-| - sendResults | Array | O | 受信者別の送信結果リスト |
-| -- recipientSeq | Integer | O | 受信者リストの順番 |
-| -- recipientNo | String | X | 受信者の電話番号 |
-| -- resultCode | Integer | O | 受信者別の送信結果コード(成功及び様々な失敗コードが存在する可能性があります) |
-| -- resultMessage | String | O | 受信者別の送信結果メッセージ(成功時は「success」または関連メッセージ、失敗時は失敗原因の詳細メッセージ) |
+| header           | Object  | O        | レスポンスヘッダー情報                                                     |
+| - isSuccessful   | boolean | O        | API 呼び出し成否                                                 |
+| - resultCode     | Integer | O        | API 呼び出し結果コード（成功: 0、失敗時はエラーコード）                           |
+| - resultMessage  | String  | O        | API 呼び出し結果メッセージ（成功時は "success" または関連成功メッセージ、失敗時は失敗原因の詳細メッセージ）  |
+| message          | Object  | X        | メッセージ送信結果情報（送信リクエストがある場合のみ存在）                             |
+| - requestId      | String  | X        | 送信リクエスト ID（各送信リクエストを一意に識別する ID）                             |
+| - sendResults    | Array   | O        | 受信者別送信結果リスト                                                |
+| -- recipientSeq  | Integer | O        | 受信者リストの連番                                                   |
+| -- recipientNo   | String  | X        | 受信者の電話番号                                                     |
+| -- resultCode    | Integer | O        | 受信者別送信結果コード（成功およびさまざまな失敗コードが存在する場合があります）                     |
+| -- resultMessage | String  | O        | 受信者別送信結果メッセージ（成功時は "success" または関連メッセージ、失敗時は失敗原因の詳細メッセージ） |
 
 <a id="request-to-send-basic-message"></a>
 
-## メッセージ基本形送信リクエスト
+## メッセージ基本型送信リクエスト
 
-* テンプレートを利用した送信です。
-* 広告やプロモーション情報を受け取ることに同意したユーザーに対してメッセージ送信を使用できます。
-    * targetingフィールドを指定して、メッセージ対象のタイプを指定できます。
-        * M: 顧客企業の広告性情報受信に同意したユーザー(カカオトークでの受信に同意)
-        * N: 顧客企業の広告性情報受信に同意したユーザー(カカオトークでの受信に同意) - チャネルの友だち
-        * I: 顧客企業の送信リクエスト対象 ∩ チャネルの友だち
-* 既存カカともへのメッセージの8つのメッセージタイプを全て使用できます。
-* BTボタンタイプは使用できません。
-* AC(チャンネル追加)ボタンを使用できます。
-* BFボタンを使用する場合、カカオから発行されたビジネスフォームIDをアップロードしてビズフォームキーを発行して使用できます。
-* 代替送信は、受信者ごとにresendParameterを介して設定できます。
-* 代替送信をご利用になる場合、代替送信管理APIを介してSMS AppKeyの登録及び送信設定が必要です。
-* **夜間送信制限(20:50～翌日08:00)**
+* テンプレートを使用した送信です。
+* マーケティング受信同意送信を使用できます。
+    * targeting フィールドを指定して、メッセージ対象のタイプを指定できます。
+        * M: 顧客企業の広告性情報受信同意ユーザー（カカオトーク受信同意）
+        * N: 顧客企業の広告性情報受信同意ユーザー（カカオトーク受信同意）- チャンネルフレンド
+        * I: 顧客企業の送信リクエスト対象 ∩ チャンネルフレンド
+* 既存フレンドトークの8種類のメッセージタイプをすべて使用できます。
+* BT ボタンタイプは使用できません。
+* AC（チャンネル追加）ボタンを使用できます。
+* BF ボタン使用時は、カカオから発行されたビジネスフォーム ID をアップロードしてビズフォームキーを発行して使用できます。
+* 代替送信は受信者ごとの resendParameter で設定できます。
+    * 代替送信を利用する場合、代替送信管理 API で SMS AppKey の登録および送信設定が必要です。
+* **夜間送信制限（20:50〜翌日 08:00）**
 
 <a id="cautions-for-use"></a>
 
-### 使用時の注意事項
+### 使用上の注意事項
 
-- unsubscribeNo、unsubscribeAuthNoは080無料受信拒否電話番号と認証番号で、どちらか一方でも入力しない場合は、送信プロフィールに登録された無料受信拒否情報で送信されます。
-- 送信時にunsubscribeNo、unsubscribeAuthNoを入力すると、送信プロフィールに登録されている無料受信拒否情報ではなく、入力した値で送信されます。
-- 送信時にunsubscribeNo、unsubscribeAuthNoを入力しない場合、送信プロフィールに登録されている無料受信拒否情報で送信されます。
-- unsubscribeNo、unsubscribeAuthNoは受信者ごとに入力でき、共通フィールドと受信者ごとフィールドの両方を入力した場合、共通フィールドが優先的に適用されます。
+- unsubscribeNo、unsubscribeAuthNo は 080 無料受信拒否電話番号と認証番号です。どちらか一方でも入力しない場合、発信プロフィールに登録された無料受信拒否情報で送信されます。
+- 送信時に unsubscribeNo、unsubscribeAuthNo を入力した場合、発信プロフィールに登録された無料受信拒否情報ではなく、入力した値で送信されます。
+- 送信時に unsubscribeNo、unsubscribeAuthNo を入力しない場合、発信プロフィールに登録された無料受信拒否情報で送信されます。
+- unsubscribeNo、unsubscribeAuthNo は受信者ごとに入力できます。共通フィールドと受信者別フィールドの両方を入力した場合、共通フィールドが優先して適用されます。
 
 [URL]
 
@@ -1181,7 +1324,7 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 名前   | タイプ   | 説明   |
+| 名前     | タイプ     | 説明     |
 |--------|--------|--------|
 | appkey | String | 固有のアプリキー |
 
@@ -1193,7 +1336,7 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前         | タイプ   | 必須 | 説明             |
+| 名前           | タイプ     | 必須 | 説明               |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
 
@@ -1206,6 +1349,7 @@ Content-Type: application/json;charset=UTF-8
   "senderKey": String,
   "templateCode": String,
   "pushAlarm": boolean,
+  "requestDate": String,
   "unsubscribeNo": String,
   "unsubscribeAuthNo": String,
   "recipientList": [
@@ -1235,37 +1379,37 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前                     | タイプ      | 必須 | 説明                                                                                                                                                                                                                                     |
+| 名前                     | タイプ      | 必須 | 説明                                                                                                                                                                                                                                      |
 |------------------------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| senderKey              | String  | O  | 送信キー(40文字)、グループ送信キーは使用不可                                                                                                                                                                                                                |
-| templateCode           | String  | O  | 使用するテンプレートコード                                                                                                                                                                                                                           |
-| pushAlarm              | boolean | X  | メッセージのプッシュ通知送信有無(デフォルト値：true)                                                                                                                                                                                                              |
-| requestDate            | String  | X  | リクエスト日時(yyyy-MM-dd HH:mm)<br>(入力しない場合は即時送信)<br>最大60日後まで予約可能                                                                                                                                                                     |
-| unsubscribeNo          | String  | X  | 080無料受信拒否電話番号(全て未入力の場合は送信プロファイルに登録された無料受信拒否情報で送信される)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx                                                                                                           |
-| unsubscribeAuthNo      | String  | X  | 080無料受信拒否認証番号(全て未入力の場合は送信プロファイルに登録された無料受信拒否情報で送信される)<br>unsubscribe_phone_numberなしでunsubscribe_auth_numberのみの入力は不可<br>例：1234                                                                                                           |
-| recipientList          | List    | O  | 受信者一覧(最大1,000名)                                                                                                                                                                                                                       |
-| - recipientNo          | String  | O  | 受信番号                                                                                                                                                                                                                                  |
-| - targeting            | String  | O  | メッセージ対象のタイプ(M：マーケティング受信同意ユーザー、N：友だちではないマーケティング受信同意ユーザーのみ、I：友だちのユーザー)                                                                                                                                                                       |
-| - templateParameter    | Object  | X  | テンプレートパラメータ(テンプレートに置換する変数が含まれる場合は必須)<br>- カルーセルタイプ：アイテムごとに異なる置換パラメータ値を適用する場合は`キー@$.carousel.list[インデックス]`形式を使用(例：`productName@$.carousel.list[0]`)<br>- headがある場合はheadがlist[0]を占め、実際のアイテムはlist[1]から開始<br>- 置換パラメータのキーに`@`文字は使用不可<br>- キー/値はそれぞれ最大1,300文字 |
-| - imageParameters      | List    | X  | テンプレートの画像フィールド値を変更できる動的パラメータ(テンプレートに存在する画像数と同じサイズのJSONリストのみ使用可能。使用する場合、変更しない画像には空のJSONオブジェクトを入力する必要がある)                                                                                                                       |
-| -- imageUrl            | String  | O  | 画像URL                                                                                                                                                                                                                                 |
-| -- imageLink           | String  | X  | 画像リンク                                                                                                                                                                                                                                 |
-| - videoParameter       | Object  | X  | テンプレートの動画フィールド値を変更できる動的パラメータ                                                                                                                                                                                                         |
+| senderKey              | String  | O  | 発信キー(40文字)、グループ発信キーは使用不可                                                                                                                                                                                                                |
+| templateCode           | String  | O  | 使用するテンプレートコード                                                                                                                                                                                                                            |
+| pushAlarm              | boolean | X  | メッセージプッシュ通知の送信有無(デフォルト値: true)                                                                                                                                                                                                              |
+| requestDate            | String  | X  | リクエスト日時(yyyy-MM-dd HH:mm)<br>(入力しない場合は即時送信)<br>最大60日後まで予約可能                                                                                                                                                                      |
+| unsubscribeNo          | String  | X  | 080無料受信拒否電話番号(すべて未入力の場合、発信プロフィールに登録された受信拒否情報で送信されます)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx                                                                                                           |
+| unsubscribeAuthNo      | String  | X  | 080無料受信拒否認証番号(最大10文字、すべて未入力の場合、発信プロフィールに登録された受信拒否情報で送信されます)<br>unsubscribeNoなしでunsubscribeAuthNoのみの入力は不可<br>例: 1234                                                                                                           |
+| recipientList          | List    | O  | 受信者リスト(最大1,000名)                                                                                                                                                                                                                       |
+| - recipientNo          | String  | O  | 受信番号                                                                                                                                                                                                                                   |
+| - targeting            | String  | O  | メッセージ対象のタイプ(M: マーケティング受信同意ユーザー、N: フレンドではないマーケティング受信同意ユーザーのみ、I: フレンドであるユーザー)                                                                                                                                                                       |
+| - templateParameter    | Object  | X  | テンプレートパラメータ(テンプレートに置換する変数を含む場合は必須)<br>- カルーセルタイプ: アイテムごとに異なる置換値を適用する場合は `キー@$.carousel.list[インデックス]` 形式を使用(例: `productName@$.carousel.list[0]`)<br>- headがある場合、headがlist[0]を占め、実際のアイテムはlist[1]から始まります<br>- 置換キーに `@` 文字は使用不可<br>- キー/値それぞれ最大1,300文字 |
+| - imageParameters      | List    | X  | テンプレートの画像フィールド値を変更できる動的パラメータ(テンプレートに存在する画像の数と同じサイズのJSONリストのみ使用可能。使用する場合、変更しない画像には空のJSONオブジェクトを入力する必要があります)                                                                                                                      |
+| -- imageUrl            | String  | O  | 画像URL                                                                                                                                                                                                                                 |
+| -- imageLink           | String  | X  | 画像リンク                                                                                                                                                                                                                                  |
+| - videoParameter       | Object  | X  | テンプレートのビデオフィールド値を変更できる動的パラメータ                                                                                                                                                                                                          |
 | -- videoUrl            | String  | O  | カカオTV動画URL                                                                                                                                                                                                                           |
-| -- thumbnailUrl        | String  | X  | 動画サムネイル用の画像URL                                                                                                                                                                                                                        |
-| - resendParameter      | Object  | X  | 代替送信情報                                                                                                                                                                                                                               |
-| -- isResend            | boolean | X  | 送信失敗時、メッセージの代替送信有無<br>コンソールで代替送信を設定した場合、デフォルトで代替送信されます。                                                                                                                                                                                 |
-| -- resendType          | String  | X  | 代替送信タイプ(SMS、LMS)<br>値がない場合、テンプレートの本文の長さに応じてタイプが区別されます。                                                                                                                                                                                 |
-| -- resendTitle         | String  | X  | LMS代替送信のタイトル<br>(値がない場合、プラス友だちIDで代替送信されます。)                                                                                                                                                                                         |
-| -- resendContent       | String  | X  | 代替送信の内容<br>(値がない場合、[メッセージ本文]で代替送信されます。)                                                                                                                                                                                            |
-| -- resendSendNo        | String  | X  | 代替送信の送信番号<br><span style="color:red">(SMSサービスに登録された送信番号ではない場合、代替送信に失敗する可能性があります。)</span>                                                                                                                                           |
-| - unsubscribeNo        | String  | X  | 080無料受信拒否電話番号(全て未入力の場合は送信プロファイルに登録された無料受信拒否情報で送信される)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx                                                                                                           |
-| - unsubscribeAuthNo    | String  | X  | 080無料受信拒否認証番号(全て未入力の場合は送信プロファイルに登録された無料受信拒否情報で送信される)<br>unsubscribe_phone_numberなしでunsubscribe_auth_numberのみの入力は不可<br>例：1234                                                                                                           |
-| - recipientGroupingKey | String | X | 受信者グルーピングキー(受信者ごとにグルーピングキーを指定できます。最大100文字) |
-| senderGroupingKey | String | X | 送信者グルーピングキー(送信者ごとにグルーピングキーを指定できます。最大100文字) |
-| resellerCode | String | X | リセラーコード(リセラーが送信時に使用) |
-| createUser | String | X | 登録者(コンソールから送信時、ユーザーUUIDとして保存) |
-| statsId | String | X | 統計ID(送信検索条件には含まれません。最大8文字) |
+| -- thumbnailUrl        | String  | X  | 動画サムネイル用画像URL                                                                                                                                                                                                                        |
+| - resendParameter      | Object  | X  | 代替送信情報                                                                                                                                                                                                                                |
+| -- isResend            | boolean | X  | 送信失敗時、SMS代替送信の有無<br>コンソールで代替送信設定時、デフォルト値として代替送信されます。                                                                                                                                                                                 |
+| -- resendType          | String  | X  | 代替送信タイプ(SMS,LMS)<br>値がない場合、テンプレート本文の長さによってタイプが決定されます。                                                                                                                                                                                 |
+| -- resendTitle         | String  | X  | LMS代替送信タイトル<br>(値がない場合、プラスフレンドIDで代替送信されます。)                                                                                                                                                                                         |
+| -- resendContent       | String  | X  | 代替送信内容<br>(値がない場合、[メッセージ本文]で代替送信されます。)                                                                                                                                                                                            |
+| -- resendSendNo        | String  | X  | 代替送信の発信番号<br><span style="color:red">(SMSサービスに登録された発信番号でない場合、代替送信に失敗する可能性があります。)</span>                                                                                                                                           |
+| - unsubscribeNo        | String  | X  | 080無料受信拒否電話番号(すべて未入力の場合、発信プロフィールに登録された受信拒否情報で送信されます)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx                                                                                                           |
+| - unsubscribeAuthNo    | String  | X  | 080無料受信拒否認証番号(最大10文字、すべて未入力の場合、発信プロフィールに登録された受信拒否情報で送信されます)<br>unsubscribeNoなしでunsubscribeAuthNoのみの入力は不可<br>例: 1234                                                                                                           |
+| - recipientGroupingKey | String  | X  | 受信者グループキー(受信者ごとにグループキーを指定できます。最大100文字)                                                                                                                                                                                             |
+| senderGroupingKey      | String  | X  | 発信者グループキー(発信者ごとにグループキーを指定できます。最大100文字)                                                                                                                                                                                             |
+| resellerCode           | String  | X  | リセラーコード(リセラーが送信する際に使用)                                                                                                                                                                                                                    |
+| createUser             | String  | X  | 登録者(コンソールから送信する場合、ユーザーUUIDで保存されます)                                                                                                                                                                                                             |
+| statsId                | String  | X  | 統計ID(発信検索条件には含まれません。最大8文字)                                                                                                                                                                                                      |
 
 <a id="response-4"></a>
 
@@ -1292,23 +1436,23 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前             | タイプ    | Not Null | 説明                                                         |
-|:-----------------|:--------|:---------|:-------------------------------------------------------------|
-| header           | Object  | O        | レスポンスヘッダ情報                                                   |
-| - isSuccessful   | boolean | O        | API呼び出し成否                                               |
-| - resultCode | Integer | O | API呼び出し結果コード(成功：0、失敗時はエラーコード) |
-| - resultMessage | String | O | API呼び出し結果メッセージ(成功時は「success」または関連する成功メッセージ、失敗時は失敗原因の詳細メッセージ) |
-| message | Object | X | メッセージ送信結果情報(送信リクエストがある場合にのみ存在) |
-| - requestId | String | X | 送信リクエストID(各送信リクエストを一意に識別するID) |
-| - sendResults | Array | O | 受信者別の送信結果リスト |
-| -- recipientSeq | Integer | O | 受信者リストの順番 |
-| -- recipientNo | String | X | 受信者の電話番号 |
-| -- resultCode | Integer | O | 受信者別の送信結果コード(成功及び様々な失敗コードが存在する可能性があります) |
-| -- resultMessage | String | O | 受信者別の送信結果メッセージ(成功時は「success」または関連メッセージ、失敗時は失敗原因の詳細メッセージ) |
+| 名前               | タイプ     | Not Null | 説明                                                                          |
+|:-----------------|:--------|:---------|:----------------------------------------------------------------------------|
+| header           | Object  | O        | レスポンスヘッダー情報                                                                 |
+| - isSuccessful   | boolean | O        | API 呼び出し成否                                                                  |
+| - resultCode     | Integer | O        | API 呼び出し結果コード（成功: 0、失敗時はエラーコード）                                            |
+| - resultMessage  | String  | O        | API 呼び出し結果メッセージ（成功時は "success" または関連する成功メッセージ、失敗時は失敗原因の詳細メッセージ）             |
+| message          | Object  | X        | メッセージ送信結果情報（送信リクエストがある場合にのみ存在）                                             |
+| - requestId      | String  | X        | 送信リクエスト ID（各送信リクエストを一意に識別する ID）                                            |
+| - sendResults    | Array   | O        | 受信者別送信結果リスト                                                                 |
+| -- recipientSeq  | Integer | O        | 受信者リストの順番                                                                   |
+| -- recipientNo   | String  | X        | 受信者の電話番号                                                                    |
+| -- resultCode    | Integer | O        | 受信者別送信結果コード（成功およびさまざまな失敗コードが存在する場合があります）                                   |
+| -- resultMessage | String  | O        | 受信者別送信結果メッセージ（成功時は "success" または関連するメッセージ、失敗時は失敗原因の詳細メッセージ）               |
 
 <a id="view-sending-list"></a>
 
-## 送信リストの照会
+## 送信リスト照会
 
 <a id="requested-5"></a>
 
@@ -1323,7 +1467,7 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 名前   | タイプ   | 説明   |
+| 名前     | タイプ     | 説明     |
 |--------|--------|--------|
 | appkey | String | 固有のアプリキー |
 
@@ -1335,24 +1479,26 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前         | タイプ   | 必須 | 説明             |
+| 名前           | タイプ     | 必須 | 説明               |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
 
-[Query parameter] 1番or 2番の条件が必須
+[Query parameter] 1番または2番の条件が必須
 
-| 名前             | タイプ   | 必須      | 説明                             |
+| 名前               | タイプ     | 必須        | 説明                               |
 |------------------|--------|-----------|----------------------------------|
-| requestId | String | 条件付き必須(1番) | リクエストID |
-| startRequestDate | String | 条件付き必須(2番) | 送信リクエスト日付の開始値(yyyy-MM-dd HH:mm) |
-| endRequestDate | String | 条件付き必須(2番) | 送信リクエスト日付の終了値(yyyy-MM-dd HH:mm) |
-| senderKey        | String | X         | 発信キー                           |
-| templateCode     | String | X         | テンプレートコード                         |
-| recipientNo      | String | X         | 受信番号                          |
-| messageStatus | String | X | リクエストステータス(COMPLETED：成功、FAILED：失敗) |
-| resultCode       | String | X         | 送信結果(MRC01:成功MRC02:失敗)      |
+| requestId        | String | 条件必須(1番) | リクエストID                            |
+| startRequestDate | String | 条件必須(2番) | 送信リクエスト日付の開始値(yyyy-MM-dd HH:mm)  |
+| endRequestDate   | String | 条件必須(2番) | 送信リクエスト日付の終了値(yyyy-MM-dd HH:mm)   |
+| senderKey        | String | X         | 発信キー                             |
+| templateCode     | String | X         | テンプレートコード                           |
+| recipientNo      | String | X         | 受信番号                            |
+| messageStatus    | String | X         | リクエスト状態(COMPLETED: 成功、FAILED: 失敗) |
+| resultCode       | String | X         | 送信結果(MRC01: 成功 MRC02: 失敗)      |
+| senderGroupingKey    | String   | X          | 発信グルーピングキー                          |
+| recipientGroupingKey | 	String  | 	X         | 受信者グルーピングキー                        |
 | pageNum          | String | X         | ページ番号(Default: 1)               |
-| pageSize | String | X | 照会件数(Default: 15、Max: 1,000) |
+| pageSize         | String | X         | 照会件数(Default: 15、Max: 1000)    |
 
 <a id="response-5"></a>
 
@@ -1388,7 +1534,9 @@ Content-Type: application/json;charset=UTF-8
         "isAddedChannel": boolean,
         "resultCode": String,
         "resultCodeName": String,
-        "createUser": String
+        "createUser": String,
+        "senderGroupingKey": String,
+        "recipientGroupingKey": String
       }
     ],
     "totalCount": Integer
@@ -1396,36 +1544,38 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前                        | タイプ    | Not Null | 説明                                                                  |
-|:----------------------------|:--------|:---------|:-----------------------------------------------------------------------|
-| header                      | Object  | O        | ヘッダ領域                                                               |
-| - resultCode                | Integer | O        | 結果コード                                                               |
-| - resultMessage             | String  | O        | 結果メッセージ                                                              |
-| - isSuccessful              | boolean | O        | 成否                                                               |
-| messageSearchResultResponse | Object  | X        | 本文領域                                                               |
-| - messages                  | Array   | O        | メッセージリスト                                                             |
+| 名前                          | タイプ      | Not Null | 説明                                                                    |
+|:----------------------------|:--------|:---------|:----------------------------------------------------------------------|
+| header                      | Object  | O        | ヘッダー領域                                                                 |
+| - resultCode                | Integer | O        | 結果コード                                                                 |
+| - resultMessage             | String  | O        | 結果メッセージ                                                                |
+| - isSuccessful              | boolean | O        | 成功かどうか                                                                 |
+| messageSearchResultResponse | Object  | X        | 本文領域                                                                 |
+| - messages                  | Array   | O        | メッセージリスト                                                               |
 | -- requestId                | String  | O        | リクエストID                                                                 |
-| -- recipientSeq             | Integer | O        | 受信者シーケンス番号                                                          |
-| -- plusFriendId             | String  | O        | 送信プロフィールID                                                             |
-| -- senderKey                | String  | O        | 発信キー                                                                |
-| -- templateCode             | String  | X        | テンプレートコード                                                              |
-| -- recipientNo              | String  | O        | 受信番号                                                               |
-| -- targeting | String | O | メッセージ対象のタイプ(M - マーケティング受信同意ユーザー、N - 友だちではないマーケティング受信同意ユーザーにのみ、I - 友だちであるユーザー) |
-| -- requestDate              | String  | O        | リクエスト日時                                                               |
-| -- createDate               | String  | O        | 登録日時                                                               |
-| -- receiveDate              | String  | X        | 受信日時                                                               |
-| -- chatBubbleType           | String  | O        | メッセージタイプ                                                              |
-| -- pushAlarm | boolean | O | プッシュ通知を使用するかどうか |
-| -- messageStatus | String | O | リクエストステータス(COMPLETED：成功、FAILED：失敗) |
-| -- resendStatusCode         | String  | X        | 代替送信ステータスコード                                                         |
-| -- resendStatusName | String | X | 代替送信ステータス名 |
-| -- resendResultCode         | String  | X        | 代替送信結果コード                                                         |
+| -- recipientSeq             | Integer | O        | 受信者シーケンス番号                                                            |
+| -- plusFriendId             | String  | O        | 発信プロフィールID                                                             |
+| -- senderKey                | String  | O        | 発信キー                                                                  |
+| -- templateCode             | String  | X        | テンプレートコード                                                                |
+| -- recipientNo              | String  | O        | 受信番号                                                                 |
+| -- targeting                | String  | O        | メッセージ対象のタイプ(M: マーケティング受信同意ユーザー、N: フレンドではないマーケティング受信同意ユーザーのみ、I: フレンドであるユーザー) |
+| -- requestDate              | String  | O        | リクエスト日時(yyyy-MM-dd HH:mm)<br>(入力しない場合は즉시送信)<br>最大60日後まで予約可能                                                                 |
+| -- createDate               | String  | O        | 登録日時                                                                 |
+| -- receiveDate              | String  | X        | 受信日時                                                                 |
+| -- chatBubbleType           | String  | O        | メッセージタイプ                                                                |
+| -- pushAlarm                | boolean | O        | プッシュアラームかどうか                                                              |
+| -- messageStatus            | String  | O        | リクエスト状態(COMPLETED: 成功、FAILED: 失敗)                                      |
+| -- resendStatusCode         | String  | X        | 代替送信状態コード                                                           |
+| -- resendStatusName         | String  | X        | 代替送信状態名                                                           |
+| -- resendResultCode         | String  | X        | 代替送信結果コード                                                           |
 | -- resendRequestId          | String  | X        | 代替送信リクエストID                                                           |
-| -- isAddedChannel | boolean | O | チャンネルの友達かどうか |
-| -- resultCode               | String  | X        | 受信結果コード                                                            |
-| -- resultCodeName           | String  | X        | 受信結果コード名                                                           |
-| -- createUser | String | X | 登録者(コンソールで送信時にユーザーUUIDとして保存) |
-| - totalCount | Integer | O | 合計数 |
+| -- isAddedChannel           | boolean | O        | チャンネルフレンドかどうか                                                              |
+| -- resultCode               | String  | X        | 受信結果コード                                                              |
+| -- resultCodeName           | String  | X        | 受信結果コード名                                                             |
+| -- createUser               | String  | X        | 登録者(コンソールから送信時にユーザーUUIDで保存)                                           |
+| -- senderGroupingKey        | String  | X        | 発信グルーピングキー                                                 |
+| -- recipientGroupingKey     | String  | X        | 受信者グルーピングキー                                           |
+| - totalCount                | Integer | O        | 総件数                                                                  |
 
 <a id="view-single-sending"></a>
 
@@ -1444,10 +1594,10 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 名前         | タイプ    | 説明       |
+| 名前           | タイプ      | 説明         |
 |--------------|---------|------------|
-| appkey       | String  | 固有のアプリキー   |
-| requestId    | String  | リクエストID      |
+| appkey       | String  | 固有のアプリキー     |
+| requestId    | String  | リクエスト ID      |
 | recipientSeq | Integer | 受信者シーケンス番号 |
 
 [Header]
@@ -1458,7 +1608,7 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前         | タイプ   | 必須 | 説明             |
+| 名前           | タイプ     | 必須 | 説明               |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
 
@@ -1601,160 +1751,305 @@ Content-Type: application/json;charset=UTF-8
     "resendStatusName": String,
     "resendResultCode": String,
     "resendRequestId": String,
-    "createUser": String
+    "createUser": String,
+    "senderGroupingKey": String,
+    "recipientGroupingKey": String
   }
 }
 ```
 
-| 名前                  | タイプ    | Not Null | 説明                                                                                             | 
- |:----------------------|:--------|:---------|:-------------------------------------------------------------------------------------------------| 
-| header                | Object  | O        | ヘッダ領域                                                                                          | 
-| - resultCode          | Integer | O        | 結果コード                                                                                          | 
-| - resultMessage       | String  | O        | 結果メッセージ                                                                                         | 
-| - isSuccessful        | boolean | O        | 成否                                                                                          | 
-| message | Object | X | メッセージ本文領域(メッセージ失敗時は存在しない場合があります) |
-| - requestId | String | O | リクエストID(messageオブジェクトが存在する場合Not Null) |
-| - recipientSeq | Integer | O | 受信者シーケンス番号(messageオブジェクトが存在する場合Not Null) |
-| - plusFriendId | String | O | 送信プロフィールID(messageオブジェクトが存在する場合Not Null) |
-| - senderKey | String | O | 送信キー(messageオブジェクトが存在する場合Not Null) |
-| - templateCode        | String  | X        | テンプレートコード                                                                                         | 
-| - recipientNo | String | O | 受信番号(messageオブジェクトが存在する場合Not Null) |
-| - targeting | String | O | メッセージ対象のタイプ(M - マーケティング受信同意ユーザー、N - 友だちではないマーケティング受信同意ユーザーにのみ、I - 友だちであるユーザー)(messageオブジェクトが存在する場合Not Null) |
-| - requestDate | String | O | リクエスト日時(messageオブジェクトが存在する場合Not Null) |
-| - createDate | String | O | 登録日時(messageオブジェクトが存在する場合Not Null) |
-| - receiveDate         | String  | X        | 受信日時                                                                                          | 
-| - chatBubbleType      | String  | O        | メッセージタイプ(messageオブジェクトが存在する場合Not Null)                                                                | 
-| - content | String | X | メッセージの内容 |
-| - adult | boolean | O | 成人向けメッセージかどうか(messageオブジェクトが存在する場合Not Null) |
-| - header              | String  | X        | ヘッダ(メッセージ内)                                                                                       | 
-| - additionalContent   | String  | X        | 付加情報(メッセージ内)                                                                                    |
-| - image | Object | X | 画像要素 |
-| -- imageUrl | String | O | 画像のURL(imageオブジェクトが存在する場合Not Null) |
-| -- imageLink | String | X | 画像のリンク |
-| - buttons             | Array   | X        | ボタンリスト                                                                                          | 
-| --- name | String | O | ボタンのタイトル(buttons配列の項目が存在する場合Not Null) |
-| --- type | String | O | ボタンのタイプ(buttons配列の項目が存在する場合Not Null) |
-| -- linkMo             | String  | X        | モバイルWebリンク                                                                                       | 
-| -- linkPc             | String  | X        | PC Webリンク                                                                                        | 
-| -- schemeIos          | String  | X        | iOSアプリリンク                                                                                       | 
-| -- schemeAndroid      | String  | X        | Androidアプリリンク                                                                                     | 
-| --- chatExtra | String | X | BTタイプのボタンの場合に転送するメタ情報 |
-| --- chatEvent | String | X | BTタイプのボタンの場合に接続するボットのイベント名 |
-| --- bizFormKey | String | X | BFタイプのボタンの場合のビズフォームキー |
-| - item                | Object  | X        | ワイドリスト要素                                                                                     | 
-| -- list | Array | X | ワイドリスト(itemオブジェクトが存在する場合Nullable) |
-| --- title             | String  | X        | アイテムのタイトル                                                                                         | 
-| --- imageUrl | String | O | アイテム画像のURL(item.listの項目が存在する場合Not Null) |
-| --- linkMo | String | O | モバイルWebリンク(item.listの項目が存在する場合Not Null) |
-| --- linkPc            | String  | X        | PC Webリンク                                                                                        | 
-| --- schemeIos         | String  | X        | iOSアプリリンク                                                                                       | 
-| --- schemeAndroid     | String  | X        | Androidアプリリンク                                                                                     | 
-| - coupon              | Object  | X        | クーポン要素                                                                                          | 
-| -- title              | String  | O        | クーポンのタイトル(couponオブジェクトが存在する場合Not Null)                                                                  | 
-| -- description | String | O | クーポンの詳細説明(couponオブジェクトが存在する場合Not Null) |
-| -- linkMo             | String  | X        | モバイルWebリンク                                                                                       | 
-| -- linkPc             | String  | X        | PC Webリンク                                                                                        | 
-| -- schemeAndroid      | String  | X        | Androidアプリリンク                                                                                     | 
-| -- schemeIos          | String  | X        | iOSアプリリンク                                                                                       | 
-| - commerce            | Object  | X        | コマース要素                                                                                         | 
-| -- title              | String  | O        | 商品名(commerceオブジェクトが存在する場合Not Null)                                                                | 
-| -- regularPrice       | Integer | X        | 通常価格                                                                                          | 
-| -- discountPrice      | Integer | X        | 割引価格                                                                                           | 
-| -- discountRate       | Integer | X        | 割引率                                                                                            | 
-| -- discountFixed      | Integer | X        | 定額割引価格                                                                                         | 
-| - video               | Object  | X        | 動画要素                                                                                         | 
-| -- videoUrl | String | O | カカオTVの動画URL(videoオブジェクトが存在する場合Not Null) |
-| -- thumbnailUrl | String | X | 動画のサムネイル用画像のURL |
-| - carousel            | Object  | X        | カルーセル                                                                                            | 
-| -- head | Object | X | カルーセルのイントロ(carouselオブジェクトが存在する場合Nullable) |
-| --- header | String | O | カルーセルのイントロヘッダ(headオブジェクトが存在する場合Not Null) |
-| --- content | String | O | カルーセルのイントロ内容(headオブジェクトが存在する場合Not Null) |
-| --- imageUrl | String | O | カルーセルのイントロ画像のURL(headオブジェクトが存在する場合Not Null) |
-| --- linkMo            | String  | X        | モバイルWebリンク                                                                                       | 
-| --- linkPc            | String  | X        | PC Webリンク                                                                                        | 
-| --- schemeIos         | String  | X        | iOSアプリリンク                                                                                       | 
-| --- schemeAndroid     | String  | X        | Androidアプリリンク                                                                                     | 
-| -- list               | Array   | O        | カルーセルリスト(carouselオブジェクトが存在する場合Not Null)                                                              | 
-| --- header | String | X | カルーセルアイテムのヘッダ |
-| --- message | String | O | カルーセルアイテムのメッセージ(listの項目が存在する場合Not Null) |
-| --- additionalContent | String  | X        | 付加情報                                                                                          | 
-| --- imageUrl | String | X | 画像のURL |
-| --- imageLink | String | X | 画像のリンク |
-| --- commerce | Object | X | コマース(カルーセル内) |
-| ---- title | String | O | 商品のタイトル(carousel.list.commerceが存在する場合Not Null) |
-| ---- regularPrice     | Integer | X        | 通常価格                                                                                          | 
-| ---- discountPrice    | Integer | X        | 割引価格                                                                                           | 
-| ---- discountRate     | Integer | X        | 割引率                                                                                            | 
-| ---- discountFixed    | Integer | X        | 定額割引価格                                                                                         | 
-| --- buttons           | Array   | X        | ボタンリスト(カルーセル内)                                                                                    | 
-| ---- name | String | O | ボタンのタイトル(carousel.list.buttonsの項目が存在する場合Not Null) |
-| ---- type | String | O | ボタンのタイプ(carousel.list.buttonsの項目が存在する場合Not Null) |
-| ---- linkMo           | String  | X        | モバイルWebリンク                                                                                       | 
-| ---- linkPc           | String  | X        | PC Webリンク                                                                                        | 
-| ---- schemeAndroid    | String  | X        | Androidアプリリンク                                                                                     | 
-| ---- schemeIos        | String  | X        | iOSアプリリンク                                                                                       | 
-| ---- chatExtra | String | X | BTタイプのボタンの場合に転送するメタ情報 |
-| ---- chatEvent | String | X | BTタイプのボタンの場合に接続するボットのイベント名 |
-| ---- bizFormKey | String | X | BFタイプのボタンの場合のビズフォームキー |
-| --- coupon | Object | X | クーポン(カルーセル内) |
-| ---- title | String | O | クーポンの件名(carousel.list.couponが存在する場合Not Null) |
-| ---- description | String | O | クーポンの詳細説明(carousel.list.couponが存在する場合Not Null) |
-| ---- linkMo           | String  | X        | モバイルWebリンク                                                                                       | 
-| ---- linkPc           | String  | X        | PC Webリンク                                                                                        | 
-| ---- schemeAndroid    | String  | X        | Androidアプリリンク                                                                                     | 
-| ---- schemeIos        | String  | X        | iOSアプリリンク                                                                                       | 
-| -- tail | Object | X | もっと見るボタンの情報(carouselオブジェクトが存在する場合Nullable) |
-| --- linkMo | String | O | モバイルWebリンク(tailオブジェクトが存在する場合Not Null) |
-| --- linkPc            | String  | X        | PC Webリンク                                                                                        | 
-| --- schemeAndroid     | String  | X        | Androidアプリリンク                                                                                     | 
-| --- schemeIos         | String  | X        | iOSアプリリンク                                                                                       | 
-| - templateParameter   | String  | X        | テンプレートパラメータ                                                                                       | 
-| - pushAlarm | boolean | O | プッシュ通知を使用するかどうか(messageオブジェクトが存在する場合Not Null) |
-| - messageStatus | String | O | リクエストステータス(COMPLETED：成功、FAILED：失敗)(messageオブジェクトが存在する場合Not Null) |
-| - isAddedChannel | boolean | O | チャンネルの友だちかどうか(messageオブジェクトが存在する場合Not Null) |
-| - resultCode          | String  | X        | 受信結果コード(メッセージ内)                                                                                 | 
-| - resultCodeName      | String  | X        | 受信結果コード名(メッセージ内)                                                                                | 
-| - resendStatusCode    | String  | X        | 代替送信ステータスコード                                                                                    | 
-| - resendStatusName    | String  | X        | 代替送信ステータスコード名                                                                                   | 
-| - resendResultCode    | String  | X        | 代替送信結果コード                                                                                    | 
-| - resendRequestId     | String  | X        | 代替送信リクエストID                                                                                      | 
-| - createUser          | String  | X        | 登録者(コンソールから送信した場合、ユーザーUUIDで保存)                                                                      |
+| 名前                    | タイプ      | Not Null | 説明                                                                                               |
+|:----------------------|:--------|:---------|:-------------------------------------------------------------------------------------------------|
+| header                | Object  | O        | ヘッダー領域                                                                                           |
+| - resultCode          | Integer | O        | 結果コード                                                                                            |
+| - resultMessage       | String  | O        | 結果メッセージ                                                                                          |
+| - isSuccessful        | boolean | O        | 成功かどうか                                                                                           |
+| message               | Object  | X        | メッセージ本文領域（メッセージ失敗時に存在しない場合があります）                                                                |
+| - requestId           | String  | O        | リクエスト ID（message オブジェクト存在時 Not Null）                                                            |
+| - recipientSeq        | Integer | O        | 受信者シーケンス番号（message オブジェクト存在時 Not Null）                                                          |
+| - plusFriendId        | String  | O        | 発信プロフィール ID（message オブジェクト存在時 Not Null）                                                          |
+| - senderKey           | String  | O        | 発信キー（message オブジェクト存在時 Not Null）                                                                |
+| - templateCode        | String  | X        | テンプレートコード                                                                                        |
+| - recipientNo         | String  | O        | 受信番号（message オブジェクト存在時 Not Null）                                                                |
+| - targeting           | String  | O        | メッセージ対象のタイプ（M: マーケティング受信同意ユーザー、N: フレンドでないマーケティング受信同意ユーザーのみ、I: フレンドであるユーザー）（message オブジェクト存在時 Not Null） |
+| - requestDate         | String  | O        | リクエスト日時（yyyy-MM-dd HH:mm）<br>（入力しない場合は即時送信）<br>最大 60 日後まで予約可能（message オブジェクト存在時 Not Null）      |
+| - createDate          | String  | O        | 登録日時（message オブジェクト存在時 Not Null）                                                                |
+| - receiveDate         | String  | X        | 受信日時                                                                                             |
+| - chatBubbleType      | String  | O        | メッセージタイプ（message オブジェクト存在時 Not Null）                                                             |
+| - content             | String  | X        | メッセージ内容                                                                                          |
+| - adult               | boolean | O        | 成人向けメッセージかどうか（message オブジェクト存在時 Not Null）                                                       |
+| - header              | String  | X        | ヘッダー（メッセージ内）                                                                                     |
+| - additionalContent   | String  | X        | 付加情報（メッセージ内）                                                                                     |
+| - image               | Object  | X        | 画像要素                                                                                             |
+| -- imageUrl           | String  | O        | 画像 URL（image オブジェクト存在時 Not Null）                                                                |
+| -- imageLink          | String  | X        | 画像リンク                                                                                            |
+| - buttons             | Array   | X        | ボタンリスト                                                                                           |
+| -- name               | String  | O        | ボタンタイトル（buttons 配列項目存在時 Not Null）                                                               |
+| -- type               | String  | O        | ボタンタイプ（buttons 配列項目存在時 Not Null）                                                                |
+| -- linkMo             | String  | X        | モバイル Web リンク                                                                                     |
+| -- linkPc             | String  | X        | PC Web リンク                                                                                       |
+| -- schemeIos          | String  | X        | iOS アプリリンク                                                                                       |
+| -- schemeAndroid      | String  | X        | Android アプリリンク                                                                                   |
+| -- chatExtra          | String  | X        | BT タイプボタンの場合に渡すメタ情報                                                                             |
+| -- chatEvent          | String  | X        | BT タイプボタンの場合に接続するボットイベント名                                                                       |
+| -- bizFormKey         | String  | X        | BF タイプボタンの場合のビズフォームキー                                                                           |
+| - item                | Object  | X        | ワイドリスト要素                                                                                         |
+| -- list               | Array   | X        | ワイドリスト（item オブジェクト存在時 Nullable）                                                                 |
+| --- title             | String  | X        | アイテムタイトル                                                                                         |
+| --- imageUrl          | String  | O        | アイテム画像 URL（item.list 項目存在時 Not Null）                                                            |
+| --- linkMo            | String  | O        | モバイル Web リンク（item.list 項目存在時 Not Null）                                                          |
+| --- linkPc            | String  | X        | PC Web リンク                                                                                       |
+| --- schemeIos         | String  | X        | iOS アプリリンク                                                                                       |
+| --- schemeAndroid     | String  | X        | Android アプリリンク                                                                                   |
+| - coupon              | Object  | X        | クーポン要素                                                                                           |
+| -- title              | String  | O        | クーポンタイトル（coupon オブジェクト存在時 Not Null）                                                             |
+| -- description        | String  | O        | クーポン詳細説明（coupon オブジェクト存在時 Not Null）                                                             |
+| -- linkMo             | String  | X        | モバイル Web リンク                                                                                     |
+| -- linkPc             | String  | X        | PC Web リンク                                                                                       |
+| -- schemeAndroid      | String  | X        | Android アプリリンク                                                                                   |
+| -- schemeIos          | String  | X        | iOS アプリリンク                                                                                       |
+| - commerce            | Object  | X        | コマース要素                                                                                           |
+| -- title              | String  | O        | 商品タイトル（commerce オブジェクト存在時 Not Null）                                                             |
+| -- regularPrice       | Integer | X        | 通常価格                                                                                             |
+| -- discountPrice      | Integer | X        | 割引価格                                                                                             |
+| -- discountRate       | Integer | X        | 割引率                                                                                              |
+| -- discountFixed      | Integer | X        | 定額割引価格                                                                                           |
+| - video               | Object  | X        | 動画要素                                                                                             |
+| -- videoUrl           | String  | O        | カカオTV 動画 URL（video オブジェクト存在時 Not Null）                                                          |
+| -- thumbnailUrl       | String  | X        | 動画サムネイル用画像 URL                                                                                   |
+| - carousel            | Object  | X        | カルーセル                                                                                            |
+| -- head               | Object  | X        | カルーセルイントロ（carousel オブジェクト存在時 Nullable）                                                          |
+| --- header            | String  | O        | カルーセルイントロヘッダー（head オブジェクト存在時 Not Null）                                                          |
+| --- content           | String  | O        | カルーセルイントロ内容（head オブジェクト存在時 Not Null）                                                            |
+| --- imageUrl          | String  | O        | カルーセルイントロ画像アドレス（head オブジェクト存在時 Not Null）                                                        |
+| --- linkMo            | String  | X        | モバイル Web リンク                                                                                     |
+| --- linkPc            | String  | X        | PC Web リンク                                                                                       |
+| --- schemeIos         | String  | X        | iOS アプリリンク                                                                                       |
+| --- schemeAndroid     | String  | X        | Android アプリリンク                                                                                       |
+| -- list               | Array   | O        | カルーセルリスト（carousel オブジェクト存在時 Not Null）                                                              |
+| --- header            | String  | X        | カルーセルアイテムヘッダー                                                                                       |
+| --- message           | String  | O        | カルーセルアイテムメッセージ（list 項目存在時 Not Null）                                                              |
+| --- additionalContent | String  | X        | 付加情報                                                                                            |
+| --- imageUrl          | String  | X        | 画像 URL                                                                                          |
+| --- imageLink         | String  | X        | 画像リンク                                                                                           |
+| --- commerce          | Object  | X        | コマース（カルーセル内）                                                                                      |
+| ---- title            | String  | O        | 商品タイトル（carousel.list.commerce 存在時 Not Null）                                                     |
+| ---- regularPrice     | Integer | X        | 通常価格                                                                                            |
+| ---- discountPrice    | Integer | X        | 割引価格                                                                                             |
+| ---- discountRate     | Integer | X        | 割引率                                                                                              |
+| ---- discountFixed    | Integer | X        | 定額割引価格                                                                                           |
+| --- buttons           | Array   | X        | ボタンリスト（カルーセル内）                                                                                    |
+| ---- name             | String  | O        | ボタンタイトル（carousel.list.buttons 項目存在時 Not Null）                                                   |
+| ---- type             | String  | O        | ボタンタイプ（carousel.list.buttons 項目存在時 Not Null）                                                   |
+| ---- linkMo           | String  | X        | モバイル Web リンク                                                                                         |
+| ---- linkPc           | String  | X        | PC Web リンク                                                                                          |
+| ---- schemeAndroid    | String  | X        | Android アプリリンク                                                                                       |
+| ---- schemeIos        | String  | X        | iOS アプリリンク                                                                                         |
+| ---- chatExtra        | String  | X        | BT タイプのボタンの場合に渡すメタ情報                                                                      |
+| ---- chatEvent        | String  | X        | BT タイプのボタンの場合に接続するボットイベント名                                                                          |
+| ---- bizFormKey       | String  | X        | BF タイプのボタンの場合のビズフォームキー                                                                               |
+| --- coupon            | Object  | X        | クーポン（カルーセル内）                                                                                       |
+| ---- title            | String  | O        | クーポンタイトル（carousel.list.coupon 存在時 Not Null）                                                       |
+| ---- description      | String  | O        | クーポン詳細説明（carousel.list.coupon 存在時 Not Null）                                                    |
+| ---- linkMo           | String  | X        | モバイル Web リンク                                                                                         |
+| ---- linkPc           | String  | X        | PC Web リンク                                                                                          |
+| ---- schemeAndroid    | String  | X        | Android アプリリンク                                                                                       |
+| ---- schemeIos        | String  | X        | iOS アプリリンク                                                                                         |
+| -- tail               | Object  | X        | もっと見るボタン情報（carousel オブジェクト存在時 Nullable）                                                            |
+| --- linkMo            | String  | O        | モバイル Web リンク（tail オブジェクト存在時 Not Null）                                                                 |
+| --- linkPc            | String  | X        | PC Web リンク                                                                                          |
+| --- schemeAndroid     | String  | X        | Android アプリリンク                                                                                       |
+| --- schemeIos         | String  | X        | iOS アプリリンク                                                                                         |
+| - templateParameter   | String  | X        | テンプレートパラメータ                                                                                         |
+| - pushAlarm           | boolean | O        | プッシュ通知の有無（message オブジェクト存在時 Not Null）                                                              |
+| - messageStatus       | String  | O        | リクエスト状態（COMPLETED: 成功、FAILED: 失敗）（message オブジェクト存在時 Not Null）                                     |
+| - isAddedChannel      | boolean | O        | チャンネルフレンドの有無（message オブジェクト存在時 Not Null）                                                              |
+| - resultCode          | String  | X        | 受信結果コード（メッセージ内）                                                                                 |
+| - resultCodeName      | String  | X        | 受信結果コード名（メッセージ内）                                                                                |
+| - resendStatusCode    | String  | X        | 代替送信ステータスコード                                                                                      |
+| - resendStatusName    | String  | X        | 代替送信ステータスコード名                                                                                     |
+| - resendResultCode    | String  | X        | 代替送信結果コード                                                                                      |
+| - resendRequestId     | String  | X        | 代替送信リクエスト ID                                                                                      |
+| - createUser          | String  | X        | 登録者（コンソールから送信時はユーザー UUID で保存）                                                                      |
+| - senderGroupingKey   | String  | X        | 発信グルーピングキー                                                 |
+| - recipientGroupingKey | String  | X        | 受信者グルーピングキー                                           |
 
 <a id="message-results"></a>
 
-## メッセージ結果アップデート照会
-
-<!-- TODO: translate body -->
+## メッセージ結果更新照会
 
 <a id="requested-25"></a>
 
 #### リクエスト
 
-<!-- TODO: translate body -->
+[URL]
+
+```
+GET  /brand-message/v1.0/appkeys/{appKey}/message-results
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 名前     | タイプ     | 説明     |
+|--------|--------|--------|
+| appKey | String | 固有のアプリキー |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前           | タイプ     | 必須 | 説明               |
+|--------------|--------|----|------------------|
+| X-Secret-Key | String | O  | コンソールで作成できます。 |
+
+[Query parameter]
+
+| 名前              | タイプ      | 必須 | 説明                                                                  |
+|-----------------|---------|----|---------------------------------------------------------------------|
+| startUpdateDate | String  | O  | 結果更新照会の開始日時(yyyy-MM-dd HH:mm)                                  |
+| endUpdateDate   | String  | O  | 結果更新照会の終了日時(yyyy-MM-dd HH:mm)                                  |
+| targeting       | String  | X  | メッセージ対象のタイプ(M: マーケティング受信同意ユーザー、N: フレンドではないマーケティング受信同意ユーザーのみ、I: フレンドであるユーザー) |
+| pageNum         | Integer | X  | ページ番号(デフォルト: 1)                                                       |
+| pageSize        | Integer | X  | 照会件数(デフォルト: 15)                                                       |
+
+!!! tip "ヒント"
+    照会可能な期間は直近90日以内で、1回の照会範囲は最大31日です。
 
 <a id="response-25"></a>
 
 #### レスポンス
 
-<!-- TODO: translate body -->
+```
+{
+  "header": {
+    "resultCode": Integer,
+    "resultMessage": String,
+    "isSuccessful": boolean
+  },
+  "messageSearchResultResponse": {
+    "messages": [
+      {
+        "requestId": String,
+        "recipientSeq": Integer,
+        "plusFriendId": String,
+        "recipientNo": String,
+        "targeting": String,
+        "requestDate": String,
+        "messageStatus": String,
+        "isAddedChannel": boolean,
+        "resendStatus": String,
+        "resendStatusName": String,
+        "resultCode": String,
+        "resultCodeName": String,
+        "senderGroupingKey": String,
+        "recipientGroupingKey": String
+      }
+    ],
+    "totalCount": Integer
+  }
+}
+```
+
+| 名前                          | タイプ      | Not Null | 説明                                                                    |
+|:----------------------------|:--------|:---------|:----------------------------------------------------------------------|
+| header                      | Object  | O        | ヘッダー領域                                                                 |
+| - resultCode                | Integer | O        | 結果コード                                                                 |
+| - resultMessage             | String  | O        | 結果メッセージ                                                                |
+| - isSuccessful              | Boolean | O        | 成功かどうか                                                                 |
+| messageSearchResultResponse | Object  | X        | 本文領域                                                                 |
+| - messages                  | Array   | X        | メッセージリスト                                                               |
+| -- requestId                | String  | O        | リクエスト ID                                                                 |
+| -- recipientSeq             | Integer | O        | 受信者シーケンス番号                                                            |
+| -- plusFriendId             | String  | O        | 発信プロフィール ID                                                             |
+| -- recipientNo              | String  | O        | 受信番号                                                                 |
+| -- targeting                | String  | O        | メッセージ対象のタイプ(M: マーケティング受信同意ユーザー、N: フレンドではないマーケティング受信同意ユーザーのみ、I: フレンドであるユーザー) |
+| -- requestDate              | String  | O        | リクエスト日時                                                                 |
+| -- messageStatus            | String  | O        | リクエスト状態(COMPLETED: 成功、FAILED: 失敗、CANCEL: 取消)                         |
+| -- isAddedChannel           | Boolean | O        | チャンネルフレンドかどうか                                                              |
+| -- resendStatus             | String  | X        | 代替送信状態コード                                                           |
+| -- resendStatusName         | String  | X        | 代替送信状態コード名                                                          |
+| -- resultCode               | String  | X        | 受信結果コード                                                              |
+| -- resultCodeName           | String  | X        | 受信結果コード名                                                             |
+| -- senderGroupingKey        | String  | X        | 発信グルーピングキー                                                             |
+| -- recipientGroupingKey     | String  | X        | 受信者グルーピングキー                                                            |
+| - totalCount                | Integer | X        | 総件数                                                                  |
+
+[例]
+
+```
+curl -X GET -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appKey}/message-results?startUpdateDate=2026-06-01%2000:00&endUpdateDate=2026-06-30%2023:59"
+```
 
 <a id="cancel-message-sending"></a>
 
 ## メッセージ送信取消
 
-<!-- TODO: translate body -->
-
 <a id="requested-7"></a>
 
 #### リクエスト
 
-<!-- TODO: translate body -->
+[URL]
+
+```
+DELETE  /brand-message/v1.0/appkeys/{appkey}/messages/{requestId}
+Content-Type: application/json;charset=UTF-8
+```
+
+[Path parameter]
+
+| 名前        | 	タイプ     | 	説明     |
+|-----------|---------|---------|
+| appkey    | 	String | 	固有のアプリキー |
+| requestId | String  | リクエスト ID   |
+
+[Header]
+
+```
+{
+  "X-Secret-Key": String
+}
+```
+
+| 名前           | 	タイプ     | 	必須 | 	説明              |
+|--------------|---------|-----|------------------|
+| X-Secret-Key | 	String | O   | コンソールで作成できます。 |
+
+[Query parameter]
+
+| 名前           | 	タイプ     | 	必須 | 	説明                                         |
+|--------------|---------|-----|---------------------------------------------|
+| recipientSeq | 	String | 	X  | 受信者シーケンス番号<br>(入力しない場合、リクエスト ID のすべての送信件を取消) |
 
 <a id="response-7"></a>
 
 #### レスポンス
 
-<!-- TODO: translate body -->
+```
+{
+  "header": {
+      "resultCode": Integer,
+      "resultMessage": String,
+      "isSuccessful": boolean
+  }
+}
+```
+
+| 名前              | タイプ      | Not Null | 説明     |
+|-----------------|---------|:--------:|--------|
+| header          | Object  |    X     | ヘッダー領域  |
+| - resultCode    | Integer |    X     | 結果コード  |
+| - resultMessage | String  |    X     | 結果メッセージ |
+| - isSuccessful  | Boolean |    X     | 成否  |
+
+[例]
+```
+curl -X DELETE -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:{secretkey}" "https://kakaotalk-bizmessage.api.nhncloudservice.com/brand-message/v1.0/appkeys/{appkey}/messages/{requestId}?recipientSeq=1,2,3"
+```
 
 <a id="manage-templates"></a>
 
@@ -1777,10 +2072,10 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 名前      | タイプ   | 説明   |
+| 名前        | タイプ     | 説明     |
 |-----------|--------|--------|
 | appkey    | String | 固有のアプリキー |
-| senderKey | String | 発信キー |
+| senderKey | String | 発信キー   |
 
 [Header]
 
@@ -1790,23 +2085,23 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前         | タイプ   | 必須 | 説明             |
+| 名前           | タイプ     | 必須 | 説明               |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
 
 [Query parameter]
 
-| 名前         | タイプ    | 必須 | 説明                          |
+| 名前           | タイプ      | 必須 | 説明                            |
 |--------------|---------|----|-------------------------------|
-| templateCode | String  | X  | テンプレートコード                      |
-| templateName | String  | X  | テンプレート名                      |
-| status       | String  | X  | テンプレートステータスコード                   |
+| templateCode | String  | X  | テンプレートコード                        |
+| templateName | String  | X  | テンプレート名                        |
+| status       | String  | X  | テンプレート状態コード                     |
 | pageNum      | Integer | X  | ページ番号(Default: 1)            |
-| pageSize     | Integer | X  | 照会件数(Default: 15, Max: 1,000) |
+| pageSize     | Integer | X  | 照会件数(Default: 15, Max: 1000) |
 
 <a id="response-8"></a>
 
-#### レスポンス
+#### 応答
 
 ```
 {
@@ -1935,107 +2230,107 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前                    | タイプ    | Not Null | 説明                                   |
+| 名前                      | タイプ      | Not Null | 説明                                     |
 |:------------------------|:--------|:---------|:---------------------------------------|
-| header                  | Object  | O        | ヘッダ領域                                |
-| - resultCode            | Integer | O        | 結果コード                                |
-| - resultMessage         | String  | O        | 結果メッセージ                               |
-| - isSuccessful          | boolean | O        | 成否                                |
-| templateListResponse    | Object  | O        | 本文領域                                |
-| - templates             | Array   | O        | テンプレートリスト                              |
-| -- plusFriendId         | String  | O        | 送信プロフィールID                              |
-| -- plusFriendType       | String  | O        | 送信プロフィールタイプ                            |
-| -- templateCode         | String  | O        | テンプレートコード                               |
-| -- templateName         | String  | O        | テンプレート名                                |
-| -- chatBubbleType       | String  | O        | メッセージタイプ                               |
-| -- content              | String  | X        | メッセージの内容                                |
-| -- header               | String  | X        | ヘッダ                                   |
-| -- additionalContent    | String  | X        | (説明テーブル参考)                            |
-| -- adult                | boolean | O        | 成人向けメッセージかどうか                            |
-| -- image                | Object  | X        | 画像情報                                |
-| --- imageUrl            | String  | O        | 画像のURL                                |
-| --- imageLink           | String  | X        | 画像のリンク                                |
-| -- buttons              | Array   | X        | ボタンリスト                                |
-| --- name                | String  | O        | ボタンのタイトル                                 |
-| --- type                | String  | O        | ボタンタイプ                                |
-| --- linkMo              | String  | X        | モバイルWebリンク                             |
-| --- linkPc              | String  | X        | PC Webリンク                              |
-| --- schemeIos           | String  | X        | iOSアプリリンク                             |
-| --- schemeAndroid       | String  | X        | Androidアプリリンク                           |
-| --- bizFormId           | Integer | X        | ビズフォームID (JSON基準)                       |
-| -- item                 | Object  | X        | ワイドリスト要素                           |
-| --- list                | Array   | X        | ワイドリスト                              |
-| ---- title              | String  | X        | アイテムのタイトル                                |
-| ---- imageUrl           | String  | O        | アイテム画像のURL                            |
-| ---- linkMo             | String  | O        | モバイルWebリンク                             |
-| ---- linkPc             | String  | X        | PC Webリンク                              |
-| ---- schemeAndroid      | String  | X        | Androidアプリリンク                           |
-| ---- schemeIos          | String  | X        | iOSアプリリンク                             |
-| -- coupon               | Object  | X        | クーポン要素                                |
-| --- title               | String  | O        | クーポン名                                |
-| --- description         | String  | O        | クーポンの詳細説明                              |
-| --- linkMo              | String  | X        | モバイルWebリンク                             |
-| --- linkPc              | String  | X        | PC Webリンク                              |
-| --- schemeAndroid       | String  | X        | Androidアプリリンク                           |
-| --- schemeIos           | String  | X        | iOSアプリリンク                             |
-| -- commerce             | Object  | X        | コマース要素                               |
-| --- title               | String  | O        | 商品名                                 |
-| --- regularPrice        | Integer | X        | 通常価格                                |
-| --- discountPrice       | Integer | X        | 割引価格                                 |
-| --- discountRate        | Integer | X        | 割引率                                  |
-| --- discountFixed       | Integer | X        | 定額割引価格                               |
-| -- video                | Object  | X        | 動画要素                               |
-| --- videoUrl            | String  | O        | カカオTVの動画URL                          |
-| --- thumbnailUrl        | String  | X        | 動画のサムネイル用画像のURL                       |
-| -- carousel             | Object  | X        | カルーセル                                  |
-| --- head                | Object  | X        | カルーセルイントロ                              |
-| ---- header             | String  | O        | カルーセルイントロヘッダ                           |
-| ---- content            | String  | O        | カルーセルイントロ内容                           |
-| ---- imageUrl           | String  | O        | カルーセルイントロ画像アドレス                        |
-| ---- linkMo             | String  | X        | モバイルWebリンク                             |
-| ---- linkPc             | String  | X        | PC Webリンク                              |
-| ----- schemeAndroid     | String  | X        | Androidアプリリンク                           |
-| ----- schemeIos         | String  | X        | iOSアプリリンク                             |
-| ---- list               | Array   | O        | カルーセルリスト                              |
-| ----- header            | String  | O        | カルーセルアイテムヘッダ                           |
-| ----- message           | String  | O        | カルーセルアイテムメッセージ(Not Nullリストのcontentマッピング) |
-| ----- additionalContent | String  | X        | 付加情報                                |
-| ----- imageUrl          | String  | O        | 画像URL (カルーセルアイテム内)                    |
-| ----- imageLink         | String  | X        | 画像リンク(カルーセルアイテム内)                     |
-| ----- commerce          | Object  | O        | コマース(カルーセルアイテム内)                        |
-| ------ title            | String  | O        | 商品名                                 |
-| ------ regularPrice     | Integer | X        | 通常価格                                |
-| ------ discountPrice    | Integer | X        | 割引価格                                 |
-| ------ discountRate     | Integer | X        | 割引率                                  |
-| ------ discountFixed    | Integer | X        | 定額割引価格                               |
-| ----- buttons           | Array   | O        | カルーセルリストのボタン一覧                         |
-| ------ name             | String  | O        | ボタンのタイトル                                 |
-| ------ type             | String  | O        | ボタンタイプ                                |
-| ------ linkMo           | String  | X        | モバイルWebリンク                             |
-| ------ linkPc           | String  | X        | PC Webリンク                              |
-| ------ schemeIos        | String  | X        | iOSアプリリンク                             |
-| ------ schemeAndroid    | String  | X        | Androidアプリリンク                           |
-| ------ bizFormId        | Integer | X        | ビズフォームID (JSON基準)                       |
-| ----- coupon            | Object  | X        | クーポン要素(カルーセルアイテム内)                      |
-| ------ title            | String  | X        | クーポン名                                 |
-| ------ description      | String  | X        | クーポンの詳細説明                              |
-| ------ linkMo           | String  | X        | モバイルWebリンク                             |
-| ------ linkPc           | String  | X        | PC Webリンク                              |
-| ------ schemeAndroid    | String  | X        | Androidアプリリンク                           |
-| ------ schemeIos        | String  | X        | iOSアプリリンク                             |
-| ---- tail               | Object  | X        | もっと見るボタン情報                             |
-| ----- linkMo            | String  | O        | モバイルWebリンク                             |
-| ----- linkPc            | String  | X        | PC Webリンク                              |
-| ----- schemeAndroid     | String  | X        | Androidアプリリンク                           |
-| ----- schemeIos         | String  | X        | iOSアプリリンク                             |
-| --- status              | String  | O        | テンプレートの状態(A:登録、 S:ブロック)                   |
-| --- createDate          | String  | O        | 登録日時                                |
-| --- updateDate          | String  | X        | 修正日時                                |
-| - totalCount            | Integer | O        | 合計数                                  |
+| header                  | Object  | O        | ヘッダー領域                                  |
+| - resultCode            | Integer | O        | 結果コード                                  |
+| - resultMessage         | String  | O        | 結果メッセージ                                 |
+| - isSuccessful          | boolean | O        | 成功かどうか                                  |
+| templateListResponse    | Object  | O        | 本文領域                                  |
+| - templates             | Array   | O        | テンプレートリスト                                |
+| -- plusFriendId         | String  | O        | 発信プロフィール ID                              |
+| -- plusFriendType       | String  | O        | 発信プロフィールタイプ                              |
+| -- templateCode         | String  | O        | テンプレートコード                                 |
+| -- templateName         | String  | O        | テンプレート名                                  |
+| -- chatBubbleType       | String  | O        | メッセージタイプ                                 |
+| -- content              | String  | X        | メッセージ内容                                 |
+| -- header               | String  | X        | ヘッダー                                     |
+| -- additionalContent    | String  | X        |（説明テーブル参照）                            |
+| -- adult                | boolean | O        | 成人向けメッセージかどうか                             |
+| -- image                | Object  | X        | 画像情報                                 |
+| --- imageUrl            | String  | O        | 画像 URL                                |
+| --- imageLink           | String  | X        | 画像リンク                                 |
+| -- buttons              | Array   | X        | ボタンリスト                                  |
+| --- name                | String  | O        | ボタンタイトル                                  |
+| --- type                | String  | O        | ボタンタイプ                                  |
+| --- linkMo              | String  | X        | モバイル Web リンク                               |
+| --- linkPc              | String  | X        | PC Web リンク                                |
+| --- schemeIos           | String  | X        | iOS アプリリンク                               |
+| --- schemeAndroid       | String  | X        | Android アプリリンク                             |
+| --- bizFormId           | Integer | X        | ビズフォーム ID（JSON 基準）                       |
+| -- item                 | Object  | X        | ワイドリスト要素                             |
+| --- list                | Array   | X        | ワイドリスト                                |
+| ---- title              | String  | X        | アイテムタイトル                                 |
+| ---- imageUrl           | String  | O        | アイテム画像 URL                            |
+| ---- linkMo             | String  | O        | モバイル Web リンク                               |
+| ---- linkPc             | String  | X        | PC Web リンク                                |
+| ---- schemeAndroid      | String  | X        | Android アプリリンク                             |
+| ---- schemeIos          | String  | X        | iOS アプリリンク                               |
+| -- coupon               | Object  | X        | クーポン要素                                  |
+| --- title               | String  | O        | クーポンタイトル                                  |
+| --- description         | String  | O        | クーポン詳細説明                               |
+| --- linkMo              | String  | X        | モバイル Web リンク                               |
+| --- linkPc              | String  | X        | PC Web リンク                                |
+| --- schemeAndroid       | String  | X        | Android アプリリンク                             |
+| --- schemeIos           | String  | X        | iOS アプリリンク                               |
+| -- commerce             | Object  | X        | コマース要素                                 |
+| --- title               | String  | O        | 商品タイトル                                  |
+| --- regularPrice        | Integer | X        | 通常価格                                  |
+| --- discountPrice       | Integer | X        | 割引価格                                   |
+| --- discountRate        | Integer | X        | 割引率                                    |
+| --- discountFixed       | Integer | X        | 定額割引価格                                 |
+| -- video                | Object  | X        | 動画要素                                 |
+| --- videoUrl            | String  | O        | カカオ TV 動画 URL                          |
+| --- thumbnailUrl        | String  | X        | 動画サムネイル用画像 URL                       |
+| -- carousel             | Object  | X        | カルーセル                                    |
+| --- head                | Object  | X        | カルーセルイントロ                                |
+| ---- header             | String  | O        | カルーセルイントロヘッダー                             |
+| ---- content            | String  | O        | カルーセルイントロ内容                             |
+| ---- imageUrl           | String  | O        | カルーセルイントロ画像アドレス                         |
+| ---- linkMo             | String  | X        | モバイル Web リンク                               |
+| ---- linkPc             | String  | X        | PC Web リンク                                |
+| ----- schemeAndroid     | String  | X        | Android アプリリンク                             |
+| ----- schemeIos         | String  | X        | iOS アプリリンク                               |
+| ---- list               | Array   | O        | カルーセルリスト                                |
+| ----- header            | String  | O        | カルーセルアイテムヘッダー                             |
+| ----- message           | String  | O        | カルーセルアイテムメッセージ（Not Null リストの content マッピング） |
+| ----- additionalContent | String  | X        | 付加情報                                  |
+| ----- imageUrl          | String  | O        | 画像 URL（カルーセルアイテム内）                    |
+| ----- imageLink         | String  | X        | 画像リンク（カルーセルアイテム内）                     |
+| ----- commerce          | Object  | O        | コマース（カルーセルアイテム内）                        |
+| ------ title            | String  | O        | 商品タイトル                                  |
+| ------ regularPrice     | Integer | X        | 通常価格                                  |
+| ------ discountPrice    | Integer | X        | 割引価格                                   |
+| ------ discountRate     | Integer | X        | 割引率                                    |
+| ------ discountFixed    | Integer | X        | 定額割引価格                                 |
+| ----- buttons           | Array   | O        | カルーセルリストボタンリスト                          |
+| ------ name             | String  | O        | ボタンタイトル                                  |
+| ------ type             | String  | O        | ボタンタイプ                                  |
+| ------ linkMo           | String  | X        | モバイル Web リンク                               |
+| ------ linkPc           | String  | X        | PC Web リンク                                |
+| ------ schemeIos        | String  | X        | iOS アプリリンク                               |
+| ------ schemeAndroid    | String  | X        | Android アプリリンク                             |
+| ------ bizFormId        | Integer | X        | ビズフォーム ID（JSON 基準）                       |
+| ----- coupon            | Object  | X        | クーポン要素（カルーセルアイテム内）                      |
+| ------ title            | String  | X        | クーポンタイトル                                  |
+| ------ description      | String  | X        | クーポン詳細説明                               |
+| ------ linkMo           | String  | X        | モバイル Web リンク                               |
+| ------ linkPc           | String  | X        | PC Web リンク                                |
+| ------ schemeAndroid    | String  | X        | Android アプリリンク                             |
+| ------ schemeIos        | String  | X        | iOS アプリリンク                               |
+| ---- tail               | Object  | X        | もっと見るボタン情報                              |
+| ----- linkMo            | String  | O        | モバイル Web リンク                               |
+| ----- linkPc            | String  | X        | PC Web リンク                                |
+| ----- schemeAndroid     | String  | X        | Android アプリリンク                             |
+| ----- schemeIos         | String  | X        | iOS アプリリンク                               |
+| --- status              | String  | O        | テンプレート状態（A: 登録、S: ブロック）                   |
+| --- createDate          | String  | O        | 登録日時                                  |
+| --- updateDate          | String  | X        | 修正日時                                  |
+| - totalCount            | Integer | O        | 総件数                                   |
 
 <a id="view-single-template"></a>
 
-### テンプレートの個別照会
+### テンプレート単件照会
 
 [URL]
 
@@ -2046,10 +2341,10 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 名前         | タイプ   | 説明   |
+| 名前           | タイプ     | 説明     |
 |--------------|--------|--------|
 | appkey       | String | 固有のアプリキー |
-| senderKey    | String | 発信キー |
+| senderKey    | String | 発信キー   |
 | templateCode | String | テンプレートコード |
 
 [Header]
@@ -2060,14 +2355,14 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前         | タイプ   | 必須 | 説明             |
+| 名前           | タイプ     | 必須 | 説明               |
 |--------------|--------|----|------------------|
-| X-Secret-Key | String | O  | コンソールで作成できます。 |
-|X-NC-API-IDEMPOTENCY-KEY| String| X | 重複メッセージ送信リクエストの基準key<br>10分間同じkeyでリクエストした場合、該当リクエストは失敗として処理します。 |
+| X-Secret-Key | String | O  | コンソールで生成できます。 |
+|X-NC-API-IDEMPOTENCY-KEY|	String| X | 重複メッセージ送信リクエストの基準キー<br>10分間、同一キーでリクエストした場合、該当リクエストを失敗として処理します。 |
 
 <a id="response-9"></a>
 
-#### レスポンス
+#### 応答
 
 ```
 {
@@ -2191,102 +2486,102 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前                  | タイプ    | Not Null | 説明                 |
+| 名前                    | タイプ      | Not Null | 説明                   |
 |:----------------------|:--------|:---------|:---------------------|
-| header                | Object  | O        | ヘッダ領域              |
-| - resultCode          | Integer | O        | 結果コード              |
-| - resultMessage       | String  | O        | 結果メッセージ             |
-| - isSuccessful        | boolean | O        | 成否              |
-| template              | Object  | O        | テンプレート本文領域          |
-| - plusFriendId        | String  | O        | 送信プロフィールID            |
-| - plusFriendType      | String  | O        | 送信プロフィールタイプ          |
-| - templateCode        | String  | O        | テンプレートコード             |
+| header                | Object  | O        | ヘッダー領域               |
+| - resultCode          | Integer | O        | 結果コード                |
+| - resultMessage       | String  | O        | 結果メッセージ              |
+| - isSuccessful        | boolean | O        | 成否                   |
+| template              | Object  | O        | テンプレート本文領域           |
+| - plusFriendId        | String  | O        | 発信プロフィール ID          |
+| - plusFriendType      | String  | O        | 発信プロフィールタイプ          |
+| - templateCode        | String  | O        | テンプレートコード            |
 | - templateName        | String  | O        | テンプレート名              |
 | - chatBubbleType      | String  | O        | メッセージタイプ             |
 | - pushAlarm           | boolean | X        | プッシュ通知の有無            |
-| - content             | String  | X        | メッセージの内容              |
-| - adult               | boolean | O        | 成人向けメッセージかどうか          |
-| - header              | String  | X        | ヘッダ(テンプレート内)           |
-| - additionalContent   | String  | X        | 付加情報(テンプレート内)        |
-| - image               | Object  | X        | 画像情報              |
-| -- imageUrl           | String  | O        | 画像のURL              |
-| -- imageLink          | String  | X        | 画像のリンク              |
-| - buttons             | Array   | X        | ボタンリスト              |
-| -- name               | String  | O        | ボタンのタイトル               |
-| -- type               | String  | O        | ボタンタイプ              |
-| -- linkMo             | String  | X        | モバイルWebリンク           |
-| -- linkPc             | String  | X        | PC Webリンク            |
-| -- schemeIos          | String  | X        | iOSアプリリンク           |
-| -- schemeAndroid      | String  | X        | Androidアプリリンク         |
-| -- bizFormId          | Integer | X        | ビズフォームID (JSON基準)     |
-| - item                | Object  | X        | ワイドリスト要素         |
-| -- list               | Array   | X        | ワイドリスト            |
-| --- title             | String  | X        | アイテムのタイトル              |
-| --- imageUrl          | String  | O        | アイテム画像のURL          |
-| --- linkMo            | String  | O        | モバイルWebリンク           |
-| --- linkPc            | String  | X        | PC Webリンク            |
-| --- schemeIos         | String  | X        | iOSアプリリンク           |
-| --- schemeAndroid     | String  | X        | Androidアプリリンク         |
-| - coupon              | Object  | X        | クーポン要素              |
-| -- title              | String  | O        | クーポン名               |
-| -- description        | String  | O        | クーポンの詳細説明            |
-| -- linkMo             | String  | X        | モバイルWebリンク           |
-| -- linkPc             | String  | X        | PC Webリンク            |
-| -- schemeIos          | String  | X        | iOSアプリリンク           |
-| -- schemeAndroid      | String  | X        | Androidアプリリンク         |
-| - commerce            | Object  | X        | コマース要素             |
-| -- title              | String  | O        | 商品名              |
-| -- regularPrice       | Integer | X        | 通常価格              |
-| -- discountPrice      | Integer | X        | 割引価格               |
-| -- discountRate       | Integer | X        | 割引率                |
-| -- discountFixed      | Integer | X        | 定額割引価格             |
-| - video               | Object  | X        | 動画要素             |
-| -- videoUrl           | String  | O        | カカオTVの動画URL        |
-| -- thumbnailUrl       | String  | X        | 動画のサムネイル用画像のURL     |
+| - content             | String  | X        | メッセージ内容              |
+| - adult               | boolean | O        | 成人向けメッセージの有無         |
+| - header              | String  | X        | ヘッダー（テンプレート内）        |
+| - additionalContent   | String  | X        | 付加情報（テンプレート内）        |
+| - image               | Object  | X        | 画像情報                 |
+| -- imageUrl           | String  | O        | 画像 URL               |
+| -- imageLink          | String  | X        | 画像リンク                |
+| - buttons             | Array   | X        | ボタンリスト               |
+| -- name               | String  | O        | ボタンタイトル              |
+| -- type               | String  | O        | ボタンタイプ               |
+| -- linkMo             | String  | X        | モバイル Web リンク         |
+| -- linkPc             | String  | X        | PC Web リンク           |
+| -- schemeIos          | String  | X        | iOS アプリリンク            |
+| -- schemeAndroid      | String  | X        | Android アプリリンク        |
+| -- bizFormId          | Integer | X        | ビズフォーム ID（JSON 基準）  |
+| - item                | Object  | X        | ワイドリスト要素             |
+| -- list               | Array   | X        | ワイドリスト               |
+| --- title             | String  | X        | アイテムタイトル             |
+| --- imageUrl          | String  | O        | アイテム画像 URL           |
+| --- linkMo            | String  | O        | モバイル Web リンク         |
+| --- linkPc            | String  | X        | PC Web リンク           |
+| --- schemeIos         | String  | X        | iOS アプリリンク            |
+| --- schemeAndroid     | String  | X        | Android アプリリンク        |
+| - coupon              | Object  | X        | クーポン要素               |
+| -- title              | String  | O        | クーポンタイトル             |
+| -- description        | String  | O        | クーポン詳細説明             |
+| -- linkMo             | String  | X        | モバイル Web リンク         |
+| -- linkPc             | String  | X        | PC Web リンク           |
+| -- schemeIos          | String  | X        | iOS アプリリンク            |
+| -- schemeAndroid      | String  | X        | Android アプリリンク        |
+| - commerce            | Object  | X        | コマース要素               |
+| -- title              | String  | O        | 商品タイトル               |
+| -- regularPrice       | Integer | X        | 通常価格                 |
+| -- discountPrice      | Integer | X        | 割引価格                 |
+| -- discountRate       | Integer | X        | 割引率                  |
+| -- discountFixed      | Integer | X        | 定額割引価格               |
+| - video               | Object  | X        | 動画要素                 |
+| -- videoUrl           | String  | O        | カカオ TV 動画 URL        |
+| -- thumbnailUrl       | String  | X        | 動画サムネイル用画像 URL       |
 | - carousel            | Object  | X        | カルーセル                |
 | -- head               | Object  | X        | カルーセルイントロ            |
-| --- header            | String  | O        | カルーセルイントロヘッダ         |
-| --- content           | String  | O        | カルーセルイントロ内容         |
-| --- imageUrl          | String  | O        | カルーセルイントロ画像アドレス      |
-| --- linkMo            | String  | X        | モバイルWebリンク           |
-| --- linkPc            | String  | X        | PC Webリンク            |
-| --- schemeIos         | String  | X        | iOSアプリリンク           |
-| --- schemeAndroid     | String  | X        | Androidアプリリンク         |
-| -- list               | Array   | O        | カルーセルリスト            |
-| --- header            | String  | O        | カルーセルアイテムヘッダ         |
-| --- message           | String  | O        | カルーセルアイテムメッセージ        |
-| --- additionalContent | String  | X        | 付加情報(カルーセルアイテム内)    |
-| --- imageUrl          | String  | O        | 画像URL (カルーセルアイテム内)  |
-| --- imageLink         | String  | X        | 画像リンク(カルーセルアイテム内)   |
-| --- commerce          | Object  | O        | コマース(カルーセルアイテム内)      |
-| ---- title            | String  | O        | 商品名              |
-| ---- regularPrice     | Integer | X        | 通常価格              |
-| ---- discountPrice    | Integer | X        | 割引価格               |
-| ---- discountRate     | Integer | X        | 割引率                |
-| ---- discountFixed    | Integer | X        | 定額割引価格             |
-| --- buttons           | Array   | O        | カルーセルリストのボタン一覧       |
-| ---- name             | String  | O        | ボタンのタイトル               |
-| ---- type             | String  | O        | ボタンタイプ              |
-| ---- linkMo           | String  | X        | モバイルWebリンク           |
-| ---- linkPc           | String  | X        | PC Webリンク            |
-| ---- schemeIos        | String  | X        | iOSアプリリンク           |
-| ---- schemeAndroid    | String  | X        | Androidアプリリンク         |
-| ---- bizFormId        | Integer | X        | ビズフォームID (JSON基準)     |
-| --- coupon            | Object  | X        | クーポン要素(カルーセルアイテム内)    |
-| ---- title            | String  | X        | クーポン名               |
-| ---- description      | String  | X        | クーポンの詳細説明            |
-| ---- linkMo           | String  | X        | モバイルWebリンク           |
-| ---- linkPc           | String  | X        | PC Webリンク            |
-| ---- schemeIos        | String  | X        | iOSアプリリンク           |
-| ---- schemeAndroid    | String  | X        | Androidアプリリンク         |
+| --- header            | String  | O        | カルーセルイントロヘッダー        |
+| --- content           | String  | O        | カルーセルイントロ内容          |
+| --- imageUrl          | String  | O        | カルーセルイントロ画像アドレス      |
+| --- linkMo            | String  | X        | モバイル Web リンク         |
+| --- linkPc            | String  | X        | PC Web リンク           |
+| --- schemeIos         | String  | X        | iOS アプリリンク            |
+| --- schemeAndroid     | String  | X        | Android アプリリンク        |
+| -- list               | Array   | O        | カルーセルリスト             |
+| --- header            | String  | O        | カルーセルアイテムヘッダー        |
+| --- message           | String  | O        | カルーセルアイテムメッセージ       |
+| --- additionalContent | String  | X        | 付加情報（カルーセルアイテム内）     |
+| --- imageUrl          | String  | O        | 画像 URL（カルーセルアイテム内）  |
+| --- imageLink         | String  | X        | 画像リンク（カルーセルアイテム内）   |
+| --- commerce          | Object  | O        | コマース（カルーセルアイテム内）    |
+| ---- title            | String  | O        | 商品タイトル               |
+| ---- regularPrice     | Integer | X        | 通常価格                 |
+| ---- discountPrice    | Integer | X        | 割引価格                 |
+| ---- discountRate     | Integer | X        | 割引率                  |
+| ---- discountFixed    | Integer | X        | 定額割引価格               |
+| --- buttons           | Array   | O        | カルーセルリストボタンリスト       |
+| ---- name             | String  | O        | ボタンタイトル              |
+| ---- type             | String  | O        | ボタンタイプ               |
+| ---- linkMo           | String  | X        | モバイル Web リンク         |
+| ---- linkPc           | String  | X        | PC Web リンク           |
+| ---- schemeIos        | String  | X        | iOS アプリリンク            |
+| ---- schemeAndroid    | String  | X        | Android アプリリンク        |
+| ---- bizFormId        | Integer | X        | ビズフォーム ID（JSON 基準）  |
+| --- coupon            | Object  | X        | クーポン要素（カルーセルアイテム内）  |
+| ---- title            | String  | X        | クーポンタイトル             |
+| ---- description      | String  | X        | クーポン詳細説明             |
+| ---- linkMo           | String  | X        | モバイル Web リンク         |
+| ---- linkPc           | String  | X        | PC Web リンク           |
+| ---- schemeIos        | String  | X        | iOS アプリリンク            |
+| ---- schemeAndroid    | String  | X        | Android アプリリンク        |
 | -- tail               | Object  | X        | もっと見るボタン情報           |
-| --- linkMo            | String  | O        | モバイルWebリンク           |
-| --- linkPc            | String  | X        | PC Webリンク            |
-| --- schemeIos         | String  | X        | iOSアプリリンク           |
-| --- schemeAndroid     | String  | X        | Androidアプリリンク         |
-| - status              | String  | O        | テンプレートの状態(A:登録、 S:ブロック) |
-| - createDate          | String  | O        | 登録日時              |
-| - updateDate          | String  | X        | 修正日時              |
+| --- linkMo            | String  | O        | モバイル Web リンク         |
+| --- linkPc            | String  | X        | PC Web リンク           |
+| --- schemeIos         | String  | X        | iOS アプリリンク            |
+| --- schemeAndroid     | String  | X        | Android アプリリンク        |
+| - status              | String  | O        | テンプレート状態（A: 登録、S: ブロック） |
+| - createDate          | String  | O        | 登録日時                 |
+| - updateDate          | String  | X        | 修正日時                 |
 
 <a id="register-template"></a>
 
@@ -2305,10 +2600,10 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 名前      | タイプ   | 説明   |
+| 名前        | タイプ     | 説明     |
 |-----------|--------|--------|
 | appkey    | String | 固有のアプリキー |
-| senderKey | String | 発信キー |
+| senderKey | String | 発信キー   |
 
 [Header]
 
@@ -2318,7 +2613,7 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前         | タイプ   | 必須 | 説明             |
+| 名前           | タイプ     | 必須 | 説明               |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
 
@@ -2326,22 +2621,22 @@ Content-Type: application/json;charset=UTF-8
 
 #### 注意事項
 
-* クーポン名にプレースホルダーを適用する場合、次のような固定プレースホルダーを使用する必要があります。
+* クーポンタイトルに置換値を適用する場合は、次の固定置換値を使用する必要があります。
 
 ```
-- #{割引金額}KRW割引クーポン(#{割引金額}の範囲は1 ～ 99,999,999)
-- #{割引率}%割引クーポン(#{割引率}の範囲は1 ～ 100)
-- 送料割引クーポン
-- #{商品名}無料クーポン(#{商品名}は最大7文字)
-- #{商品名} UPクーポン(#{商品名}は最大7文字)
+- #{할인금액}원 할인 쿠폰(#{할인금액} 범위는 1 ~ 99,999,999)
+- #{할인율}% 할인 쿠폰(#{할인율} 범위는 1 ~ 100)
+- 배송비 할인 쿠폰
+- #{상품명} 무료 쿠폰(#{상품명}은 최대 7자)
+- #{상품명} UP 쿠폰(#{상품명}은 최대 7자)
 ```
 
-* コマースで商品名を除いたregularPrice、 discountPrice、 discountRate、 discountFixedフィールドには、ユーザーがプレースホルダーを指定することはできません。
-    * 商品名を除く全てのフィールドの値を空にした場合、自動的に固定プレースホルダーが入力されて保存されます。
-    * regularPrice -> #{通常価格}
-    * discountPrice -> #{割引価格}
-    * discountRate -> #{割引率}
-    * discountFixed -> #{定額割引価格}
+* コマースでは、商品タイトルを除く regularPrice、discountPrice、discountRate、discountFixed フィールドにはユーザーが置換値を指定できません。
+    * 商品タイトルを除くすべてのフィールドの値を空にした場合、自動的に固定置換値が入力されて保存されます。
+    * regularPrice -> #{정상가격}
+    * discountPrice -> #{할인가격}
+    * discountRate -> #{할인율}
+    * discountFixed -> #{정액할인가격}
 
 <a id="request-to-register-text-type-template"></a>
 
@@ -2377,27 +2672,27 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前            | タイプ    | 必須 | 説明                                                                                                                                                                                                                                                |
-|-----------------|---------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| templateName    | String  | O  | テンプレート名(最大200文字)                                                                                                                                                                                                                                     |
-| chatBubbleType  | String  | O  | メッセージタイプ(TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE)                                                                                                                                               |
-| adult           | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                                             |
-| content         | String  | O  | - TEXTタイプの場合、最大1,300文字(改行:最大99個、URL形式入力可能)<br>- IMAGEタイプの場合、最大400文字(改行:最大29個、URL形式入力可能)<br>- WIDEタイプの場合、最大76文字(改行:最大1個)<br>- PREMIUM_VIDEOタイプの場合、該当フィールドをオプションとして使用可能、最大76文字(改行:最大1個)<br>- その他のタイプの場合、該当フィールドは使用しません |
-| buttons         | List    | X  | ボタンリスト<br>- TEXT、IMAGEタイプの場合、クーポン適用時は最大4件、それ以外は最大5件<br>- WIDE、WIDE_ITEM_LISTタイプの場合、最大2件<br>- PREMIUM_VIDEOタイプの場合、最大1件<br>- COMMERCEタイプの場合、最小1件、最大2件                                                                                      |
-| - name          | String  | O  | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字<br>プレースホルダー使用不可                                                                                                                                                                           |
-| - type          | String  | O  | ボタンタイプ(WL: Webリンク、 AL:アプリリンク、 BK:ボットキーワード、 MD:メッセージ伝達、 AC:チャンネル追加、 BC:トーク相談転換、 BT:チャットボット転換、 BF:ビジネスフォーム)<br>- テンプレートではBCタイプは利用できません <br>- BTタイプ <br>- テンプレートではBFタイプは利用できません<br>- ACタイプはTEXT、IMAGEの場合、最初のボタンとして、その他のメッセージタイプの場合は最後のボタンとして登録する必要があります                  |
-| - linkMo        | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                                              |
-| - linkPc        | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                                               |
-| - schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                                            |
-| - schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合は必須フィールド)、500文字制限                                                                                                                                                                                                              |
-| - bizFormKey    | String  | X  | BFタイプのボタンの場合、ビズフォームキー<br>プレースホルダー使用不可                                                                                                                                                                                                                   |
-| coupon          | Object  | X  | クーポン要素                                                                                                                                                                                                                                             |
-| - title         | String  | O  | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」                                                                                  |
-| - description   | String  | O  | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字、改行:不可<br>- その他のタイプの場合、最大12文字、改行:不可                                                                                                                                           |
-| - linkMo        | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                         |
-| - linkPc        | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                                               |
-| - schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                       |
-| - schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                         |
+| 名前              | タイプ      | 必須 | 説明                                                                                                                                                                                                                                             |
+|-----------------|---------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| templateName    | String  | O  | テンプレート名（最大 200 文字）                                                                                                                                                                                                                                  |
+| chatBubbleType  | String  | O  | メッセージタイプ（TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE）                                                                                                                                           |
+| adult           | boolean | X  | 成人向けメッセージかどうか（デフォルト値: false）                                                                                                                                                                                                                         |
+| content         | String  | O  | - TEXT タイプの場合、最大 1,300 文字（改行: 最大 99 個、URL 形式の入力可能）<br>- IMAGE タイプの場合、最大 1,300 文字（改行: 最大 99 個、URL 形式の入力可能）<br>- WIDE タイプの場合、最大 76 文字（改行: 最大 5 個）<br>- PREMIUM_VIDEO タイプの場合、このフィールドは任意で使用可能、最大 76 文字（改行: 最大 5 個）<br>- その他のタイプの場合、このフィールドは使用しません |
+| buttons         | List    | X  | ボタンリスト<br>- TEXT、IMAGE タイプの場合、クーポン適用時は最大 4 個、それ以外は最大 5 個<br>- WIDE、WIDE_ITEM_LIST タイプの場合、最大 2 個<br>- PREMIUM_VIDEO タイプの場合、最大 1 個<br>- COMMERCE タイプの場合、最小 1 個、最大 2 個                                                                                  |
+| - name          | String  | O  | ボタンタイトル<br>- TEXT、IMAGE タイプの場合、最大 14 文字<br>- その他のタイプの場合、最大 8 文字<br>置換変数は使用不可                                                                                                                                                                       |
+| - type          | String  | O  | ボタンタイプ（WL: Web リンク、AL: アプリリンク、BK: ボットキーワード、MD: メッセージ転送、AC: チャンネル追加、BT: チャットボット切替、BF: ビジネスフォーム）<br>- AC タイプは TEXT、IMAGE の場合は最初のボタンとして、その他のメッセージタイプの場合は最後のボタンとして登録する必要があります             |
+| - linkMo        | String  | X  | モバイル Web リンク（WL タイプの場合は必須フィールド）、500 文字制限                                                                                                                                                                                                             |
+| - linkPc        | String  | X  | PC Web リンク（WL タイプの場合は任意フィールド）、500 文字制限                                                                                                                                                                                                            |
+| - schemeAndroid | String  | X  | Android アプリリンク（AL タイプの場合は必須フィールド）、500 文字制限                                                                                                                                                                                                         |
+| - schemeIos     | String  | X  | iOS アプリリンク（AL タイプの場合は必須フィールド）、500 文字制限                                                                                                                                                                                                           |
+| - bizFormKey    | String  | X  | BF タイプボタンの場合、ビズフォームキー<br>置換変数は使用不可                                                                                                                                                                                                               |
+| coupon          | Object  | X  | クーポン要素                                                                                                                                                                                                                                          |
+| - title         | String  | O  | title は 5 種類の形式に制限されます<br>- "${数字}円割引クーポン" 数字は 1 以上 99,999,999 以下<br>- "${数字}% 割引クーポン" 数字は 1 以上 100 以下<br>- "送料割引クーポン"<br>- "${7 文字以内} 無料クーポン"<br>- "${7 文字以内} UP クーポン"                                                                             |
+| - description   | String  | O  | クーポン詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO タイプの場合、最大 18 文字、改行: 不可<br>- その他のタイプの場合、最大 12 文字、改行: 不可                                                                                                                                       |
+| - linkMo        | String  | X  | モバイル Web リンク（WL タイプの場合は必須フィールド）、500 文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）となります。                                                     |
+| - linkPc        | String  | X  | PC Web リンク（WL タイプの場合は任意フィールド）、500 文字制限                                                                                                                                                                                                            |
+| - schemeAndroid | String  | X  | Android アプリリンク（AL タイプの場合は必須フィールド）、500 文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）となります。                                                   |
+| - schemeIos     | String  | X  | iOS アプリリンク（AL タイプの場合は必須フィールド）、500 文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）となります。                                                     |
 
 <a id="request-to-register-image-type-template"></a>
 
@@ -2437,30 +2732,30 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前            | タイプ    | 必須 | 説明                                                                                                                                                                                                                                                |
+| 名前              | タイプ      | 必須 | 説明                                                                                                                                                                                                                                                  |
 |-----------------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| templateName    | String  | O  | テンプレート名(最大200文字)                                                                                                                                                                                                                                     |
-| chatBubbleType  | String  | O  | メッセージタイプ(TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE)                                                                                                                                               |
-| adult           | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                                             |
-| content         | String  | O  | - TEXTタイプの場合、最大1,300文字(改行:最大99個、URL形式入力可能)<br>- IMAGEタイプの場合、最大400文字(改行:最大29個、URL形式入力可能)<br>- WIDEタイプの場合、最大76文字(改行:最大1個)<br>- PREMIUM_VIDEOタイプの場合、該当フィールドをオプションとして使用可能、最大76文字(改行:最大1個)<br>- その他のタイプの場合、該当フィールドは使用しません |
-| image           | Object  | O  | 画像要素<br>- IMAGE、WIDE、COMMERCEタイプの場合、必須フィールド                                                                                                                                                                                                     |
-| - imageUrl      | String  | O  | 画像URL、一般画像としてアップロードされた画像URLを使用<br>プレースホルダー使用不可                                                                                                                                                                                                     |
-| - imageLink     | String  | X  | 画像をクリックした際に移動するURL、500文字制限<br>未設定の場合、カカオトーク内の画像ビューアを使用<br>プレースホルダー使用不可                                                                                                                                                                                   |
-| buttons         | List    | X  | ボタンリスト<br>- TEXT、IMAGEタイプの場合、クーポン適用時は最大4件、それ以外は最大5件<br>- WIDE、WIDE_ITEM_LISTタイプの場合、最大2件<br>- PREMIUM_VIDEOタイプの場合、最大1件<br>- COMMERCEタイプの場合、最小1件、最大2件                                                                                      |
-| - name          | String  | O  | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字<br>プレースホルダー使用不可                                                                                                                                                                           |
-| - type          | String  | O  | ボタンタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- ACタイプはTEXT、IMAGEの場合は最初のボタンとして、それ以外のメッセージタイプの場合は最後のボタンとして登録する必要がある             |
-| - linkMo        | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                                              |
-| - linkPc        | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                                               |
-| - schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                                            |
-| - schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合は必須フィールド)、500文字制限                                                                                                                                                                                                              |
-| - bizFormKey    | String  | X  | BFタイプのボタンの場合、ビズフォームキー                                                                                                                                                                                                                                 |
-| coupon          | Object  | X  | クーポン要素                                                                                                                                                                                                                                             |
-| - title         | String  | O  | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」                                                                                  |
-| - description   | String  | O  | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字、改行:不可<br>- その他のタイプの場合、最大12文字、改行:不可                                                                                                                                           |
-| - linkMo        | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                         |
-| - linkPc        | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                                               |
-| - schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                       |
-| - schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                         |
+| templateName    | String  | O  | テンプレート名（最大 200 文字）                                                                                                                                                                                                                                     |
+| chatBubbleType  | String  | O  | メッセージタイプ（TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE）                                                                                                                                               |
+| adult           | boolean | X  | 成人向けメッセージかどうか（デフォルト値: false）                                                                                                                                                                                                                             |
+| content         | String  | O  | - TEXT タイプの場合、最大 1,300 文字（改行: 最大 99 個、URL 形式の入力可能）<br>- IMAGE タイプの場合、最大 1,300 文字（改行: 最大 99 個、URL 形式の入力可能）<br>- WIDE タイプの場合、最大 76 文字（改行: 最大 5 個）<br>- PREMIUM_VIDEO タイプの場合、当該フィールドを任意で使用可能、最大 76 文字（改行: 最大 5 個）<br>- その他のタイプの場合、当該フィールドは使用しない |
+| image           | Object  | O  | 画像要素<br>- IMAGE、WIDE、COMMERCE タイプの場合、必須フィールド                                                                                                                                                                                                      |
+| - imageUrl      | String  | O  | 画像 URL。一般画像としてアップロードされた画像 URL を使用<br>置換子は使用不可                                                                                                                                                                                                      |
+| - imageLink     | String  | X  | 画像クリック時に移動する URL、500 文字制限<br>未設定の場合はカカオトーク内の画像ビューアーを使用<br>置換子は使用不可                                                                                                                                                                                    |
+| buttons         | List    | X  | ボタンリスト<br>- TEXT、IMAGE タイプの場合、クーポン適用時は最大 4 個、その他は最大 5 個<br>- WIDE、WIDE_ITEM_LIST タイプの場合、最大 2 個<br>- PREMIUM_VIDEO タイプの場合、最大 1 個<br>- COMMERCE タイプの場合、最小 1 個〜最大 2 個                                                                                       |
+| - name          | String  | O  | ボタンタイトル<br>- TEXT、IMAGE タイプの場合、最大 14 文字<br>- その他のタイプの場合、最大 8 文字<br>置換子は使用不可                                                                                                                                                                            |
+| - type          | String  | O  | ボタンタイプ（WL: Webリンク、AL: アプリリンク、BK: ボットキーワード、MD: メッセージ転送、AC: チャンネル追加、BT: チャットボット切替、BF: ビジネスフォーム）<br>- AC タイプは TEXT、IMAGE の場合は最初のボタンとして、その他のメッセージタイプの場合は最後のボタンとして登録する必要があります                   |
+| - linkMo        | String  | X  | モバイル Web リンク（WL タイプの場合は必須フィールド）、500 文字制限                                                                                                                                                                                                               |
+| - linkPc        | String  | X  | PC Web リンク（WL タイプの場合は任意フィールド）、500 文字制限                                                                                                                                                                                                                |
+| - schemeAndroid | String  | X  | Android アプリリンク（AL タイプの場合は必須フィールド）、500 文字制限                                                                                                                                                                                                             |
+| - schemeIos     | String  | X  | iOS アプリリンク（AL タイプの場合は必須フィールド）、500 文字制限                                                                                                                                                                                                               |
+| - bizFormKey    | String  | X  | BF タイプのボタンの場合、ビズフォームキー                                                                                                                                                                                                                                  |
+| coupon          | Object  | X  | クーポン要素                                                                                                                                                                                                                                               |
+| - title         | String  | O  | title は 5 種類の形式に制限されます<br>- "${数字}円割引クーポン" 数字は 1 以上 99,999,999 以下<br>- "${数字}% 割引クーポン" 数字は 1 以上 100 以下<br>- "送料割引クーポン"<br>- "${7文字以内} 無料クーポン"<br>- "${7文字以内} UP クーポン"                                                                                  |
+| - description   | String  | O  | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO タイプの場合、最大 18 文字、改行: 不可<br>- その他のタイプの場合、最大 12 文字、改行: 不可                                                                                                                                            |
+| - linkMo        | String  | X  | モバイル Web リンク（WL タイプの場合は必須フィールド）、500 文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）となります。                                                         |
+| - linkPc        | String  | X  | PC Web リンク（WL タイプの場合は任意フィールド）、500 文字制限                                                                                                                                                                                                                |
+| - schemeAndroid | String  | X  | Android アプリリンク（AL タイプの場合は必須フィールド）、500 文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）となります。                                                       |
+| - schemeIos     | String  | X  | iOS アプリリンク（AL タイプの場合は必須フィールド）、500 文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）となります。                                                         |
 
 <a id="request-to-register-wide-image-type-template"></a>
 
@@ -2500,34 +2795,34 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前            | タイプ    | 必須 | 説明                                                                                                                                                                                                                                                |
+| 名前              | タイプ      | 必須 | 説明                                                                                                                                                                                                                                                  |
 |-----------------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| templateName    | String  | O  | テンプレート名(最大200文字)                                                                                                                                                                                                                                     |
-| chatBubbleType  | String  | O  | メッセージタイプ(TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE)                                                                                                                                               |
-| adult           | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                                             |
-| content         | String  | O  | - TEXTタイプの場合、最大1,300文字(改行:最大99個、URL形式入力可能)<br>- IMAGEタイプの場合、最大400文字(改行:最大29個、URL形式入力可能)<br>- WIDEタイプの場合、最大76文字(改行:最大1個)<br>- PREMIUM_VIDEOタイプの場合、該当フィールドをオプションとして使用可能、最大76文字(改行:最大1個)<br>- その他のタイプの場合、該当フィールドは使用しません |
-| image           | Object  | O  | 画像要素<br>- IMAGE、WIDE、COMMERCEタイプの場合、必須フィールド                                                                                                                                                                                                     |
-| - imageUrl      | String  | O  | 画像URL、ワイド画像としてアップロードされた画像URLを使用<br>プレースホルダー使用不可                                                                                                                                                                                                    |
-| - imageLink     | String  | X  | 画像をクリックした際に移動するURL、500文字制限<br>未設定の場合、カカオトーク内の画像ビューアを使用<br>プレースホルダー使用不可                                                                                                                                                                                   |
-| buttons         | List    | X  | ボタンリスト<br>- TEXT、IMAGEタイプの場合、クーポン適用時は最大4件、それ以外は最大5件<br>- WIDE、WIDE_ITEM_LISTタイプの場合、最大2件<br>- PREMIUM_VIDEOタイプの場合、最大1件<br>- COMMERCEタイプの場合、最小1件、最大2件                                                                                      |
-| - name          | String  | O  | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字<br>プレースホルダー使用不可                                                                                                                                                                           |
-| - type          | String  | O  | ボタンタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- ACタイプはTEXT、IMAGEの場合は最初のボタンとして、それ以外のメッセージタイプの場合は最後のボタンとして登録する必要がある                   |
-| - linkMo        | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                                              |
-| - linkPc        | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                                               |
-| - schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                                            |
-| - schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合は必須フィールド)、500文字制限                                                                                                                                                                                                              |
-| - bizFormKey    | String  | X  | BFタイプのボタンの場合、ビズフォームキー                                                                                                                                                                                                                                 |
-| coupon          | Object  | X  | クーポン要素                                                                                                                                                                                                                                             |
-| - title         | String  | O  | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」                                                                                  |
-| - description   | String  | O  | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字、改行:不可<br>- その他のタイプの場合、最大12文字、改行:不可                                                                                                                                           |
-| - linkMo        | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                         |
-| - linkPc        | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                                               |
-| - schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                       |
-| - schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                         |
+| templateName    | String  | O  | テンプレート名（最大 200 文字）                                                                                                                                                                                                                                     |
+| chatBubbleType  | String  | O  | メッセージタイプ（TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE）                                                                                                                                               |
+| adult           | boolean | X  | 成人向けメッセージかどうか（デフォルト値: false）                                                                                                                                                                                                                             |
+| content         | String  | O  | - TEXT タイプの場合、最大 1,300 文字（改行: 最大 99 個、URL 形式で入力可能）<br>- IMAGE タイプの場合、最大 1,300 文字（改行: 最大 99 個、URL 形式で入力可能）<br>- WIDE タイプの場合、最大 76 文字（改行: 最大 5 個）<br>- PREMIUM_VIDEO タイプの場合、当該フィールドを任意で使用できます。最大 76 文字（改行: 最大 5 個）<br>- その他のタイプの場合、当該フィールドは使用しません |
+| image           | Object  | O  | 画像要素<br>- IMAGE、WIDE、COMMERCE タイプの場合、必須フィールド                                                                                                                                                                                                      |
+| - imageUrl      | String  | O  | 画像 URL。ワイド画像としてアップロードされた画像 URL を使用します。<br>置換変数は使用できません                                                                                                                                                                                                     |
+| - imageLink     | String  | X  | 画像クリック時に遷移する URL。500 文字制限<br>未設定の場合、カカオトーク内の画像ビューアを使用します<br>置換変数は使用できません                                                                                                                                                                                    |
+| buttons         | List    | X  | ボタンリスト<br>- TEXT、IMAGE タイプの場合、クーポン適用時は最大 4 個、それ以外は最大 5 個<br>- WIDE、WIDE_ITEM_LIST タイプの場合、最大 2 個<br>- PREMIUM_VIDEO タイプの場合、最大 1 個<br>- COMMERCE タイプの場合、最小 1 個、最大 2 個                                                                                       |
+| - name          | String  | O  | ボタンタイトル<br>- TEXT、IMAGE タイプの場合、最大 14 文字<br>- その他のタイプの場合、最大 8 文字<br>置換変数は使用できません                                                                                                                                                                            |
+| - type          | String  | O  | ボタンタイプ（WL: Webリンク、AL: アプリリンク、BK: Botキーワード、MD: メッセージ転達、AC: チャンネル追加、BT: チャットボット切替、BF: ビジネスフォーム）<br>- AC タイプは TEXT、IMAGE の場合は 1 番目のボタンとして、その他のメッセージタイプの場合は最後のボタンとして登録する必要があります                   |
+| - linkMo        | String  | X  | モバイル Web リンク（WL タイプの場合、必須フィールド）。500 文字制限                                                                                                                                                                                                               |
+| - linkPc        | String  | X  | PC Web リンク（WL タイプの場合、任意フィールド）。500 文字制限                                                                                                                                                                                                                |
+| - schemeAndroid | String  | X  | Android アプリリンク（AL タイプの場合、必須フィールド）。500 文字制限                                                                                                                                                                                                             |
+| - schemeIos     | String  | X  | iOS アプリリンク（AL タイプの場合、必須フィールド）。500 文字制限                                                                                                                                                                                                               |
+| - bizFormKey    | String  | X  | BF タイプのボタンの場合、ビズフォームキー                                                                                                                                                                                                                                  |
+| coupon          | Object  | X  | クーポン要素                                                                                                                                                                                                                                               |
+| - title         | String  | O  | title は 5 種類の形式に限定されます<br>- "${数字}円割引クーポン"（数字は 1 以上 99,999,999 以下）<br>- "${数字}% 割引クーポン"（数字は 1 以上 100 以下）<br>- "送料割引クーポン"<br>- "${7 文字以内} 無料クーポン"<br>- "${7 文字以内} UP クーポン"                                                                                  |
+| - description   | String  | O  | クーポン詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO タイプの場合、最大 18 文字、改行: 不可<br>- その他のタイプの場合、最大 12 文字、改行: 不可                                                                                                                                            |
+| - linkMo        | String  | X  | モバイル Web リンク（WL タイプの場合、必須フィールド）。500 文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意項目（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意項目（オプション）となります。                                                         |
+| - linkPc        | String  | X  | PC Web リンク（WL タイプの場合、任意フィールド）。500 文字制限                                                                                                                                                                                                                |
+| - schemeAndroid | String  | X  | Android アプリリンク（AL タイプの場合、必須フィールド）。500 文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意項目（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意項目（オプション）となります。                                                       |
+| - schemeIos     | String  | X  | iOS アプリリンク（AL タイプの場合、必須フィールド）。500 文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意項目（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意項目（オプション）となります。                                                         |
 
 <a id="request-to-register-wide-item-list-type-template"></a>
 
-#### ワイドアイテムリスト型テンプレート登録リクエスト
+#### ワイドアイテムリストタイプのテンプレート登録リクエスト
 
 [Request body]
 
@@ -2587,35 +2882,35 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前             | タイプ    | 必須 | 説明                                                                                                                                                                                                                              |
+| 名前               | タイプ      | 必須 | 説明                                                                                                                                                                                                                                |
 |------------------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| templateName     | String  | O  | テンプレート名(最大200文字)                                                                                                                                                                                                                   |
-| chatBubbleType   | String  | O  | メッセージタイプ(TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE)                                                                                                                             |
-| adult            | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                           |
-| header           | String  | O  | ヘッダ<br>- WIDE_ITEM_LISTタイプの場合、必須フィールドで最大20文字(改行:不可)<br>- PREMIUM_VIDEOタイプの場合、任意フィールドで最大20文字(改行:不可)                                                                                                                         |
-| item             | Object  | O  | ワイドリスト要素(WIDE_ITEM_LISTタイプでのみ使用可能)                                                                                                                                                                                           |
-| - list           | List    | O  | ワイドリスト(最小: 3、最大4)                                                                                                                                                                                                             |
-| -- title         | String  | O  | アイテムのタイトル<br>- 1番目のアイテムは最大25文字に制限(改行:最大1個、1番目のアイテムの場合、titleは必須値ではありません)<br>- 1番目のアイテムはtitleが必須フィールドではありません<br>- 2～4番目のアイテムは最大30文字に制限(改行:最大1個)                                                                                     |
-| -- imageUrl      | String  | O  | アイテム画像URL<br>- 1番目のアイテムには、最初のワイドアイテムリスト画像としてアップロードされた画像URLを使用<br>- 2～4番目のアイテムは、一般のワイドアイテムリスト画像としてアップロードされた画像URLを使用<br>プレースホルダー使用不可                                                                                                  |
-| -- linkMo        | String  | O  | モバイルWebリンク、500文字制限                                                                                                                                                                                                             |
-| -- linkPc        | String  | X  | PC Webリンク、500文字制限                                                                                                                                                                                                              |
-| -- schemeAndroid | String  | X  | Androidアプリリンク、500文字制限                                                                                                                                                                                                           |
-| -- schemeIos     | String  | X  | iOSアプリリンク、500文字制限                                                                                                                                                                                                             |
-| buttons          | List    | X  | ボタンリスト<br>- TEXT、IMAGEタイプの場合、クーポン適用時は最大4件、それ以外は最大5件<br>- WIDE、WIDE_ITEM_LISTタイプの場合、最大2件<br>- PREMIUM_VIDEOタイプの場合、最大1件<br>- COMMERCEタイプの場合、最小1件、最大2件                                                                    |
-| - name           | String  | O  | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字<br>プレースホルダー使用不可                                                                                                                                                         |
-| - type          | String  | O  | ボタンタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- ACタイプはTEXT、IMAGEの場合は最初のボタンとして、それ以外のメッセージタイプの場合は最後のボタンとして登録する必要がある                   |
-| - linkMo         | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                            |
-| - linkPc         | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                             |
-| - schemeAndroid  | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                          |
-| - schemeIos      | String  | X  | iOSアプリリンク(ALタイプの場合は必須フィールド)、500文字制限                                                                                                                                                                                            |
-| - bizFormKey     | String  | X  | BFタイプのボタンの場合、ビズフォームキー                                                                                                                                                                                                               |
-| coupon           | Object  | X  | クーポン要素                                                                                                                                                                                                                           |
-| - title          | String  | O  | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」                                                                |
-| - description    | String  | O  | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字、改行:不可<br>- その他のタイプの場合、最大12文字、改行:不可                                                                                                                         |
-| - linkMo         | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                       |
-| - linkPc         | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                             |
-| - schemeAndroid  | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                     |
-| - schemeIos      | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                       |
+| templateName     | String  | O  | テンプレート名（最大 200 文字）                                                                                                                                                                                                                   |
+| chatBubbleType   | String  | O  | メッセージタイプ（TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE）                                                                                                                             |
+| adult            | boolean | X  | 成人向けメッセージかどうか（デフォルト値: false）                                                                                                                                                                                                           |
+| header           | String  | O  | ヘッダー<br>- WIDE_ITEM_LIST タイプの場合は必須フィールドで最大 20 文字（改行: 不可）<br>- PREMIUM_VIDEO タイプの場合は任意フィールドで最大 20 文字（改行: 不可）                                                                                                                         |
+| item             | Object  | O  | ワイドリスト要素（WIDE_ITEM_LIST タイプのみ使用可能）                                                                                                                                                                                           |
+| - list           | List    | O  | ワイドリスト（最小: 3、最大: 4）                                                                                                                                                                                                             |
+| -- title         | String  | O  | アイテムタイトル<br>- 1 番目のアイテムは最大 25 文字（改行: 最大 1 個、1 番目のアイテムの場合 title は必須値ではない）<br>- 1 番目のアイテムは title が必須フィールドではない<br>- 2〜4 番目のアイテムは最大 30 文字（改行: 最大 1 個）                                                                                     |
+| -- imageUrl      | String  | O  | アイテム画像 URL<br>- 1 番目のアイテムには、最初のワイドアイテムリスト画像としてアップロードした画像 URL を使用<br>- 2〜4 番目のアイテムは通常のワイドアイテムリスト画像としてアップロードした画像 URL を使用<br>置換子は使用不可                                                                                                   |
+| -- linkMo        | String  | O  | モバイル Web リンク、500 文字制限                                                                                                                                                                                                               |
+| -- linkPc        | String  | X  | PC Web リンク、500 文字制限                                                                                                                                                                                                                |
+| -- schemeAndroid | String  | X  | Android アプリリンク、500 文字制限                                                                                                                                                                                                             |
+| -- schemeIos     | String  | X  | iOS アプリリンク、500 文字制限                                                                                                                                                                                                               |
+| buttons          | List    | X  | ボタンリスト<br>- TEXT、IMAGE タイプの場合、クーポン適用時は最大 4 個、それ以外は最大 5 個<br>- WIDE、WIDE_ITEM_LIST タイプの場合は最大 2 個<br>- PREMIUM_VIDEO タイプの場合は最大 1 個<br>- COMMERCE タイプの場合は最小 1 個、最大 2 個                                                                     |
+| - name           | String  | O  | ボタンタイトル<br>- TEXT、IMAGE タイプの場合は最大 14 文字<br>- それ以外のタイプの場合は最大 8 文字<br>置換子は使用不可                                                                                                                                                          |
+| - type           | String  | O  | ボタンタイプ（WL: Web リンク、AL: アプリリンク、BK: ボットキーワード、MD: メッセージ転送、AC: チャンネル追加、BT: チャットボット切替、BF: ビジネスフォーム）<br>- AC タイプは TEXT、IMAGE の場合は最初のボタンとして、それ以外のメッセージタイプの場合は最後のボタンとして登録する必要があります |
+| - linkMo         | String  | X  | モバイル Web リンク（WL タイプの場合は必須フィールド）、500 文字制限                                                                                                                                                                                             |
+| - linkPc         | String  | X  | PC Web リンク（WL タイプの場合は任意フィールド）、500 文字制限                                                                                                                                                                                              |
+| - schemeAndroid  | String  | X  | Android アプリリンク（AL タイプの場合は必須フィールド）、500 文字制限                                                                                                                                                                                           |
+| - schemeIos      | String  | X  | iOS アプリリンク（AL タイプの場合は必須フィールド）、500 文字制限                                                                                                                                                                                             |
+| - bizFormKey     | String  | X  | BF タイプのボタンの場合のビジフォームキー                                                                                                                                                                                                                |
+| coupon           | Object  | X  | クーポン要素                                                                                                                                                                                                                             |
+| - title          | String  | O  | title は 5 種類の形式に限定されます<br>- 「${数字}円割引クーポン」数字は 1 以上 99,999,999 以下<br>- 「${数字}% 割引クーポン」数字は 1 以上 100 以下<br>- 「送料割引クーポン」<br>- 「${7 文字以内} 無料クーポン」<br>- 「${7 文字以内} UP クーポン」                                                                |
+| - description    | String  | O  | クーポン詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO タイプの場合は最大 18 文字、改行: 不可<br>- それ以外のタイプの場合は最大 12 文字、改行: 不可                                                                                                                          |
+| - linkMo         | String  | X  | モバイル Web リンク（WL タイプの場合は必須フィールド）、500 文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）となります。                                       |
+| - linkPc         | String  | X  | PC Web リンク（WL タイプの場合は任意フィールド）、500 文字制限                                                                                                                                                                                              |
+| - schemeAndroid  | String  | X  | Android アプリリンク（AL タイプの場合は必須フィールド）、500 文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）となります。                                     |
+| - schemeIos      | String  | X  | iOS アプリリンク（AL タイプの場合は必須フィールド）、500 文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）となります。                                       |
 
 <a id="request-to-register-premium-video-type-template"></a>
 
@@ -2656,35 +2951,35 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前            | タイプ    | 必須 | 説明                                                                                                                                                                                                                                                |
+| 名前              | タイプ      | 必須 | 説明                                                                                                                                                                                                                                                  |
 |-----------------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| templateName    | String  | O  | テンプレート名(最大200文字)                                                                                                                                                                                                                                     |
-| chatBubbleType  | String  | O  | メッセージタイプ(TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE)                                                                                                                                               |
-| adult           | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                                             |
-| content         | String  | X  | - TEXTタイプの場合、最大1,300文字(改行:最大99個、URL形式の入力が可能)<br>- IMAGEタイプの場合、最大400文字(改行:最大29回、URL形式の入力が可能)<br>- WIDEタイプの場合、最大76文字(改行:最大1回)<br>- PREMIUM_VIDEOタイプの場合、このフィールドをオプションとして使用可能、最大76文字(改行:最大1回)<br>- その他のタイプの場合、このフィールドは使用しません |
-| header          | String  | X  | ヘッダ<br>- WIDE_ITEM_LISTタイプの場合、必須フィールドで最大20文字(改行:不可)<br>- PREMIUM_VIDEOタイプの場合、任意フィールドで最大20文字(改行:不可)                                                                                                                                           |
-| video           | Object  | O  | 動画要素(PREMIUM_VIDEOタイプのみ使用可能)                                                                                                                                                                                                                    |
-| - videoUrl      | String  | O  | カカオTV動画URL (カカオTVにアップロードされた動画アドレスのみ使用可能)、最大500文字制限<br>プレースホルダー使用不可                                                                                                                                                                                |
-| - thumbnailUrl  | String  | X  | 動画サムネイル用画像URL。一般画像としてアップロードされたURLのみ使用可能(ない場合はカカオTV動画の基本サムネイルを使用)、最大500文字制限<br>プレースホルダー使用不可                                                                                                                                                    |
-| buttons         | List    | X  | ボタンリスト<br>- TEXT、IMAGEタイプの場合、クーポン適用時は最大4件、それ以外は最大5件<br>- WIDE、WIDE_ITEM_LISTタイプの場合、最大2件<br>- PREMIUM_VIDEOタイプの場合、最大1件<br>- COMMERCEタイプの場合、最小1件、最大2件                                                                                      |
-| - name          | String  | O  | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字<br>プレースホルダー使用不可                                                                                                                                                                           |
-| - type           | String  | O  | ボタンタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- ACタイプはTEXT、IMAGEの場合は最初のボタンとして、それ以外のメッセージタイプの場合は最後のボタンとして登録する必要がある |
-| - linkMo        | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                                              |
-| - linkPc        | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                                               |
-| - schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                                            |
-| - schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合は必須フィールド)、500文字制限                                                                                                                                                                                                              |
-| - bizFormKey    | String  | X  | BFタイプのボタンの場合、ビズフォームキー                                                                                                                                                                                                                                 |
-| coupon          | Object  | X  | クーポン要素                                                                                                                                                                                                                                             |
-| - title         | String  | O  | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」                                                                                  |
-| - description   | String  | O  | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字、改行:不可<br>- その他のタイプの場合、最大12文字、改行:不可                                                                                                                                           |
-| - linkMo        | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                         |
-| - linkPc        | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                                               |
-| - schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                       |
-| - schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                                         |
+| templateName    | String  | O  | テンプレート名（最大 200 文字）                                                                                                                                                                                                                                     |
+| chatBubbleType  | String  | O  | メッセージタイプ（TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE）                                                                                                                                               |
+| adult           | boolean | X  | 成人向けメッセージかどうか（デフォルト値: false）                                                                                                                                                                                                                             |
+| content         | String  | X  | - TEXT タイプの場合、最大 1,300 文字（改行: 最大 99 個、URL 形式入力可能）<br>- IMAGE タイプの場合、最大 1,300 文字（改行: 最大 99 個、URL 形式入力可能）<br>- WIDE タイプの場合、最大 76 文字（改行: 最大 5 個）<br>- PREMIUM_VIDEO タイプの場合、このフィールドは任意で使用可能、最大 76 文字（改行: 最大 5 個）<br>- その他のタイプの場合、このフィールドは使用不可 |
+| header          | String  | X  | ヘッダー<br>- WIDE_ITEM_LIST タイプの場合、必須フィールドで最大 20 文字（改行: 不可）<br>- PREMIUM_VIDEO タイプの場合、任意フィールドで最大 20 文字（改行: 不可）                                                                                                                                           |
+| video           | Object  | O  | 動画要素（PREMIUM_VIDEO タイプのみ使用可能）                                                                                                                                                                                                                    |
+| - videoUrl      | String  | O  | カカオTV 動画 URL（カカオTV にアップロードされた動画アドレスのみ使用可能）、最大 500 文字制限<br>置換変数は使用不可                                                                                                                                                                                 |
+| - thumbnailUrl  | String  | X  | 動画サムネイル用画像 URL。通常画像としてアップロードされた URL のみ使用可能（未指定の場合はカカオTV 動画のデフォルトサムネイルを使用）、最大 500 文字制限<br>置換変数は使用不可                                                                                                                                                    |
+| buttons         | List    | X  | ボタンリスト<br>- TEXT、IMAGE タイプの場合、クーポン適用時は最大 4 個、その他は最大 5 個<br>- WIDE、WIDE_ITEM_LIST タイプの場合、最大 2 個<br>- PREMIUM_VIDEO タイプの場合、最大 1 個<br>- COMMERCE タイプの場合、最小 1 個・最大 2 個                                                                                       |
+| - name          | String  | O  | ボタンタイトル<br>- TEXT、IMAGE タイプの場合、最大 14 文字<br>- その他のタイプの場合、最大 8 文字<br>置換変数は使用不可                                                                                                                                                                            |
+| - type          | String  | O  | ボタンタイプ（WL: Web リンク、AL: アプリリンク、BK: ボットキーワード、MD: メッセージ転送、AC: チャンネル追加、BT: チャットボット切替、BF: ビジネスフォーム）<br>- AC タイプは TEXT、IMAGE の場合は最初のボタンとして、その他のメッセージタイプの場合は最後のボタンとして登録する必要があります                   |
+| - linkMo        | String  | X  | モバイル Web リンク（WL タイプの場合は必須フィールド）、500 文字制限                                                                                                                                                                                                               |
+| - linkPc        | String  | X  | PC Web リンク（WL タイプの場合は任意フィールド）、500 文字制限                                                                                                                                                                                                                |
+| - schemeAndroid | String  | X  | Android アプリリンク（AL タイプの場合は必須フィールド）、1,000 文字制限                                                                                                                                                                                                             |
+| - schemeIos     | String  | X  | iOS アプリリンク（AL タイプの場合は必須フィールド）、500 文字制限                                                                                                                                                                                                               |
+| - bizFormKey    | String  | X  | BF タイプのボタンの場合、ビズフォームキー                                                                                                                                                                                                                                  |
+| coupon          | Object  | X  | クーポン要素                                                                                                                                                                                                                                               |
+| - title         | String  | O  | title は 5 種類の形式に限定されます<br>- 「${数字}円割引クーポン」数字は 1 以上 99,999,999 以下<br>- 「${数字}% 割引クーポン」数字は 1 以上 100 以下<br>- 「送料割引クーポン」<br>- 「${7 文字以内} 無料クーポン」<br>- 「${7 文字以内} UP クーポン」                                                                                  |
+| - description   | String  | O  | クーポン詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO タイプの場合、最大 18 文字、改行: 不可<br>- その他のタイプの場合、最大 12 文字、改行: 不可                                                                                                                                            |
+| - linkMo        | String  | X  | モバイル Web リンク（WL タイプの場合は必須フィールド）、500 文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）となります。                                                         |
+| - linkPc        | String  | X  | PC Web リンク（WL タイプの場合は任意フィールド）、500 文字制限                                                                                                                                                                                                                |
+| - schemeAndroid | String  | X  | Android アプリリンク（AL タイプの場合は必須フィールド）、500 文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）となります。                                                       |
+| - schemeIos     | String  | X  | iOS アプリリンク（AL タイプの場合は必須フィールド）、500 文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）となります。                                                         |
 
 <a id="request-to-register-commerce-type-template"></a>
 
-#### コマース型テンプレート登録リクエスト
+#### コマースタイプテンプレート登録リクエスト
 
 [Request body]
 
@@ -2728,36 +3023,36 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前              | タイプ    | 必須 | 説明                                                                                                                                                                                                                              |
+| 名前                | タイプ      | 必須 | 説明                                                                                                                                                                                                                                |
 |-------------------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| templateName      | String  | O  | テンプレート名(最大200文字)                                                                                                                                                                                                                   |
-| chatBubbleType    | String  | O  | メッセージタイプ(TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE)                                                                                                                             |
-| adult             | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                           |
-| additionalContent | String  | X  | 付加情報(最大34文字、改行:最大1回)、コマース形式でのみ使用可能                                                                                                                                                                                         |
-| image             | Object  | O  | 画像要素<br>- IMAGE、WIDE、COMMERCEタイプの場合、必須フィールド                                                                                                                                                                                   |
-| - imageUrl        | String  | O  | 画像URL、一般画像としてアップロードされた画像URLを使用<br>プレースホルダー使用不可                                                                                                                                                                                    |
-| - imageLink       | String  | X  | 画像をクリックした際に移動するURL、1,000文字制限<br>未設定の場合、カカオトーク内の画像ビューアを使用<br>プレースホルダー使用不可                                                                                                                                                                 |
-| commerce          | Object  | O  | コマース(COMMERCEタイプでのみ使用可能)                                                                                                                                                                                                        |
-| title             | String  | O  | 商品名(最大30文字、改行:不可)                                                                                                                                                                                                           |
-| regularPrice      | Integer | O  | 通常価格(0 ～ 99,999,999)<br>プレースホルダーのユーザー指定は不可能、値を空にすると固定プレースホルダー`#{通常価格}`で保存されます                                                                                                                                                         |
-| discountPrice     | Integer | X  | 割引価格(0 ～ 99,999,999)<br>プレースホルダーのユーザー指定は不可能、値を空にすると固定プレースホルダー`#{割引価格}`で保存されます                                                                                                                                                           |
-| discountRate      | Integer | X  | 割引率(0 ～ 100)、割引価格が存在する場合、割引率、定額割引価格のいずれかは必須<br>プレースホルダーのユーザー指定は不可能、値を空にすると固定プレースホルダー`#{割引率}`で保存されます                                                                                                                                     |
-| discountFixed     | Integer | X  | 定額割引価格(0 ～ 999,999)、割引価格が存在する場合、割引率、定額割引価格のいずれかは必須<br>プレースホルダーのユーザー指定は不可能、値を空にすると固定プレースホルダー`#{定額割引価格}`で保存されます                                                                                                                           |
-| buttons           | List    | O  | ボタンリスト<br>- TEXT、IMAGEタイプの場合、クーポン適用時は最大4件、それ以外は最大5件<br>- WIDE、WIDE_ITEM_LISTタイプの場合、最大2件<br>- PREMIUM_VIDEOタイプの場合、最大1件<br>- COMMERCEタイプの場合、最小1件、最大2件                                                                    |
-| - name            | String  | O  | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字<br>プレースホルダー使用不可                                                                                                                                                         |
-| - type          | String  | O  | ボタンタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- ACタイプはTEXT、IMAGEの場合は最初のボタンとして、それ以外のメッセージタイプの場合は最後のボタンとして登録する必要がある                   |
-| - linkMo          | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                            |
-| - linkPc          | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                             |
-| - schemeAndroid   | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                          |
-| - schemeIos       | String  | X  | iOSアプリリンク(ALタイプの場合は必須フィールド)、500文字制限                                                                                                                                                                                            |
-| - bizFormKey      | String  | X  | BFタイプのボタンの場合、ビズフォームキー                                                                                                                                                                                                               |
-| coupon            | Object  | X  | クーポン要素                                                                                                                                                                                                                           |
-| - title           | String  | O  | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」                                                                |
-| - description     | String  | O  | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字、改行:不可<br>- その他のタイプの場合、最大12文字、改行:不可                                                                                                                         |
-| - linkMo          | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                       |
-| - linkPc          | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                             |
-| - schemeAndroid   | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                     |
-| - schemeIos       | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                       |
+| templateName      | String  | O  | テンプレート名（最大200文字）                                                                                                                                                                                                                   |
+| chatBubbleType    | String  | O  | メッセージタイプ（TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE）                                                                                                                             |
+| adult             | boolean | X  | 成人向けメッセージかどうか（デフォルト値: false）                                                                                                                                                                                                           |
+| additionalContent | String  | X  | 追加情報（最大34文字、改行: 最大1個）、コマースタイプでのみ使用可能                                                                                                                                                                                          |
+| image             | Object  | O  | 画像要素<br>- IMAGE、WIDE、COMMERCE タイプの場合は必須フィールド                                                                                                                                                                                    |
+| - imageUrl        | String  | O  | 画像 URL、通常の画像としてアップロードされた画像 URL を使用<br>置換子は使用不可                                                                                                                                                                                    |
+| - imageLink       | String  | X  | 画像クリック時の遷移先 URL、500文字制限<br>未設定の場合はカカオトーク内画像ビューアーを使用<br>置換子は使用不可                                                                                                                                                                  |
+| commerce          | Object  | O  | コマース（COMMERCE タイプでのみ使用可能）                                                                                                                                                                                                        |
+| title             | String  | O  | 商品タイトル（最大30文字、改行: 不可）                                                                                                                                                                                                           |
+| regularPrice      | Integer | O  | 通常価格（0〜99,999,999）<br>置換子のカスタマイズ不可。値を空にすると固定置換子 `#{정상가격}` として保存されます                                                                                                                                                          |
+| discountPrice     | Integer | X  | 割引価格（0〜99,999,999）<br>置換子のカスタマイズ不可。値を空にすると固定置換子 `#{할인가격}` として保存されます                                                                                                                                                            |
+| discountRate      | Integer | X  | 割引率（0〜100）、割引価格が存在する場合、割引率と定額割引価格のいずれか一方が必須<br>置換子のカスタマイズ不可。値を空にすると固定置換子 `#{할인율}` として保存されます                                                                                                                                      |
+| discountFixed     | Integer | X  | 定額割引価格（0〜999,999）、割引価格が存在する場合、割引率と定額割引価格のいずれか一方が必須<br>置換子のカスタマイズ不可。値を空にすると固定置換子 `#{정액할인가격}` として保存されます                                                                                                                            |
+| buttons           | List    | O  | ボタンリスト<br>- TEXT、IMAGE タイプの場合、クーポン適用時は最大4個、それ以外は最大5個<br>- WIDE、WIDE_ITEM_LIST タイプの場合は最大2個<br>- PREMIUM_VIDEO タイプの場合は最大1個<br>- COMMERCE タイプの場合は最小1個、最大2個                                                                     |
+| - name            | String  | O  | ボタンタイトル<br>- TEXT、IMAGE タイプの場合は最大14文字<br>- その他のタイプの場合は最大8文字<br>置換子は使用不可                                                                                                                                                          |
+| - type            | String  | O  | ボタンタイプ（WL: Webリンク、AL: アプリリンク、BK: ボットキーワード、MD: メッセージ転送、AC: チャンネル追加、BT: チャットボット切替、BF: ビジネスフォーム）<br>- AC タイプは TEXT、IMAGE の場合は1番目のボタンとして、その他のメッセージタイプの場合は最後のボタンとして登録する必要があります |
+| - linkMo          | String  | X  | モバイル Web リンク（WL タイプの場合は必須フィールド）、500文字制限                                                                                                                                                                                             |
+| - linkPc          | String  | X  | PC Web リンク（WL タイプの場合は任意フィールド）、500文字制限                                                                                                                                                                                              |
+| - schemeAndroid   | String  | X  | Android アプリリンク（AL タイプの場合は必須フィールド）、500文字制限                                                                                                                                                                                           |
+| - schemeIos       | String  | X  | iOS アプリリンク（AL タイプの場合は必須フィールド）、500文字制限                                                                                                                                                                                             |
+| - bizFormKey      | String  | X  | BF タイプのボタンの場合のビズフォームキー                                                                                                                                                                                                                |
+| coupon            | Object  | X  | クーポン要素                                                                                                                                                                                                                             |
+| - title           | String  | O  | title は以下の5種類の形式に限定されます<br>- 「${数字}円割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内} UP クーポン」                                                                |
+| - description     | String  | O  | クーポン詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO タイプの場合は最大18文字、改行: 不可<br>- その他のタイプの場合は最大12文字、改行: 不可                                                                                                                          |
+| - linkMo          | String  | X  | モバイル Web リンク（WL タイプの場合は必須フィールド）、500文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意項目（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意項目（オプション）となります。                                       |
+| - linkPc          | String  | X  | PC Web リンク（WL タイプの場合は任意フィールド）、500文字制限                                                                                                                                                                                              |
+| - schemeAndroid   | String  | X  | Android アプリリンク（AL タイプの場合は必須フィールド）、500文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意項目（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意項目（オプション）となります。                                     |
+| - schemeIos       | String  | X  | iOS アプリリンク（AL タイプの場合は必須フィールド）、500文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意項目（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意項目（オプション）となります。                                       |
 
 <a id="request-to-register-carousel-feed-type-template"></a>
 
@@ -2835,41 +3130,41 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前              | タイプ    | 必須 | 説明                                                                                                                                                                                                                              |
+| 名前                | タイプ      | 必須 | 説明                                                                                                                                                                                                                                |
 |-------------------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| templateName      | String  | O  | テンプレート名(最大200文字)                                                                                                                                                                                                                   |
-| chatBubbleType    | String  | O  | メッセージタイプ(TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE)                                                                                                                             |
-| pushAlarm         | boolean | X  | メッセージプッシュ通知の送信有無(デフォルト: true)                                                                                                                                                                                                       |
-| adult             | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                           |
-| carousel          | Object  | O  | カルーセル                                                                                                                                                                                                                             |
-| - list            | List    | O  | カルーセルリスト(最小2件、最大6件)                                                                                                                                                                                                            |
-| -- header         | String  | O  | カルーセルアイテムのタイトル(最大20文字)、カルーセルフィード型でのみ使用可能                                                                                                                                                                                             |
-| -- message        | String  | O  | カルーセルアイテムのタイトル(最大20文字)、カルーセルアイテムのメッセージ(最大180文字)、カルーセルフィード型でのみ使用可能。                                                                                                                                                                        |
-| -- imageUrl       | String  | O  | 画像URL (カルーセルフィード型の画像としてアップロードされた画像のみ使用可能)<br>プレースホルダーは使用不可。                                                                                                                                                                              |
-| -- imageLink      | String  | X  | 画像リンク、1,000文字制限<br>プレースホルダーは使用不可。                                                                                                                                                                                                    |
-| -- buttons        | List    | O  | カルーセルリストのボタンリスト最小1件、最大2件                                                                                                                                                                                                       |
-| --- name          | String  | O  | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字<br>プレースホルダーは使用不可。                                                                                                                                                          |
-| - type            | String  | O  | ボタンタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- ACタイプはTEXT、IMAGEの場合は最初のボタンとして、それ以外のメッセージタイプの場合は最後のボタンとして登録する必要がある |
-| --- linkMo        | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                            |
-| --- linkPc        | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                             |
-| --- schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                          |
-| --- schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合は必須フィールド)、500文字制限                                                                                                                                                                                            |
-| --- bizFormKey    | String  | X  | BFタイプのボタンの場合、ビズフォームキー                                                                                                                                                                                                               |
-| -- coupon         | Object  | X  | クーポン要素                                                                                                                                                                                                                           |
-| --- title         | String  | O  | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」                                                                |
-| --- description   | String  | O  | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字、改行:不可<br>- その他のタイプの場合、最大12文字、改行:不可                                                                                                                         |
-| --- linkMo        | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                       |
-| --- linkPc        | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                             |
-| --- schemeAndroid | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                     |
-| --- schemeIos     | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                       |
-| - tail            | Object  | X  | もっと見るボタン情報                                                                                                                                                                                                                        |
-| -- linkMo         | String  | O  | モバイルWebリンク、500文字制限<br>プレースホルダーは使用不可。                                                                                                                                                                                                 |
-| -- linkPc         | String  | X  | PC Webリンク、500文字制限<br>プレースホルダーは使用不可。                                                                                                                                                                                                  |
-| -- schemeAndroid  | String  | X  | Androidアプリリンク、500文字制限<br>プレースホルダーは使用不可。                                                                                                                                                                                               |
-| -- schemeIos      | String  | X  | iOSアプリリンク、500文字制限<br>プレースホルダーは使用不可。                                                                                                                                                                                                 |
-| recipientList     | List    | O  | 受信者リスト(最大1,000人)                                                                                                                                                                                                                 |
-| - recipientNo     | String  | O  | 受信番号                                                                                                                                                                                                                           |
-| createUser        | String  | X  | 登録者(コンソールから送信した場合、ユーザーUUIDで保存)                                                                                                                                                                                                       |
+| templateName      | String  | O  | テンプレート名（最大200文字）                                                                                                                                                                                                                   |
+| chatBubbleType    | String  | O  | メッセージタイプ（TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE）                                                                                                                             |
+| pushAlarm         | boolean | X  | メッセージプッシュアラーム送信有無（デフォルト値: true）                                                                                                                                                                                                       |
+| adult             | boolean | X  | 成人向けメッセージ有無（デフォルト値: false）                                                                                                                                                                                                           |
+| carousel          | Object  | O  | カルーセル                                                                                                                                                                                                                               |
+| - list            | List    | O  | カルーセルリスト（最小2個、最大6個）                                                                                                                                                                                                            |
+| -- header         | String  | O  | カルーセルアイテムタイトル（最大20文字）、カルーセルフィードタイプでのみ使用可能                                                                                                                                                                                              |
+| -- message        | String  | O  | カルーセルアイテムタイトル（最大20文字）、カルーセルアイテムメッセージ（最大180文字）、カルーセルフィードタイプでのみ使用可能                                                                                                                                                                        |
+| -- imageUrl       | String  | O  | 画像URL（カルーセルフィードタイプ画像としてアップロードされた画像のみ使用可能）<br>置換子は使用不可                                                                                                                                                                              |
+| -- imageLink      | String  | X  | 画像リンク、500文字制限<br>置換子は使用不可                                                                                                                                                                                                    |
+| -- buttons        | List    | O  | カルーセルリストボタン一覧 最小1個、最大2個                                                                                                                                                                                                        |
+| --- name          | String  | O  | ボタンタイトル<br>- TEXT、IMAGEタイプの場合は最大14文字<br>- それ以外のタイプの場合は最大8文字<br>置換子は使用不可                                                                                                                                                          |
+| --- type          | String  | O  | ボタンタイプ（WL: Webリンク、AL: アプリリンク、BK: ボットキーワード、MD: メッセージ転送、AC: チャンネル追加、BT: チャットボット切替、BF: ビジネスフォーム）<br>- ACタイプはTEXT、IMAGEの場合は1番目のボタンとして、それ以外のメッセージタイプの場合は最後のボタンとして登録する必要があります |
+| --- linkMo        | String  | X  | モバイルWebリンク（WLタイプの場合は必須フィールド）、500文字制限                                                                                                                                                                                             |
+| --- linkPc        | String  | X  | PC Webリンク（WLタイプの場合は任意フィールド）、500文字制限                                                                                                                                                                                              |
+| --- schemeAndroid | String  | X  | Android アプリリンク（ALタイプの場合は必須フィールド）、500文字制限                                                                                                                                                                                           |
+| --- schemeIos     | String  | X  | iOS アプリリンク（ALタイプの場合は必須フィールド）、500文字制限                                                                                                                                                                                             |
+| --- bizFormKey    | String  | X  | BFタイプボタンの場合はビズフォームキー                                                                                                                                                                                                                |
+| -- coupon         | Object  | X  | クーポン要素                                                                                                                                                                                                                             |
+| --- title         | String  | O  | titleは5種類の形式に制限されます<br>- "${数字}円割引クーポン" 数字は1以上99,999,999以下<br>- "${数字}%割引クーポン" 数字は1以上100以下<br>- "送料割引クーポン"<br>- "${7文字以内}無料クーポン"<br>- "${7文字以内} UPクーポン"                                                                |
+| --- description   | String  | O  | クーポン詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合は最大18文字、改行: 不可<br>- それ以外のタイプの場合は最大12文字、改行: 不可                                                                                                                          |
+| --- linkMo        | String  | X  | モバイルWebリンク（WLタイプの場合は必須フィールド）、500文字制限<br>クーポンにlinkMoフィールドを入力した場合、残りのフィールドは任意（オプション）となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）となります。                                       |
+| --- linkPc        | String  | X  | PC Webリンク（WLタイプの場合は任意フィールド）、500文字制限                                                                                                                                                                                              |
+| --- schemeAndroid | String  | X  | Android アプリリンク（ALタイプの場合は必須フィールド）、500文字制限<br>クーポンにlinkMoフィールドを入力した場合、残りのフィールドは任意（オプション）となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）となります。                                     |
+| --- schemeIos     | String  | X  | iOS アプリリンク（ALタイプの場合は必須フィールド）、500文字制限<br>クーポンにlinkMoフィールドを入力した場合、残りのフィールドは任意（オプション）となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）となります。                                       |
+| - tail            | Object  | X  | もっと見るボタン情報                                                                                                                                                                                                                         |
+| -- linkMo         | String  | O  | モバイルWebリンク、500文字制限<br>置換子は使用不可                                                                                                                                                                                                 |
+| -- linkPc         | String  | X  | PC Webリンク、500文字制限<br>置換子は使用不可                                                                                                                                                                                                  |
+| -- schemeAndroid  | String  | X  | Android アプリリンク、500文字制限<br>置換子は使用不可                                                                                                                                                                                               |
+| -- schemeIos      | String  | X  | iOS アプリリンク、500文字制限<br>置換子は使用不可                                                                                                                                                                                                 |
+| recipientList     | List    | O  | 受信者リスト（最大1,000名）                                                                                                                                                                                                                 |
+| - recipientNo     | String  | O  | 受信番号                                                                                                                                                                                                                             |
+| createUser        | String  | X  | 登録者（コンソールから送信する場合はユーザーUUIDで保存）                                                                                                                                                                                                       |
 
 <a id="request-to-register-carousel-commerce-type-template"></a>
 
@@ -2935,51 +3230,51 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前                 | タイプ    | 必須 | 説明                                                                                                                                                                                                                              |
+| 名前                   | タイプ      | 必須 | 説明                                                                                                                                                                                                                                |
 |----------------------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| templateName         | String  | O  | テンプレート名(最大200文字)                                                                                                                                                                                                                   |
-| chatBubbleType       | String  | O  | メッセージタイプ(TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE)                                                                                                                             |
-| pushAlarm            | boolean | X  | メッセージプッシュ通知の送信有無(デフォルト: true)                                                                                                                                                                                                       |
-| adult                | boolean | X  | 成人向けメッセージの有無(デフォルト値：false)                                                                                                                                                                                                           |
+| templateName         | String  | O  | テンプレート名（最大 200 文字）                                                                                                                                                                                                               |
+| chatBubbleType       | String  | O  | メッセージタイプ（TEXT、IMAGE、WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO、COMMERCE、CAROUSEL_FEED、CAROUSEL_COMMERCE）                                                                                                                                  |
+| pushAlarm            | boolean | X  | メッセージプッシュ通知の送信有無（デフォルト値: true）                                                                                                                                                                                                   |
+| adult                | boolean | X  | 成人向けメッセージの有無（デフォルト値: false）                                                                                                                                                                                                       |
 | carousel             | Object  | O  | カルーセル                                                                                                                                                                                                                             |
 | - head               | Object  | X  | カルーセルイントロ                                                                                                                                                                                                                         |
-| -- header            | String  | O  | カルーセルイントロヘッダ(最大20文字)                                                                                                                                                                                                                |
-| -- content           | String  | O  | カルーセルイントロ内容(最大50文字)                                                                                                                                                                                                                |
-| -- imageUrl          | String  | O  | カルーセルイントロ画像のURL(カルーセルコマース型の画像としてアップロードされた画像を使用、使用する画像はカルーセルの画像と比率が同一である必要があります)<br>プレースホルダーは使用不可。                                                                                                                                          |
-| -- linkMo            | String  | X  | モバイルWebリンク(linkMo、linkPc、schemeAndroid、schemeIosのいずれかを使用する場合、linkMoは必須値)、500文字制限                                                                                                                                       |
-| -- linkPc            | String  | X  | PC Webリンク、500文字制限                                                                                                                                                                                                             |
-| -- schemeAndroid     | String  | X  | Androidアプリリンク、500文字制限                                                                                                                                                                                                           |
-| -- schemeIos         | String  | X  | iOSアプリリンク、500文字制限                                                                                                                                                                                                             |
-| - list               | List    | O  | カルーセルリスト(headが存在する場合、最小1件、最大5件 / それ以外は最小2件、最大6件)                                                                                                                                                                          |
-| -- additionalContent | String  | X  | 付加情報(最大34文字)、カルーセルコマース形式でのみ使用可能                                                                                                                                                                                                 |
-| -- imageUrl          | String  | O  | 画像URL (カルーセルコマース型の画像としてアップロードされた画像を使用)<br>プレースホルダーは使用不可。                                                                                                                                                                                 |
-| -- imageLink         | String  | X  | 画像リンク、1,000文字制限<br>プレースホルダーは使用不可。                                                                                                                                                                                                    |
-| -- commerce          | Object  | O  | コマース(CAROUSEL_COMMERCEタイプでのみ使用可能)                                                                                                                                                                                               |
-| --- title            | String  | O  | 商品名(最大30文字、改行:不可)                                                                                                                                                                                                           |
-| --- regularPrice     | Integer | O  | 通常価格(0～99,999,999)<br>プレースホルダーのユーザー指定は不可能、値を空にすると固定プレースホルダー`#{通常価格}`で保存されます                                                                                                                                                         |
-| --- discountPrice    | Integer | X  | 割引価格(0 ～ 99,999,999)<br>プレースホルダーのユーザー指定は不可能、値を空にすると固定プレースホルダー`#{割引価格}`で保存されます                                                                                                                                                           |
-| --- discountRate     | Integer | X  | 割引率(0 ～ 100)、割引価格が存在する場合、割引率、定額割引価格のいずれかは必須<br>プレースホルダーのユーザー指定は不可能、値を空にすると固定プレースホルダー`#{割引率}`で保存されます                                                                                                                                     |
-| --- discountFixed    | Integer | X  | 定額割引価格(0 ～ 999,999)、割引価格が存在する場合、割引率、定額割引価格のいずれかは必須<br>プレースホルダーのユーザー指定は不可能、値を空にすると固定プレースホルダー`#{定額割引価格}`で保存されます                                                                                                                           |
-| -- buttons           | List    | O  | カルーセルリストのボタンリスト最小1件、最大2件                                                                                                                                                                                                       |
-| --- name             | String  | O  | ボタンのタイトル<br>- TEXT、IMAGEタイプの場合、最大14文字<br>- その他のタイプの場合、最大8文字<br>プレースホルダーは使用不可。                                                                                                                                                          |
-| --- type             | String  | O  | ボタンタイプ(WL：Webリンク、AL：アプリリンク、BK：ボットキーワード、MD：メッセージ転送、AC：チャンネル追加、BT：チャットボット転換、BF：ビジネスフォーム)<br>- ACタイプはTEXT、IMAGEの場合は最初のボタンとして、それ以外のメッセージタイプの場合は最後のボタンとして登録する必要がある |
-| --- linkMo           | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                            |
-| --- linkPc           | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                             |
-| --- schemeAndroid    | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限                                                                                                                                                                                          |
-| --- schemeIos        | String  | X  | iOSアプリリンク(ALタイプの場合は必須フィールド)、500文字制限                                                                                                                                                                                            |
-| --- bizFormKey       | String  | X  | BFタイプのボタンの場合、ビズフォームキー                                                                                                                                                                                                               |
-| -- coupon            | Object  | X  | クーポン要素                                                                                                                                                                                                                           |
-| --- title            | String  | O  | titleは5つの形式に制限されます<br>- 「${数字}KRW割引クーポン」数字は1以上99,999,999以下<br>- 「${数字}%割引クーポン」数字は1以上100以下<br>- 「送料割引クーポン」<br>- 「${7文字以内}無料クーポン」<br>- 「${7文字以内}UPクーポン」                                                                |
-| --- description      | String  | O  | クーポンの詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEOタイプの場合、最大18文字、改行:不可<br>- その他のタイプの場合、最大12文字、改行:不可                                                                                                                         |
-| --- linkMo           | String  | X  | モバイルWebリンク(WLタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                       |
-| --- linkPc           | String  | X  | PC Webリンク(WLタイプの場合、任意フィールド)、500文字制限                                                                                                                                                                                             |
-| --- schemeAndroid    | String  | X  | Androidアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                     |
-| --- schemeIos        | String  | X  | iOSアプリリンク(ALタイプの場合、必須フィールド)、500文字制限<br>クーポンにlinkMoフィールドを入力する場合、残りのフィールドは任意項目(オプション)となり、<br>scheme_androidまたはscheme_iosフィールドにチャンネルクーポンURL(形式: alimtalk=coupon://)を入力する場合、残りのフィールドが任意項目(オプション)になります。                                       |
-| - tail               | Object  | X  | もっと見るボタン情報                                                                                                                                                                                                                        |
-| -- linkMo            | String  | O  | モバイルWebリンク、500文字制限<br>プレースホルダーは使用不可。                                                                                                                                                                                                 |
-| -- linkPc            | String  | X  | PC Webリンク、500文字制限<br>プレースホルダーは使用不可。                                                                                                                                                                                                  |
-| -- schemeAndroid     | String  | X  | Androidアプリリンク、500文字制限<br>プレースホルダーは使用不可。                                                                                                                                                                                               |
-| -- schemeIos         | String  | X  | iOSアプリリンク、500文字制限<br>プレースホルダーは使用不可。                                                                                                                                                                                                 |
+| -- header            | String  | O  | カルーセルイントロヘッダー（最大 20 文字）                                                                                                                                                                                                           |
+| -- content           | String  | O  | カルーセルイントロ内容（最大 50 文字）                                                                                                                                                                                                             |
+| -- imageUrl          | String  | O  | カルーセルイントロ画像アドレス（カルーセルコマース型画像としてアップロードされた画像を使用。使用する画像はカルーセルの画像と同じ比率である必要があります）<br>置換子の使用不可                                                                                                                                   |
+| -- linkMo            | String  | X  | モバイル Web リンク（linkMo、linkPc、schemeAndroid、schemeIos のいずれかを使用する場合、linkMo は必須）、500 文字制限                                                                                                                                           |
+| -- linkPc            | String  | X  | PC Web リンク、500 文字制限                                                                                                                                                                                                              |
+| -- schemeAndroid     | String  | X  | Android アプリリンク、500 文字制限                                                                                                                                                                                                           |
+| -- schemeIos         | String  | X  | iOS アプリリンク、500 文字制限                                                                                                                                                                                                               |
+| - list               | List    | O  | カルーセルリスト（head が存在する場合は最小 1 個・最大 5 個 / それ以外は最小 2 個・最大 6 個）                                                                                                                                                                       |
+| -- additionalContent | String  | X  | 追加情報（最大 34 文字）、カルーセルコマース型でのみ使用可能                                                                                                                                                                                                 |
+| -- imageUrl          | String  | O  | 画像 URL（カルーセルコマース型画像としてアップロードされた画像を使用）<br>置換子の使用不可                                                                                                                                                                               |
+| -- imageLink         | String  | X  | 画像リンク、500 文字制限<br>置換子の使用不可                                                                                                                                                                                                       |
+| -- commerce          | Object  | O  | コマース（CAROUSEL_COMMERCE タイプでのみ使用可能）                                                                                                                                                                                               |
+| --- title            | String  | O  | 商品タイトル（最大 30 文字、改行: 不可）                                                                                                                                                                                                           |
+| --- regularPrice     | Integer | O  | 通常価格（0〜99,999,999）<br>置換子のカスタマイズ不可。値を空白にすると固定置換子 `#{정상가격}` として保存されます                                                                                                                                                          |
+| --- discountPrice    | Integer | X  | 割引価格（0〜99,999,999）<br>置換子のカスタマイズ不可。値を空白にすると固定置換子 `#{할인가격}` として保存されます                                                                                                                                                            |
+| --- discountRate     | Integer | X  | 割引率（0〜100）。割引価格が存在する場合、割引率と定額割引価格のいずれかが必須<br>置換子のカスタマイズ不可。値を空白にすると固定置換子 `#{할인율}` として保存されます                                                                                                                                     |
+| --- discountFixed    | Integer | X  | 定額割引価格（0〜999,999）。割引価格が存在する場合、割引率と定額割引価格のいずれかが必須<br>置換子のカスタマイズ不可。値を空白にすると固定置換子 `#{정액할인가격}` として保存されます                                                                                                                          |
+| -- buttons           | List    | O  | カルーセルリストボタン一覧（最小 1 個、最大 2 個）                                                                                                                                                                                                     |
+| --- name             | String  | O  | ボタンタイトル<br>- TEXT、IMAGE タイプの場合は最大 14 文字<br>- その他のタイプの場合は最大 8 文字<br>置換子の使用不可                                                                                                                                                       |
+| --- type             | String  | O  | ボタンタイプ（WL: Web リンク、AL: アプリリンク、BK: ボットキーワード、MD: メッセージ転送、AC: チャンネル追加、BT: チャットボット切り替え、BF: ビジネスフォーム）<br>- AC タイプは TEXT、IMAGE の場合は 1 番目のボタンとして、その他のメッセージタイプの場合は最後のボタンとして登録する必要があります |
+| --- linkMo           | String  | X  | モバイル Web リンク（WL タイプの場合は必須フィールド）、500 文字制限                                                                                                                                                                                        |
+| --- linkPc           | String  | X  | PC Web リンク（WL タイプの場合は任意フィールド）、500 文字制限                                                                                                                                                                                           |
+| --- schemeAndroid    | String  | X  | Android アプリリンク（AL タイプの場合は必須フィールド）、500 文字制限                                                                                                                                                                                       |
+| --- schemeIos        | String  | X  | iOS アプリリンク（AL タイプの場合は必須フィールド）、500 文字制限                                                                                                                                                                                           |
+| --- bizFormKey       | String  | X  | BF タイプのボタンの場合はビズフォームキー                                                                                                                                                                                                             |
+| -- coupon            | Object  | X  | クーポン要素                                                                                                                                                                                                                            |
+| --- title            | String  | O  | title は 5 種類の形式に限定されます<br>- 「${数字}円割引クーポン」数字は 1 以上 99,999,999 以下<br>- 「${数字}% 割引クーポン」数字は 1 以上 100 以下<br>- 「送料割引クーポン」<br>- 「${7 文字以内} 無料クーポン」<br>- 「${7 文字以内} UP クーポン」                                                           |
+| --- description      | String  | O  | クーポン詳細説明<br>- WIDE、WIDE_ITEM_LIST、PREMIUM_VIDEO タイプの場合は最大 18 文字、改行: 不可<br>- その他のタイプの場合は最大 12 文字、改行: 不可                                                                                                                            |
+| --- linkMo           | String  | X  | モバイル Web リンク（WL タイプの場合は必須フィールド）、500 文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）となります。<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）となります。         |
+| --- linkPc           | String  | X  | PC ウェブリンク（WL タイプの場合は選択フィールド）、500 文字制限                                                                                                                                                                                              |
+| --- schemeAndroid    | String  | X  | Android アプリリンク（AL タイプの場合は必須フィールド）、500 文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）となり、<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）となります。                                     |
+| --- schemeIos        | String  | X  | iOS アプリリンク（AL タイプの場合は必須フィールド）、500 文字制限<br>クーポンに linkMo フィールドを入力した場合、残りのフィールドは任意（オプション）となり、<br>scheme_android または scheme_ios フィールドにチャンネルクーポン URL（形式: alimtalk=coupon://）を入力した場合、残りのフィールドが任意（オプション）となります。                                       |
+| - tail               | Object  | X  | もっと見るボタン情報                                                                                                                                                                                                                         |
+| -- linkMo            | String  | O  | モバイルウェブリンク、500 文字制限<br>置換変数は使用不可                                                                                                                                                                                                 |
+| -- linkPc            | String  | X  | PC ウェブリンク、500 文字制限<br>置換変数は使用不可                                                                                                                                                                                                  |
+| -- schemeAndroid     | String  | X  | Android アプリリンク、500 文字制限<br>置換変数は使用不可                                                                                                                                                                                               |
+| -- schemeIos         | String  | X  | iOS アプリリンク、500 文字制限<br>置換変数は使用不可                                                                                                                                                                                                 |
 
 <a id="response-10"></a>
 
@@ -2998,12 +3293,12 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前            | タイプ    | Not Null | 説明   |
+| 名前              | タイプ      | Not Null | 説明     |
 |:----------------|:--------|:---------|:-------|
-| header          | Object  | O        | ヘッダ領域 |
-| - resultCode    | Integer | O        | 結果コード |
+| header          | Object  | O        | ヘッダ領域  |
+| - resultCode    | Integer | O        | 結果コード  |
 | - resultMessage | String  | O        | 結果メッセージ |
-| - isSuccessful  | boolean | O        | 成否 |
+| - isSuccessful  | boolean | O        | 成功かどうか  |
 | template        | Object  | X        | テンプレート情報 |
 | - templateCode  | String  | O        | テンプレートコード |
 
@@ -3024,10 +3319,10 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 名前         | タイプ   | 説明   |
+| 名前           | タイプ     | 説明     |
 |--------------|--------|--------|
 | appkey       | String | 固有のアプリキー |
-| senderKey    | String | 発信キー |
+| senderKey    | String | 発信キー   |
 | templateCode | String | テンプレートコード |
 
 [Header]
@@ -3038,13 +3333,13 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前         | タイプ   | 必須 | 説明             |
+| 名前           | タイプ     | 必須 | 説明               |
 |--------------|--------|----|------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
 
 [Request Body]
 
-* テンプレート登録と仕様は同じです
+* テンプレート登録とスペックが同じ
 
 <a id="response-11"></a>
 
@@ -3060,12 +3355,12 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前            | タイプ    | Not Null | 説明   |
+| 名前              | タイプ      | Not Null | 説明     |
 |:----------------|:--------|:---------|:-------|
-| header          | Object  | O        | ヘッダ領域 |
-| - resultCode    | Integer | O        | 結果コード |
+| header          | Object  | O        | ヘッダー領域  |
+| - resultCode    | Integer | O        | 結果コード  |
 | - resultMessage | String  | O        | 結果メッセージ |
-| - isSuccessful  | boolean | O        | 成否 |
+| - isSuccessful  | boolean | O        | 成否  |
 
 <a id="delete-template"></a>
 
@@ -3084,11 +3379,11 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 名前         | タイプ   | 説明   |
-|--------------|--------|--------|
-| appkey       | String | 固有のアプリキー |
-| senderKey    | String | 発信キー |
-| templateCode | String | テンプレートコード |
+| 名前           | タイプ    | 説明         |
+|--------------|--------|------------|
+| appkey       | String | 固有のアプリキー   |
+| senderKey    | String | 発信キー       |
+| templateCode | String | テンプレートコード  |
 
 [Header]
 
@@ -3098,8 +3393,8 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前         | タイプ   | 必須 | 説明             |
-|--------------|--------|----|------------------|
+| 名前           | タイプ    | 必須 | 説明                  |
+|--------------|--------|----|---------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
 
 <a id="response-12"></a>
@@ -3116,12 +3411,12 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前            | タイプ    | Not Null | 説明   |
-|:----------------|:--------|:---------|:-------|
-| header          | Object  | O        | ヘッダ領域 |
-| - resultCode    | Integer | O        | 結果コード |
-| - resultMessage | String  | O        | 結果メッセージ |
-| - isSuccessful  | boolean | O        | 成否 |
+| 名前              | タイプ     | Not Null | 説明       |
+|:----------------|:--------|:---------|:---------|
+| header          | Object  | O        | ヘッダー領域   |
+| - resultCode    | Integer | O        | 結果コード    |
+| - resultMessage | String  | O        | 結果メッセージ  |
+| - isSuccessful  | boolean | O        | 成功かどうか   |
 
 <a id="manage-image"></a>
 
@@ -3133,7 +3428,7 @@ Content-Type: application/json;charset=UTF-8
 
 <a id="requested-13"></a>
 
-#### リクエスト
+#### 要求
 
 [URL]
 
@@ -3144,8 +3439,8 @@ Content-Type: multipart/form-data
 
 [Path parameter]
 
-| 名前   | タイプ   | 説明   |
-|--------|--------|--------|
+| 名前     | タイプ   | 説明       |
+|--------|--------|----------|
 | appkey | String | 固有のアプリキー |
 
 [Header]
@@ -3156,15 +3451,15 @@ Content-Type: multipart/form-data
 }
 ```
 
-| 名前         | タイプ   | 必須 | 説明             |
-|--------------|--------|----|------------------|
-| X-Secret-Key | String | O  | コンソールで作成できます。 |
+| 名前           | タイプ   | 必須 | 説明                   |
+|--------------|--------|----|----------------------|
+| X-Secret-Key | String | O  | コンソールで生成できます。 |
 
 [Request parameter]
 
-| 名前      | タイプ   | 必須 | 説明                                                                                                                           |
+| 名前        | タイプ   | 必須 | 説明                                                                                                                             |
 |-----------|--------|----|--------------------------------------------------------------------------------------------------------------------------------|
-| image     | File   | O  | 画像                                                                                                                           |
+| image     | File   | O  | 画像                                                                                                                             |
 | imageType | String | O  | 画像タイプ <br>(IMAGE, WIDE_IMAGE,MAIN_WIDE_ITEMLIST_IMAGE,NORMAL_WIDE_ITEMLIST_IMAGE,CAROUSEL_FEED_IMAGE,CAROUSEL_COMMERCE_IMAGE) |
 
 <a id="response-13"></a>
@@ -3186,40 +3481,30 @@ Content-Type: multipart/form-data
 }
 ```
 
-| 名前            | タイプ    | Not Null | 説明    |
-|:----------------|:--------|:---------|:--------|
-| header          | Object  | O        | ヘッダ領域 |
-| - resultCode    | Integer | O        | 結果コード |
-| - resultMessage | String  | O        | 結果メッセージ |
-| - isSuccessful  | boolean | O        | 成否 |
-| image           | Object  | X        | 画像領域 |
-| - imageSeq      | Integer | O        | 画像シーケンス |
-| - imageUrl      | String  | O        | 画像のURL |
-| - imageName     | String  | X        | 画像名   |
+| 名前              | タイプ     | Not Null | 説明          |
+|:----------------|:--------|:---------|:------------|
+| header          | Object  | O        | ヘッダー領域      |
+| - resultCode    | Integer | O        | 結果コード       |
+| - resultMessage | String  | O        | 結果メッセージ     |
+| - isSuccessful  | boolean | O        | 成否          |
+| image           | Object  | X        | 画像領域        |
+| - imageSeq      | Integer | O        | 画像シーケンス     |
+| - imageUrl      | String  | O        | 画像 URL      |
+| - imageName     | String  | X        | 画像名         |
 
 <a id="upload-image-specifications"></a>
 
 #### アップロード画像規格
-| 画像タイプ                      | 使用先                                                 | アップロード画像規格                                                                                                         |
-| :------------------------- | :-------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------- |
-| IMAGE                      | 画像形式の送信リクエスト、コマース形式の送信リクエスト、プレミアム動画形式の送信リクエストのサムネイル | **推奨サイズ：**800 × 400px（横500px以上）<br/>**画像比率：**0.5 ≤ 縦 ÷ 横 ≤ 1.333<br/>**ファイル形式／容量制限：**jpg、png／最大5MB                 |
-| WIDE_IMAGE                 | ワイド画像形式の送信リクエスト                                     | **推奨サイズ：**800 × 600px（横500px以上）<br/>**画像比率：**0.5 ≤ 縦 ÷ 横 ≤ 1<br/>**ファイル形式／容量制限：**jpg、png／最大5MB                     |
-| MAIN_WIDE_ITEMLIST_IMAGE   | ワイドアイテムリスト形式の送信リクエストの1番目アイテム画像                      | **制限サイズ：**横500px以上<br/>**画像比率：**縦 ÷ 横 = 0.5<br/>**ファイル形式／容量制限：**jpg、png／最大5MB                                      |
-| NORMAL_WIDE_ITEMLIST_IMAGE | ワイドアイテムリスト形式の送信リクエストの2〜4番目アイテム画像                    | **制限サイズ：**横500px以上<br/>**画像比率：**縦 ÷ 横 = 1<br/>**ファイル形式／容量制限：**jpg、png／各ファイル最大5MB                                   |
-| CAROUSEL_FEED_IMAGE        | カルーセルフィード形式の送信リクエストのセル別画像                           | **推奨サイズ：**800 × 600px または 800 × 400px（横500px以上）<br/>**画像比率：**0.5 ≤ 縦 ÷ 横 ≤ 1.333<br/>**ファイル形式／容量制限：**jpg、png／最大5MB |
-| CAROUSEL_COMMERCE_IMAGE    | コマース形式の送信リクエスト（カルーセルコマース形式）のイントロ画像、セル別画像            | **推奨サイズ：**800 × 600px または 800 × 400px（横500px以上）<br/>**画像比率：**0.5 ≤ 縦 ÷ 横 ≤ 1.333<br/>**ファイル形式／容量制限：**jpg、png／最大5MB |
+| 画像タイプ                      | 使用先                                                    | アップロード画像規格                                                                                                                                       |
+|:---------------------------|:--------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------|
+| IMAGE                      | 画像型画像、コマース型画像、プレミアム動画型サムネイル                             | 推奨サイズ: 800 X 400px (横 500px 以上)<br/>画像比率: 0.5 ≤ 縦 ÷ 横 ≤ 1.333<br/>ファイル形式および容量制限: jpg, png / 最大 5MB                                               |
+| WIDE_IMAGE                 | ワイド画像型画像                                               | 推奨サイズ: 800 X 600px (横 500px 以上)<br/>画像比率: 0.5 ≤ 縦 ÷ 横 ≤ 1<br>ファイル形式および容量制限: jpg, png / 最大 5MB                                                     |
+| MAIN_WIDE_ITEMLIST_IMAGE   | ワイドアイテムリストタイプの最初のアイテム画像                                | 制限サイズ: 横 500px 以上<br/>画像比率: 縦 ÷ 横 = 0.5<br/>ファイル形式および容量制限: jpg, png / 最大 5MB                                                                     |
+| NORMAL_WIDE_ITEMLIST_IMAGE | ワイドアイテムリストタイプの 2〜4 番目のアイテム画像                          | 制限サイズ: 横 500px 以上<br/>画像比率: 縦 ÷ 横 = 1<br/>ファイル形式およびサイズ: jpg, png / 各ファイル最大 5MB                                                                   |
+| CAROUSEL_FEED_IMAGE        | カルーセルフィードタイプのセル別画像                                     | 推奨サイズ: 800 X 600px または 800 X 400px (横 500px 以上)<br/>画像比率: 0.5 ≤ 縦 ÷ 横 ≤ 1.333<br/>ファイル形式および容量制限: jpg, png / 最大 5MB                              |
+| CAROUSEL_COMMERCE_IMAGE    | カルーセルコマースタイプのイントロ画像、カルーセルコマースタイプのセル別画像 | 推奨サイズ: 800 X 600px または 800 X 400px (横 500px 以上)<br/>画像比率: 0.5 ≤ 縦 ÷ 横 ≤ 1.333<br/>ファイル形式および容量制限: jpg, png / 最大 5MB                              |
 
-**アップロード画像規格**
-| 画像タイプ                     | 使用箇所                                                     | アップロード画像規格                                                                                                                              |
-|:---------------------------|:--------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------|
-| IMAGE                      | 画像型画像、コマース型画像、プレミアム動画型サムネイル                       | 推奨サイズ: 800 X 400px (横500px以上)<br/>画像比率: 0.5 ≤ 縦 ÷ 横 ≤ 1.333<br/>ファイル形式及び容量制限: jpg, png / 最大5MB                                |
-| WIDE_IMAGE                 | ワイド画像型画像                                                  | 推奨サイズ: 800 X 600px (横500px以上)<br/>画像比率: 0.5 ≤ 縦 ÷ 横 ≤ 1<br>ファイル形式及び容量制限: jpg, png / 最大5MB                                     |
-| MAIN_WIDE_ITEMLIST_IMAGE   | ワイドアイテムリスト型1番目のアイテム画像                                | 制限サイズ: 横500px以上<br/>画像比率: 縦 ÷ 横 = 0.5<br/>ファイル形式及び容量制限: jpg, png / 最大5MB                                                      |
-| NORMAL_WIDE_ITEMLIST_IMAGE | ワイドアイテムリスト型2～4番目のアイテム画像                              | 制限サイズ: 横500px以上<br/>画像比率: 縦 ÷ 横 = 1<br/>ファイル形式及びサイズ: jpg, png / 各ファイル最大5MB                                                      |
-| CAROUSEL_FEED_IMAGE        | カルーセルフィード型セル別画像                                          | 推奨サイズ: 800 X 600px または 800 X 400px (横500px以上)<br/>画像比率: 0.5 ≤ 縦 ÷ 横 ≤ 1.333<br/>ファイル形式及び容量制限: jpg, png / 最大5MB                 |
-| CAROUSEL_COMMERCE_IMAGE    | カルーセルコマース型イントロ画像、カルーセルコマース型セル別画像 | 推奨サイズ: 800 X 600px または 800 X 400px (横500px以上)<br/>画像比率: 0.5 ≤ 縦 ÷ 横 ≤ 1.333<br/>ファイル形式及び容量制限: jpg, png / 最大5MB                 |
-
-* テンプレート変更時に画像を別の画像に変更すると、既存の画像がKakao CDNから削除されURLが無効になります。同じ画像を使用する他のテンプレートにも影響するため注意が必要です。画像照会APIでは画像情報が保持されますが、実際の画像にはアクセスできないため、元ファイルは独自のサーバーに別途保管することを推奨します。
+* アップロードされた画像を参照するテンプレートがすべて削除されるか、別の画像に変更されると、カカオ CDN から該当画像が削除され、URL が無効になります。画像照会 API では画像情報が保持されますが、実際の画像にはアクセスできないため、元のファイルは自社サーバーに別途保管することをお勧めします。
 
 <a id="view-image"></a>
 
@@ -3227,7 +3512,7 @@ Content-Type: multipart/form-data
 
 <a id="requested-14"></a>
 
-#### リクエスト
+#### 要求
 
 [URL]
 
@@ -3238,8 +3523,8 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 名前   | タイプ   | 説明   |
-|--------|--------|--------|
+| 名前     | タイプ   | 説明       |
+|--------|--------|----------|
 | appkey | String | 固有のアプリキー |
 
 [Header]
@@ -3250,17 +3535,17 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前         | タイプ   | 必須 | 説明             |
-|--------------|--------|----|------------------|
-| X-Secret-Key | String | O  | コンソールで作成できます。 |
+| 名前           | タイプ   | 必須 | 説明                   |
+|--------------|--------|----|----------------------|
+| X-Secret-Key | String | O  | コンソールで生成できます。 |
 
 [Request parameter]
 
-| 名前       | タイプ   | 必須 | 説明                                                                                                                           |
+| 名前         | タイプ   | 必須 | 説明                                                                                                                             |
 |------------|--------|----|--------------------------------------------------------------------------------------------------------------------------------|
 | imageTypes | List   | O  | 画像タイプ <br>(IMAGE, WIDE_IMAGE,MAIN_WIDE_ITEMLIST_IMAGE,NORMAL_WIDE_ITEMLIST_IMAGE,CAROUSEL_FEED_IMAGE,CAROUSEL_COMMERCE_IMAGE) |
-| pageNum    | String | X  | ページ番号(基本: 1)                                                                                                                  |
-| pageSize   | String | X  | 照会件数(基本: 15)                                                                                                                  |
+| pageNum    | String | X  | ページ番号 (デフォルト: 1)                                                                                                               |
+| pageSize   | String | X  | 照会件数 (デフォルト: 15)                                                                                                               |
 
 <a id="response-14"></a>
 
@@ -3281,16 +3566,16 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前            | タイプ    | Not Null | 説明    |
-|:----------------|:--------|:---------|:--------|
-| header          | Object  | O        | ヘッダ領域 |
-| - resultCode    | Integer | O        | 結果コード |
-| - resultMessage | String  | O        | 結果メッセージ |
-| - isSuccessful  | boolean | O        | 成否 |
-| image           | Object  | X        | 画像領域 |
-| - imageSeq      | Integer | O        | 画像シーケンス |
-| - imageUrl      | String  | O        | 画像のURL |
-| - imageName     | String  | X        | 画像名   |
+| 名前              | タイプ     | Not Null | 説明          |
+|:----------------|:--------|:---------|:------------|
+| header          | Object  | O        | ヘッダー領域      |
+| - resultCode    | Integer | O        | 結果コード       |
+| - resultMessage | String  | O        | 結果メッセージ     |
+| - isSuccessful  | boolean | O        | 成否          |
+| image           | Object  | X        | 画像領域        |
+| - imageSeq      | Integer | O        | 画像シーケンス     |
+| - imageUrl      | String  | O        | 画像 URL      |
+| - imageName     | String  | X        | 画像名         |
 
 <a id="delete-image"></a>
 
@@ -3298,7 +3583,7 @@ Content-Type: application/json;charset=UTF-8
 
 <a id="requested-15"></a>
 
-#### リクエスト
+#### 要求
 
 [URL]
 
@@ -3309,8 +3594,8 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 名前   | タイプ   | 説明   |
-|--------|--------|--------|
+| 名前     | タイプ   | 説明       |
+|--------|--------|----------|
 | appkey | String | 固有のアプリキー |
 
 [Header]
@@ -3321,15 +3606,15 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前         | タイプ   | 必須 | 説明             |
-|--------------|--------|----|------------------|
-| X-Secret-Key | String | O  | コンソールで作成できます。 |
+| 名前           | タイプ   | 必須 | 説明                   |
+|--------------|--------|----|----------------------|
+| X-Secret-Key | String | O  | コンソールで生成できます。 |
 
 [Query parameter]
 
-| 名前     | タイプ   | 必須 | 説明   |
+| 名前       | タイプ   | 必須 | 説明     |
 |----------|--------|----|--------|
-| imageSeq | String | O  | 画像番号 |
+| imageSeq | String | O  | 画像番号   |
 
 <a id="response-15"></a>
 
@@ -3345,37 +3630,37 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前            | タイプ    | Not Null | 説明   |
-|:----------------|:--------|:---------|:-------|
-| header          | Object  | O        | ヘッダ領域 |
-| - resultCode    | Integer | O        | 結果コード |
+| 名前              | タイプ     | Not Null | 説明      |
+|:----------------|:--------|:---------|:--------|
+| header          | Object  | O        | ヘッダー領域  |
+| - resultCode    | Integer | O        | 結果コード   |
 | - resultMessage | String  | O        | 結果メッセージ |
-| - isSuccessful  | boolean | O        | 成否 |
+| - isSuccessful  | boolean | O        | 成否      |
 
 <a id="manage-video"></a>
 
 ## 動画管理
 
-ブランドメッセージに使用する動画を登録・照会・削除するAPIです。登録された動画はカカオビズセンターでエンコード処理後に送信に使用でき、状態が`PUBLIC`である動画のみテンプレートの登録及び送信が可能です(`PRIVATE`はテンプレートの登録のみ可能)。
+ブランドメッセージで使用する動画を登録・照会・削除する API です。登録された動画はカカオビズセンターでエンコード処理後、送信に使用できます。ステータスが `PUBLIC` の動画のみテンプレート登録および送信が可能です（`PRIVATE` はテンプレート登録のみ可能）。
 
 <a id="video-upload-flow"></a>
 
 ### 動画アップロードの流れ
 
-動画のアップロードは2段階で行われます。
+動画のアップロードは2段階で行います。
 
-1. **動画アップロードの登録** — 本API(`POST /brand-message/v1.0/appkeys/{appKey}/videos`)に動画のメタ情報(ファイル名・ファイルサイズ)をJSONで送信します。レスポンスとして`video`(NHN Cloud側の登録情報)と`uploadInfo`(カカオアップロードURL・トークン)を受信します。
-2. **動画ファイルのアップロード** — レスポンスとして受信した`uploadInfo.uploadUrl`に`multipart/form-data`で動画ファイルを直接アップロードします。認証は`uploadInfo.token`を`x-kamp-upload-token`ヘッダで渡します。
+1. **動画アップロード登録** — 本 API（`POST /brand-message/v1.0/appkeys/{appKey}/videos`）に動画のメタ情報（ファイル名・ファイルサイズ）を JSON で送信します。レスポンスとして `video`（NHN Cloud 側の登録情報）と `uploadInfo`（カカオのアップロード URL・トークン）を受け取ります。
+2. **動画ファイルのアップロード** — レスポンスで受け取った `uploadInfo.uploadUrl` に `multipart/form-data` で動画ファイルを直接アップロードします。認証は `uploadInfo.token` を `x-kamp-upload-token` ヘッダーで渡します。
 
-動画ファイルはNHN Cloudサーバーを経由せず、カカオ側のアップロードサーバーへ直接送信されます。したがって、本APIのリクエスト本文はメタ情報のみをJSONで送信し、実際のファイルは2段階目で別途送信します。
+動画ファイルは NHN Cloud サーバーを経由せず、カカオ側のアップロードサーバーへ直接送信されます。そのため、本 API のリクエストボディはメタ情報のみを JSON で送信し、実際のファイルは2段階目で別途送信します。
 
 > **注意**
-> * `uploadInfo.token`は発行後5分間有効です。5分が経過した場合は、1段階目の登録を再度呼び出して新しいトークンを受け取る必要があります。
-> * 1段階目のリクエストの`fileSize`は、実際に2段階目でアップロードするファイルのサイズと正確に一致する必要があります(不一致の場合、カカオ側でerrCode 109として拒否されます)。
+> * `uploadInfo.token` は発行後5分間有効です。5分が経過した場合は、1段階目の登録を再度呼び出して新しいトークンを取得する必要があります。
+> * 1段階目のリクエストの `fileSize` は、実際に2段階目でアップロードするファイルのサイズと正確に一致している必要があります（不一致の場合、カカオ側で errCode 109 として拒否されます）。
 
 <a id="register-video-upload"></a>
 
-### 動画アップロードの登録
+### 動画アップロード登録
 
 <a id="requested-16"></a>
 
@@ -3404,7 +3689,7 @@ Content-Type: application/json;charset=UTF-8
 
 | 名前           | タイプ     | 必須 | 説明               |
 |--------------|--------|----|------------------|
-| X-Secret-Key | String | O  | コンソールで作成できます。 |
+| X-Secret-Key | String | O  | コンソールで生成できます。 |
 
 [Request body]
 
@@ -3417,12 +3702,12 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前         | タイプ     | 必須 | 説明                                                                                 |
+| 名前         | タイプ     | 必須 | 説明                                                                  |
 |------------|--------|----|---------------------------------------------------------------------|
-| senderKey  | String | O  | 送信元プロファイルキー(40文字)                                                       |
-| fileName   | String | O  | 動画ファイル名(拡張子を含む、MP4・MOV・AVIのいずれか、最大250文字)                          |
-| fileSize   | Long   | O  | 動画ファイルのサイズ(バイト、最大4GB)                                                      |
-| createUser | String | X  | アップロードユーザー識別子(最大100文字)                                                |
+| senderKey  | String | O  | 発信プロフィールキー (40文字)                                                       |
+| fileName   | String | O  | 動画ファイル名 (拡張子を含む、MP4・MOV・AVI のいずれか、最大 250 文字)                          |
+| fileSize   | Long   | O  | 動画ファイルサイズ (byte、最大 4GB)                                              |
+| createUser | String | X  | アップロードユーザー識別子 (最大 100 文字)                                                |
 
 <a id="response-16"></a>
 
@@ -3453,29 +3738,29 @@ Content-Type: application/json;charset=UTF-8
 
 | 名前              | タイプ      | Not Null | 説明                                                                              |
 |:----------------|:--------|:---------|:--------------------------------------------------------------------------------|
-| header          | Object  | O        | ヘッダ領域                                                                         |
-| - resultCode    | Integer | O        | 結果コード                                                                         |
-| - resultMessage | String  | O        | 結果メッセージ                                                                       |
-| - isSuccessful  | boolean | O        | 成否                                                                           |
-| video           | Object  | X        | NHN Cloud側に登録された動画情報(status = `REGISTERED`)                                  |
-| - videoSeq      | Long    | O        | 動画シーケンス                                                                       |
-| - vid           | String  | O        | カカオ動画ID                                                                      |
-| - senderKey     | String  | O        | 送信元プロファイルキー                                                                    |
-| - title         | String  | X        | 動画のタイトル(アップロード直後はファイル名、エンコード完了後はカカオビズセンターで変更された値に同期されます)                        |
-| - fileName      | String  | O        | アップロードファイル名                                                                    |
-| - fileSize      | Long    | O        | ファイルサイズ(バイト)                                                                   |
-| - status        | String  | O        | 動画状態([動画状態](#動画-状態)を参照)。アップロードの登録レスポンスでは常に`REGISTERED`                     |
-| uploadInfo      | Object  | O        | カカオアップロード情報。2段階目に使用                                                               |
-| - uploadUrl     | String  | O        | 動画ファイルを直接アップロードするカカオ側のエンドポイント                                                       |
-| - token         | String  | O        | アップロード認証トークン。`x-kamp-upload-token`ヘッダで渡します                                         |
+| header          | Object  | O        | ヘッダー領域                                                                           |
+| - resultCode    | Integer | O        | 結果コード                                                                           |
+| - resultMessage | String  | O        | 結果メッセージ                                                                          |
+| - isSuccessful  | boolean | O        | 成功の有無                                                                           |
+| video           | Object  | X        | NHN Cloud 側に登録された動画情報 (status = `REGISTERED`)                                   |
+| - videoSeq      | Long    | O        | 動画シーケンス                                                                         |
+| - vid           | String  | O        | カカオ動画 ID                                                                      |
+| - senderKey     | String  | O        | 発信プロフィールキー                                                                         |
+| - title         | String  | X        | 動画タイトル (アップロード直後はファイル名、エンコード完了後にカカオビズセンターで修正した値に同期されます)                        |
+| - fileName      | String  | O        | アップロードファイル名                                                                         |
+| - fileSize      | Long    | O        | ファイルサイズ (byte)                                                                    |
+| - status        | String  | O        | 動画ステータス ([動画ステータス](#動画-ステータス) 参照)。アップロード登録レスポンスでは常に `REGISTERED`                     |
+| uploadInfo      | Object  | O        | カカオアップロード情報。ステップ 2 で使用                                                            |
+| - uploadUrl     | String  | O        | 動画ファイルを直接アップロードするカカオ側エンドポイント                                                     |
+| - token         | String  | O        | アップロード認証トークン。`x-kamp-upload-token` ヘッダーで渡します                                          |
 
-> エンコード完了後に値が格納される`thumbnailUrl`、`videoUrl`、`playUrl`、`updateDate`フィールドは、[動画照会](#動画-照会) APIで取得できます。
+> エンコード完了後に設定される `thumbnailUrl`、`videoUrl`、`playUrl`、`updateDate` フィールドは、[動画照会](#動画-照会) API で取得できます。
 
 <a id="video-file-upload-step-2"></a>
 
-### 動画ファイルのアップロード(2段階目)
+### 動画ファイルアップロード (ステップ 2)
 
-上記レスポンスの`uploadInfo.uploadUrl`に動画ファイルを指定して直接呼び出します。このリクエストはNHN Cloudサーバーではなく、カカオ側のアップロードサーバーに直接送信されます。
+上記レスポンスの `uploadInfo.uploadUrl` に対して動画ファイルを直接呼び出します。このリクエストは NHN Cloud サーバーではなく、カカオ側のアップロードサーバーに直接送信されます。
 
 <a id="requested-17"></a>
 
@@ -3492,13 +3777,13 @@ Content-Type: multipart/form-data
 
 | 名前                  | タイプ     | 必須 | 説明                                          |
 |---------------------|--------|----|---------------------------------------------|
-| x-kamp-upload-token | String | O  | 1段階目のレスポンスの`uploadInfo.token`の値をそのまま渡します        |
+| x-kamp-upload-token | String | O  | ステップ 1 のレスポンスの `uploadInfo.token` の値をそのまま渡します |
 
 [Request body (multipart)]
 
 | 名前   | タイプ   | 必須 | 説明                                                  |
 |------|------|----|-----------------------------------------------------|
-| file | File | O  | 動画ファイル。1段階目のリクエストの`fileSize`と正確に一致する必要があります             |
+| file | File | O  | 動画ファイル。ステップ 1 のリクエストの `fileSize` と正確に一致する必要があります |
 
 <a id="response-17"></a>
 
@@ -3513,25 +3798,25 @@ Content-Type: multipart/form-data
 }
 ```
 
-* 成功時は`vid`(1段階目のレスポンスと同一)と`playUrl`を返し、`errCode`/`message`フィールドは含まれません。
-* 失敗時はHTTP 4xxとともに`errCode`(100～110)と`message`を返します。詳細なエラーコードはカカオビズメッセージガイドをご参照ください。
+* 成功した場合、`vid`（ステップ 1 のレスポンスと同一）と `playUrl` を返し、`errCode`/`message` フィールドは含まれません。
+* 失敗した場合、HTTP 4xx とともに `errCode`（100〜110）と `message` を返します。詳細なエラーコードについては、カカオビズメッセージガイドを参照してください。
 
 <a id="upload-video-specifications"></a>
 
-#### アップロードする動画の規格
+#### アップロード動画の仕様
 
-| 項目       | 制限                                          |
-|:---------|:--------------------------------------------|
-| ファイル形式    | MP4、MOV、AVI                               |
-| 最大ファイルサイズ | 4GB                                         |
-| 最大動画長 | 4時間                                         |
-| 最大解像度   | 8K                                          |
-| ファイル名の長さ   | 250文字以内                                     |
+| 項目         | 制限                                          |
+|:-----------|:--------------------------------------------|
+| ファイル形式     | MP4、MOV、AVI                                |
+| 最大ファイルサイズ  | 4GB                                         |
+| 最大映像時間     | 4時間                                         |
+| 最大解像度      | 8K                                          |
+| ファイル名の長さ   | 250文字以内                                    |
 
-* アップロードされた動画は、カカオビズセンターでエンコードが完了した後に使用できます。エンコード時間は動画の長さによって異なりますが、通常5～10分かかります。
-* アップロード直後の動画状態は`REGISTERED`から開始し、`ENCODING`を経て`PUBLIC`または`PRIVATE`に切り替わります。状態はコンソールまたは[動画照会](#動画照会] APIで確認できます。
-* 登録された動画はカカオ側で永久保存され、テンプレートが削除されてもカカオビズセンターの動画は自動的に整理されません。カカオチャネルの管理者が、チャネルビジネスホームの管理画面で直接削除できます。
-* 1段階目の登録後、2段階目のファイルアップロードが失敗したり遅延したりしてトークン(5分)の有効期限が切れた場合、新しい登録を再度呼び出す必要があります。登録のみが行われ実際のアップロードが行われなかった動画は、一定時間が経過すると状態が自動的に`ERROR`とマークされます。
+* アップロードされた動画は、カカオビズセンターでエンコードが完了した後に使用できます。エンコード時間は映像の長さによって異なり、通常 5〜10 分かかります。
+* アップロード直後の動画ステータスは `REGISTERED` から始まり、`ENCODING` を経て `PUBLIC` または `PRIVATE` に移行します。ステータスはコンソールまたは[動画照会](#動画-照会) API で確認できます。
+* 登録された動画はカカオ側で永久保存され、テンプレートが削除されてもカカオビズセンターの動画は自動的に削除されません。カカオチャンネル管理者がチャンネルビジネスホームの管理画面から直接削除できます。
+* ステップ 1 の登録後にステップ 2 のファイルアップロードが失敗または遅延してトークン（5 分）が期限切れになった場合は、新しい登録を再度呼び出す必要があります。登録のみ行われ実際のアップロードが完了していない動画は、一定時間経過後にステータスが `ERROR` に自動的にマークされます。
 
 <a id="view-video"></a>
 
@@ -3570,9 +3855,9 @@ Content-Type: application/json;charset=UTF-8
 
 | 名前         | タイプ     | 必須 | 説明                |
 |------------|--------|----|-------------------|
-| senderKey  | String | X  | 送信元プロファイルキー(40文字)     |
-| pageNum    | String | X  | ページ番号(デフォルト: 1)    |
-| pageSize   | String | X  | 照会件数(デフォルト: 15)    |
+| senderKey  | String | X  | 発信プロフィールキー (40文字)     |
+| pageNum    | String | X  | ページ番号 (デフォルト: 1)    |
+| pageSize   | String | X  | 照会件数 (デフォルト: 15)    |
 
 <a id="response-18"></a>
 
@@ -3608,30 +3893,30 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前                  | タイプ      | Not Null | 説明                                                  |
+| 名前                  | タイプ      | Not Null | 説明                                                          |
 |:--------------------|:--------|:---------|:------------------------------------------------------------|
-| header              | Object  | O        | ヘッダ領域                                               |
-| - resultCode        | Integer | O        | 結果コード                                               |
-| - resultMessage     | String  | O        | 結果メッセージ                                              |
-| - isSuccessful      | boolean | O        | 成否                                                  |
-| videosResponse      | Object  | X        | 動画一覧領域                                               |
-| - videos            | Array   | O        | 動画配列                                                |
-| - - videoSeq        | Long    | O        | 動画シーケンス                                              |
-| - - vid             | String  | O        | カカオ動画ID                                              |
-| - - senderKey       | String  | O        | 送信元プロファイルキー                                            |
-| - - title           | String  | X        | 動画のタイトル(アップロード直後はファイル名、エンコード完了後はカカオビズセンターで変更された値に同期されます)    |
-| - - fileName        | String  | O        | アップロードファイル名                                            |
-| - - fileSize        | Long    | O        | ファイルサイズ(バイト)                                          |
-| - - status          | String  | O        | 動画状態([動画状態](#動画-状態)を参照)                              |
-| - - thumbnailUrl    | String  | X        | サムネイルURL(エンコード完了後に提供)                               |
-| - - videoUrl        | String  | X        | 送信・管理用URL(`PUBLIC`状態で提供)                               |
-| - - playUrl         | String  | X        | 再生用URL                                              |
-| - - createDate      | String  | O        | 登録時刻                                                |
-| - - updateDate      | String  | X        | 状態の同期時刻(Webhook/バッチ更新時に記録)                           |
-| - - createUser      | String  | X        | アップロードユーザー識別子                                         |
-| - totalCount        | Integer | O        | 総動画数                                                |
+| header              | Object  | O        | ヘッダー領域                                                       |
+| - resultCode        | Integer | O        | 結果コード                                                       |
+| - resultMessage     | String  | O        | 結果メッセージ                                                      |
+| - isSuccessful      | boolean | O        | 成否                                                       |
+| videosResponse      | Object  | X        | 動画リスト領域                                                   |
+| - videos            | Array   | O        | 動画配列                                                      |
+| - - videoSeq        | Long    | O        | 動画シーケンス                                                     |
+| - - vid             | String  | O        | カカオ動画 ID                                                  |
+| - - senderKey       | String  | O        | 発信プロフィールキー                                                    |
+| - - title           | String  | X        | 動画タイトル (アップロード直後はファイル名、エンコード完了後にカカオビズセンターで修正した値に同期されます)    |
+| - - fileName        | String  | O        | アップロードファイル名                                                     |
+| - - fileSize        | Long    | O        | ファイルサイズ (byte)                                                |
+| - - status          | String  | O        | 動画ステータス ([動画ステータス](#動画-状態) 参照)                              |
+| - - thumbnailUrl    | String  | X        | サムネイル URL (エンコード完了後に提供)                                       |
+| - - videoUrl        | String  | X        | 送信・管理用 URL (`PUBLIC` 状態で提供)                               |
+| - - playUrl         | String  | X        | 再生用 URL                                                     |
+| - - createDate      | String  | O        | 登録日時                                                       |
+| - - updateDate      | String  | X        | ステータス同期日時 (Webhook/バッチ更新時に記録)                                    |
+| - - createUser      | String  | X        | アップロードユーザー識別子                                                 |
+| - totalCount        | Integer | O        | 動画の総数                                                    |
 
-> アップロードの登録レスポンスの`video`は登録直後の時点であるため、`status`が常に`REGISTERED`であり、`thumbnailUrl`・`videoUrl`・`playUrl`・`createDate`・`updateDate`・`createUser`フィールドは含まれません。これらのフィールドは、エンコード完了後に動画照会APIで確認できます。
+> アップロード登録レスポンスの `video` は登録直後の時点であるため、`status` は常に `REGISTERED` であり、`thumbnailUrl`・`videoUrl`・`playUrl`・`createDate`・`updateDate`・`createUser` フィールドは含まれません。これらのフィールドはエンコード完了後に動画照会 API で確認できます。
 
 <a id="delete-video"></a>
 
@@ -3670,7 +3955,7 @@ Content-Type: application/json;charset=UTF-8
 
 | 名前       | タイプ     | 必須 | 説明                                |
 |----------|--------|----|-----------------------------------|
-| videoSeq | String | O  | 動画シーケンス(カンマ区切りで複数件の送信が可能)        |
+| videoSeq | String | O  | 動画シーケンス（カンマ区切りで複数件指定可能）        |
 
 <a id="response-19"></a>
 
@@ -3688,27 +3973,27 @@ Content-Type: application/json;charset=UTF-8
 
 | 名前              | タイプ      | Not Null | 説明     |
 |:----------------|:--------|:---------|:-------|
-| header          | Object  | O        | ヘッダ領域  |
+| header          | Object  | O        | ヘッダー領域  |
 | - resultCode    | Integer | O        | 結果コード  |
 | - resultMessage | String  | O        | 結果メッセージ |
 | - isSuccessful  | boolean | O        | 成否  |
 
 <a id="video-status"></a>
 
-### 動画状態
+### 動画ステータス
 
-動画照会レスポンスの`status`フィールド値について説明します。
+動画照会レスポンスの `status` フィールド値について説明します。
 
-| status     | 説明                                  |
-|:-----------|:------------------------------------|
-| REGISTERED | アップロードの登録                              |
-| ENCODING   | エンコード中                               |
-| PUBLIC     | 公開状態(送信及びテンプレートの登録が可能)              |
-| PRIVATE    | 非公開状態(テンプレートの登録が可能)                  |
-| VIOLATED   | 違反動画                                  |
-| ILLEGAL    | 違法撮影物の動画                               |
-| DELETED    | 削除された動画                               |
-| ERROR      | アップロード及びエンコード中にエラーが発生                   |
+| status     | 説明                                        |
+|:-----------|:------------------------------------------|
+| REGISTERED | アップロード登録                                  |
+| ENCODING   | エンコード中                                    |
+| PUBLIC     | 公開状態（送信およびテンプレート登録可能）                     |
+| PRIVATE    | 非公開状態（テンプレート登録のみ可能、送信時は失敗）               |
+| VIOLATED   | 違反動画                                      |
+| ILLEGAL    | 不法撮影物動画                                   |
+| DELETED    | 削除済み動画                                    |
+| ERROR      | アップロードおよびエンコード中にエラーが発生                    |
 
 <a id="upload"></a>
 
@@ -3731,10 +4016,10 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 名前      | タイプ   | 説明   |
-|-----------|--------|--------|
+| 名前        | タイプ     | 説明          |
+|-----------|--------|-------------|
 | appkey    | String | 固有のアプリキー |
-| senderKey | String | 発信キー |
+| senderKey | String | 発信キー        |
 
 [Header]
 
@@ -3744,8 +4029,8 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前         | タイプ   | 必須 | 説明             |
-|--------------|--------|----|------------------|
+| 名前           | タイプ     | 必須 | 説明                      |
+|--------------|--------|----|-------------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
 
 <a id="response-20"></a>
@@ -3762,20 +4047,20 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前            | タイプ    | Not Null | 説明   |
-|:----------------|:--------|:---------|:-------|
-| header          | Object  | O        | ヘッダ領域 |
-| - resultCode    | Integer | O        | 結果コード |
-| - resultMessage | String  | O        | 結果メッセージ |
-| - isSuccessful  | boolean | O        | 成否 |
+| 名前              | タイプ      | Not Null | 説明         |
+|:----------------|:--------|:---------|:-----------|
+| header          | Object  | O        | ヘッダー領域     |
+| - resultCode    | Integer | O        | 結果コード      |
+| - resultMessage | String  | O        | 結果メッセージ    |
+| - isSuccessful  | boolean | O        | 成功可否       |
 
 <a id="manage-outgoing-profiles"></a>
 
-## 送信プロフィール管理
+## 発信プロフィール管理
 
 <a id="view-outgoing-profile"></a>
 
-### 送信プロフィール照会
+### 発信プロフィール照会
 
 <a id="requested-21"></a>
 
@@ -3790,10 +4075,10 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 名前      | タイプ   | 説明   |
-|-----------|--------|--------|
-| appkey    | String | 固有のアプリキー |
-| senderKey | String | 発信キー |
+| 名前        | タイプ    | 説明          |
+|-----------|--------|-------------|
+| appkey    | String | 固有のアプリキー    |
+| senderKey | String | 発信キー        |
 
 [Header]
 
@@ -3803,8 +4088,8 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前         | タイプ   | 必須 | 説明             |
-|--------------|--------|----|------------------|
+| 名前           | タイプ    | 必須 | 説明                  |
+|--------------|--------|----|---------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
 
 <a id="response-21"></a>
@@ -3847,40 +4132,40 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前                      | タイプ    | Not Null | 説明                                                                                                                  |
-|:--------------------------|:--------|:---------|:----------------------------------------------------------------------------------------------------------------------|
-| header                    | Object  | O        | ヘッダ領域                                                                                                               |
-| - resultCode              | Integer | O        | 結果コード                                                                                                               |
-| - resultMessage           | String  | O        | 結果メッセージ                                                                                                              |
-| - isSuccessful            | boolean | O        | 成否                                                                                                               |
-| sender                    | Object  | X        | 送信プロフィール                                                                                                               |
-| - plusFriendId            | String  | O        | プラスフレンドID                                                                                                              |
-| - senderKey               | String  | O        | 発信キー                                                                                                                |
-| - categoryCode            | String  | X        | カテゴリーコード                                                                                                              |
-| - unsubscribePhoneNumber  | String  | X        | 無料受信拒否電話番号                                                                                                          |
-| - unsubscribeAuthNumber   | String  | X        | 無料受信拒否認証番号                                                                                                          |
-| - status                  | String  | X        | NHN Cloudプラスフレンドステータスコード <br>(YSC02:登録待機中、YSC03:正常登録)                                                              |
-| - statusName              | String  | X        | NHN Cloudプラスフレンド状態名(登録待機中、正常登録)                                                                                   |
-| - kakaoStatus             | String  | X        | カカオプラスフレンドステータスコード<br>(A:正常、S:ブロック)<br>statusがYSC02の場合、kakaoStatusはnull値になります。                                     |
-| - kakaoStatusName         | String  | X        | カカオプラスフレンドステータス名(正常、ブロック)<br>statusがYSC02の場合、kakaoStatusNameはnull値になります。                                             |
-| - kakaoProfileStatus      | String  | X        | カカオプラスフレンドプロフィールステータスコード<br>(A:有効、B:ブロック、C:無効、D:削除、E:削除処理中)<br>statusがYSC02の場合、kakaoProfileStatusはnull値になります。 |
-| - kakaoProfileStatusName  | String  | X        | カカオプラスフレンドプロフィールステータス名(有効、無効、ブロック、削除処理中、削除)<br>statusがYSC02の場合、kakaoProfileStatusNameはnull値になります。              |
-| - profileSpamLevel        | String  | X        | カカオトークチャネルのスパムステータス名(永久制限、警告制限、正常)<br>送信プロフィールのステータスが正常でない場合、null値になることがあります。                                           |
-| - profileMessageSpamLevel | String  | X        | カカオトークメッセージのスパムステータス名(活動制限、警告制限、正常)<br>送信プロフィールのステータスが正常でない場合、null値になることがあります。                                          |
-| - block                   | boolean | O        | 送信プロフィールのブロック有無                                                                                                         |
-| - brandMessage            | Object  | X        | ブランドメッセージ設定情報                                                                                                        |
-| -- resendAppKey           | String  | X        | 代替送信として設定するSMSサービスのアプリキー                                                                                               |
-| -- isResend               | boolean | O        | 代替送信設定(再送信)の有無                                                                                                     |
-| -- resendSendNo           | String  | X        | 再送信時、tc-smsの送信番号                                                                                                  |
-| -- resendUnsubscribeNo    | String  | X        | 再送信時、tc-smsの080受信拒否番号                                                                                           |
-| - dormant                 | boolean | O        | 送信プロフィールの休眠状態の有無                                                                                                         |
-| - marketingAgreement      | boolean | O        | M/Nタイプの利用申請の有無                                                                                                      |
-| - createDate              | String  | X        | 登録日                                                                                                                |
-| - initialUserRestriction  | boolean | O        | 初回ユーザー制限の有無                                                                                                         |
+| 名前                        | タイプ     | Not Null | 説明                                                                                                                                        |
+|:--------------------------|:--------|:---------|:------------------------------------------------------------------------------------------------------------------------------------------|
+| header                    | Object  | O        | ヘッダー領域                                                                                                                                    |
+| - resultCode              | Integer | O        | 結果コード                                                                                                                                     |
+| - resultMessage           | String  | O        | 結果メッセージ                                                                                                                                   |
+| - isSuccessful            | boolean | O        | 成否                                                                                                                                        |
+| sender                    | Object  | X        | 発信プロフィール                                                                                                                                  |
+| - plusFriendId            | String  | O        | プラスフレンド ID                                                                                                                                |
+| - senderKey               | String  | O        | 発信キー                                                                                                                                      |
+| - categoryCode            | String  | X        | カテゴリコード                                                                                                                                   |
+| - unsubscribePhoneNumber  | String  | X        | 無料受信拒否電話番号                                                                                                                                |
+| - unsubscribeAuthNumber   | String  | X        | 無料受信拒否認証番号                                                                                                                                |
+| - status                  | String  | X        | NHN Cloud プラスフレンドステータスコード <br>(YSC02: 登録待機中、YSC03: 正常登録)                                                                               |
+| - statusName              | String  | X        | NHN Cloud プラスフレンドステータス名(登録待機中、正常登録)                                                                                                      |
+| - kakaoStatus             | String  | X        | カカオプラスフレンドステータスコード<br>(A: 正常、S: ブロック)<br>status が YSC02 の場合、kakaoStatus は null 値を持ちます。                                                  |
+| - kakaoStatusName         | String  | X        | カカオプラスフレンドステータス名(正常、ブロック)<br>status が YSC02 の場合、kakaoStatusName は null 値を持ちます。                                                          |
+| - kakaoProfileStatus      | String  | X        | カカオプラスフレンドプロフィールステータスコード<br>(A: 有効、B: ブロック、C: 無効、D: 削除、E: 削除処理中)<br>status が YSC02 の場合、kakaoProfileStatus は null 値を持ちます。               |
+| - kakaoProfileStatusName  | String  | X        | カカオプラスフレンドプロフィールステータス名(有効、無効、ブロック、削除処理中、削除)<br>status が YSC02 の場合、kakaoProfileStatusName は null 値を持ちます。                                |
+| - profileSpamLevel        | String  | X        | カカオトークチャンネルスパムステータス名(永久制限、警告制限、正常)<br>発信プロフィールのステータスが正常でない場合、null 値を持つ場合があります。                                                        |
+| - profileMessageSpamLevel | String  | X        | カカオトークメッセージスパムステータス名(活動制限、警告制限、正常)<br>発信プロフィールのステータスが正常でない場合、null 値を持つ場合があります。                                                       |
+| - block                   | boolean | O        | 発信プロフィールのブロック状態                                                                                                                           |
+| - brandMessage            | Object  | X        | ブランドメッセージ設定情報                                                                                                                             |
+| -- resendAppKey           | String  | X        | 代替送信として設定する SMS サービスアプリキー                                                                                                                |
+| -- isResend               | boolean | O        | 代替送信設定(再送信)の有無                                                                                                                            |
+| -- resendSendNo           | String  | X        | 再送信時の tc-sms 発信番号                                                                                                                         |
+| -- resendUnsubscribeNo    | String  | X        | 再送信時の tc-sms 080 受信拒否番号                                                                                                                   |
+| - dormant                 | boolean | O        | 発信プロフィールの休眠状態                                                                                                                             |
+| - marketingAgreement      | boolean | O        | M/N タイプ使用申請の有無                                                                                                                            |
+| - createDate              | String  | X        | 登録日時                                                                                                                                      |
+| - initialUserRestriction  | boolean | O        | 初回ユーザー制限の有無                                                                                                                               |
 
 <a id="modify-outgoing-profile-080-opt-out-number"></a>
 
-### 送信プロフィールの080受信拒否番号の修正
+### 発信プロフィール 080 受信拒否番号の修正
 
 <a id="requested-22"></a>
 
@@ -3895,10 +4180,10 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 名前      | タイプ   | 説明   |
-|-----------|--------|--------|
-| appkey    | String | 固有のアプリキー |
-| senderKey | String | 発信キー |
+| 名前        | タイプ    | 説明          |
+|-----------|--------|-------------|
+| appkey    | String | 固有のアプリキー    |
+| senderKey | String | 発信キー        |
 
 [Header]
 
@@ -3908,8 +4193,8 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前         | タイプ   | 必須 | 説明             |
-|--------------|--------|----|------------------|
+| 名前           | タイプ    | 必須 | 説明                  |
+|--------------|--------|----|---------------------|
 | X-Secret-Key | String | O  | コンソールで作成できます。 |
 
 [Request body]
@@ -3921,10 +4206,10 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前              | 	タイプ   | 	必須 | 	説明                                                                                                                          |
-|-------------------|---------|-----|--------------------------------------------------------------------------------------------------------------------------------|
-| unsubscribeNo     | 	String | 	O  | 080無料受信拒否電話番号(両方とも未入力の場合、送信プロフィールに登録された無料受信拒否情報で送信されます)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx  |
-| unsubscribeAuthNo | 	String | 	X  | 080無料受信拒否認証番号(両方とも未入力の場合、送信プロフィールに登録された無料受信拒否情報で送信されます)<br>unsubscribe_phone_numberなしでunsubscribe_auth_numberのみの入力は不可<br>ex) 1234 |
+| 名前                | タイプ     | 必須 | 説明                                                                                                                                                         |
+|-------------------|---------|-----|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| unsubscribeNo     | String  | O   | 080 無料受信拒否電話番号(未入力の場合、発信プロフィールに登録された受信拒否情報で送信されます)<br>- 080-xxx-xxxx <br>- 080-xxxx-xxxx <br>- 080xxxxxxx <br>- 080xxxxxxxx                              |
+| unsubscribeAuthNo | String  | X   | 080 無料受信拒否認証番号(最大 10 文字。未入力の場合、発信プロフィールに登録された受信拒否情報で送信されます)<br>unsubscribeNo なしに unsubscribeAuthNo のみの入力は不可<br>例: 1234 |
 
 <a id="response-22"></a>
 
@@ -3940,12 +4225,12 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前            | タイプ    | Not Null | 説明   |
-|:----------------|:--------|:---------|:-------|
-| header          | Object  | O        | ヘッダ領域 |
-| - resultCode    | Integer | O        | 結果コード |
+| 名前              | タイプ     | Not Null | 説明      |
+|:----------------|:--------|:---------|:--------|
+| header          | Object  | O        | ヘッダー領域  |
+| - resultCode    | Integer | O        | 結果コード   |
 | - resultMessage | String  | O        | 結果メッセージ |
-| - isSuccessful  | boolean | O        | 成否 |
+| - isSuccessful  | boolean | O        | 成否      |
 
 <a id="manage-fallback"></a>
 
@@ -3953,7 +4238,7 @@ Content-Type: application/json;charset=UTF-8
 
 <a id="register-sms-appkey"></a>
 
-### SMS AppKeyの登録
+### SMS AppKey 登録
 
 [URL]
 
@@ -3964,7 +4249,7 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 名前   | 	タイプ   | 	説明   |
+| 名前     | 	タイプ     | 	説明     |
 |--------|---------|---------|
 | appkey | 	String | 	固有のアプリキー |
 
@@ -3976,7 +4261,7 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前         | 	タイプ   | 	必須 | 	説明            |
+| 名前           | 	タイプ     | 	必須 | 	説明              |
 |--------------|---------|-----|------------------|
 | X-Secret-Key | 	String | O   | コンソールで作成できます。 |
 
@@ -3988,9 +4273,9 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前         | 	タイプ   | 	必須 | 	説明                  |
+| 名前           | 	タイプ     | 	必須 | 	説明                    |
 |--------------|---------|-----|------------------------|
-| resendAppKey | 	String | 	O  | 代替送信として設定するSMSサービスのアプリキー |
+| resendAppKey | 	String | 	O  | 代替送信として設定する SMS サービスのアプリキー |
 
 [例]
 
@@ -4015,7 +4300,7 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 
 <a id="register-fallback-settings"></a>
 
-### 代替送信設定の登録
+### 代替送信設定登録
 
 [URL]
 
@@ -4026,7 +4311,7 @@ Content-Type: application/json;charset=UTF-8
 
 [Path parameter]
 
-| 名前   | 	タイプ   | 	説明   |
+| 名前     | 	タイプ     | 	説明     |
 |--------|---------|---------|
 | appkey | 	String | 	固有のアプリキー |
 
@@ -4038,7 +4323,7 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前         | 	タイプ   | 	必須 | 	説明            |
+| 名前           | 	タイプ     | 	必須 | 	説明              |
 |--------------|---------|-----|------------------|
 | X-Secret-Key | 	String | O   | コンソールで作成できます。 |
 
@@ -4053,12 +4338,12 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
-| 名前                | 	タイプ    | 	必須 | 	説明                                                                                                      |
+| 名前                  | 	タイプ      | 	必須 | 	説明                                                                                                        |
 |---------------------|----------|-----|------------------------------------------------------------------------------------------------------------|
-| senderKey           | 	String  | 	O  | 発信キー                                                                                                     |
-| isResend            | 	Boolean | 	O  | 送信に失敗した場合、SMSでの代替送信の有無<br>Consoleで代替送信を設定した場合、デフォルトで代替送信されます。                                           |
-| resendSendNo        | 	String  | 	X  | 代替送信の送信番号<br><span style="color:red">(SMS商品に登録されている送信番号ではない場合、代替送信に失敗することがあります。)</span>                 |
-| resendUnsubscribeNo | 	String  | 	X  | 代替送信の080受信拒否番号<br><span style="color:red">(SMSサービスに登録されている080受信拒否番号ではない場合、代替送信に失敗することがあります。)</span> |
+| senderKey           | 	String  | 	O  | 発信キー                                                                                                       |
+| isResend            | 	Boolean | 	O  | 送信失敗時、SMS 代替送信を行うかどうか<br>コンソールで代替送信を設定すると、デフォルトで代替送信されます。                                           |
+| resendSendNo        | 	String  | 	X  | 代替送信の発信番号<br><span style="color:red">(SMS サービスに登録された発信番号でない場合、代替送信に失敗する可能性があります。)</span>                  |
+| resendUnsubscribeNo | 	String  | 	X  | 代替送信の 080 受信拒否番号<br><span style="color:red">(SMS サービスに登録された 080 受信拒否番号でない場合、代替送信に失敗する可能性があります。)</span> |
 
 [例]
 
@@ -4080,9 +4365,9 @@ curl -X POST -H "Content-Type: application/json;charset=UTF-8" -H "X-Secret-Key:
 }
 ```
 
-| 名前            | タイプ    | Not Null | 説明   |
+| 名前              | タイプ      | Not Null | 説明     |
 |:----------------|:--------|:---------|:-------|
-| header          | Object  | O        | ヘッダ領域 |
-| - resultCode    | Integer | O        | 結果コード |
+| header          | Object  | O        | ヘッダー領域  |
+| - resultCode    | Integer | O        | 結果コード  |
 | - resultMessage | String  | O        | 結果メッセージ |
-| - isSuccessful  | boolean | O        | 成否 |
+| - isSuccessful  | boolean | O        | 成功かどうか  |

--- a/ja/friendtalkupgrade-api-guide.md
+++ b/ja/friendtalkupgrade-api-guide.md
@@ -1720,6 +1720,24 @@ Content-Type: application/json;charset=UTF-8
 | - resendRequestId     | String  | X        | 代替送信リクエストID                                                                                      | 
 | - createUser          | String  | X        | 登録者(コンソールから送信した場合、ユーザーUUIDで保存)                                                                      |
 
+<a id="message-results"></a>
+
+## メッセージ結果アップデート照会
+
+<!-- TODO: translate body -->
+
+<a id="requested-25"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="response-25"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
 <a id="cancel-message-sending"></a>
 
 ## メッセージ送信取消

--- a/ja/friendtalkupgrade-api-guide.md
+++ b/ja/friendtalkupgrade-api-guide.md
@@ -1559,7 +1559,7 @@ Content-Type: application/json;charset=UTF-8
 | -- templateCode             | String  | X        | テンプレートコード                                                                |
 | -- recipientNo              | String  | O        | 受信番号                                                                 |
 | -- targeting                | String  | O        | メッセージ対象のタイプ(M: マーケティング受信同意ユーザー、N: フレンドではないマーケティング受信同意ユーザーのみ、I: フレンドであるユーザー) |
-| -- requestDate              | String  | O        | リクエスト日時(yyyy-MM-dd HH:mm)<br>(入力しない場合は즉시送信)<br>最大60日後まで予約可能                                                                 |
+| -- requestDate              | String  | O        | リクエスト日時(yyyy-MM-dd HH:mm)<br>(入力しない場合は即時送信)<br>最大60日後まで予約可能                                                                 |
 | -- createDate               | String  | O        | 登録日時                                                                 |
 | -- receiveDate              | String  | X        | 受信日時                                                                 |
 | -- chatBubbleType           | String  | O        | メッセージタイプ                                                                |

--- a/ja/friendtalkupgrade-api-guide.md
+++ b/ja/friendtalkupgrade-api-guide.md
@@ -3749,12 +3749,12 @@ Content-Type: application/json;charset=UTF-8
 | - title         | String  | X        | 動画タイトル (アップロード直後はファイル名、エンコード完了後にカカオビズセンターで修正した値に同期されます)                        |
 | - fileName      | String  | O        | アップロードファイル名                                                                         |
 | - fileSize      | Long    | O        | ファイルサイズ (byte)                                                                    |
-| - status        | String  | O        | 動画ステータス ([動画ステータス](#動画-ステータス) 参照)。アップロード登録レスポンスでは常に `REGISTERED`                     |
+| - status        | String  | O        | 動画ステータス ([動画ステータス](#video-status) 参照)。アップロード登録レスポンスでは常に `REGISTERED`                     |
 | uploadInfo      | Object  | O        | カカオアップロード情報。ステップ 2 で使用                                                            |
 | - uploadUrl     | String  | O        | 動画ファイルを直接アップロードするカカオ側エンドポイント                                                     |
 | - token         | String  | O        | アップロード認証トークン。`x-kamp-upload-token` ヘッダーで渡します                                          |
 
-> エンコード完了後に設定される `thumbnailUrl`、`videoUrl`、`playUrl`、`updateDate` フィールドは、[動画照会](#動画-照会) API で取得できます。
+> エンコード完了後に設定される `thumbnailUrl`、`videoUrl`、`playUrl`、`updateDate` フィールドは、[動画照会](#view-video) API で取得できます。
 
 <a id="video-file-upload-step-2"></a>
 
@@ -3814,7 +3814,7 @@ Content-Type: multipart/form-data
 | ファイル名の長さ   | 250文字以内                                    |
 
 * アップロードされた動画は、カカオビズセンターでエンコードが完了した後に使用できます。エンコード時間は映像の長さによって異なり、通常 5〜10 分かかります。
-* アップロード直後の動画ステータスは `REGISTERED` から始まり、`ENCODING` を経て `PUBLIC` または `PRIVATE` に移行します。ステータスはコンソールまたは[動画照会](#動画-照会) API で確認できます。
+* アップロード直後の動画ステータスは `REGISTERED` から始まり、`ENCODING` を経て `PUBLIC` または `PRIVATE` に移行します。ステータスはコンソールまたは[動画照会](#view-video) API で確認できます。
 * 登録された動画はカカオ側で永久保存され、テンプレートが削除されてもカカオビズセンターの動画は自動的に削除されません。カカオチャンネル管理者がチャンネルビジネスホームの管理画面から直接削除できます。
 * ステップ 1 の登録後にステップ 2 のファイルアップロードが失敗または遅延してトークン（5 分）が期限切れになった場合は、新しい登録を再度呼び出す必要があります。登録のみ行われ実際のアップロードが完了していない動画は、一定時間経過後にステータスが `ERROR` に自動的にマークされます。
 
@@ -3907,7 +3907,7 @@ Content-Type: application/json;charset=UTF-8
 | - - title           | String  | X        | 動画タイトル (アップロード直後はファイル名、エンコード完了後にカカオビズセンターで修正した値に同期されます)    |
 | - - fileName        | String  | O        | アップロードファイル名                                                     |
 | - - fileSize        | Long    | O        | ファイルサイズ (byte)                                                |
-| - - status          | String  | O        | 動画ステータス ([動画ステータス](#動画-状態) 参照)                              |
+| - - status          | String  | O        | 動画ステータス ([動画ステータス](#video-status) 参照)                              |
 | - - thumbnailUrl    | String  | X        | サムネイル URL (エンコード完了後に提供)                                       |
 | - - videoUrl        | String  | X        | 送信・管理用 URL (`PUBLIC` 状態で提供)                               |
 | - - playUrl         | String  | X        | 再生用 URL                                                     |

--- a/ko/alimtalk-api-guide-v2.0.md
+++ b/ko/alimtalk-api-guide-v2.0.md
@@ -1,3 +1,5 @@
+<!-- pre-align:aligned sig=6622ebb72190 -->
+
 ## Notification > KakaoTalk Bizmessage > 알림톡 > API v2.0 Guide
 
 <a id="alimtalk"></a>

--- a/ko/alimtalk-api-guide-v2.1.md
+++ b/ko/alimtalk-api-guide-v2.1.md
@@ -1,3 +1,5 @@
+<!-- pre-align:aligned sig=59b3050f8882 -->
+
 ## Notification > KakaoTalk Bizmessage > 알림톡 > API v2.1 Guide
 
 <a id="alimtalk"></a>

--- a/ko/alimtalk-api-guide-v2.2.md
+++ b/ko/alimtalk-api-guide-v2.2.md
@@ -1,3 +1,5 @@
+<!-- pre-align:aligned sig=ff88f5bc1ceb -->
+
 ## Notification > KakaoTalk Bizmessage > 알림톡 > API v2.2 Guide
 
 <a id="alimtalk"></a>

--- a/ko/friendtalkupgrade-api-guide.md
+++ b/ko/friendtalkupgrade-api-guide.md
@@ -3749,12 +3749,12 @@ Content-Type: application/json;charset=UTF-8
 | - title         | String  | X        | 동영상 제목 (업로드 직후에는 파일명, 인코딩 완료 후 카카오 비즈센터에서 수정한 값으로 동기화됨)                        |
 | - fileName      | String  | O        | 업로드 파일명                                                                         |
 | - fileSize      | Long    | O        | 파일 크기 (byte)                                                                    |
-| - status        | String  | O        | 동영상 상태 ([동영상 상태](#동영상-상태) 참고). 업로드 등록 응답에서는 항상 `REGISTERED`                     |
+| - status        | String  | O        | 동영상 상태 ([동영상 상태](#video-status) 참고). 업로드 등록 응답에서는 항상 `REGISTERED`                     |
 | uploadInfo      | Object  | O        | 카카오 업로드 정보. 2단계에서 사용                                                            |
 | - uploadUrl     | String  | O        | 동영상 파일을 직접 업로드할 카카오 측 엔드포인트                                                     |
 | - token         | String  | O        | 업로드 인증 토큰. `x-kamp-upload-token` 헤더로 전달                                          |
 
-> 인코딩 완료 후 채워지는 `thumbnailUrl`, `videoUrl`, `playUrl`, `updateDate` 필드는 [동영상 조회](#동영상-조회) API로 얻을 수 있습니다.
+> 인코딩 완료 후 채워지는 `thumbnailUrl`, `videoUrl`, `playUrl`, `updateDate` 필드는 [동영상 조회](#view-video) API로 얻을 수 있습니다.
 
 <a id="video-file-upload-step-2"></a>
 
@@ -3814,7 +3814,7 @@ Content-Type: multipart/form-data
 | 파일명 길이   | 250자 이내                                     |
 
 * 업로드된 동영상은 카카오 비즈센터에서 인코딩이 완료된 후 사용할 수 있습니다. 인코딩 시간은 영상 길이에 따라 다르며 보통 5~10분이 소요됩니다.
-* 업로드 직후 동영상 상태는 `REGISTERED`로 시작하며 `ENCODING`을 거쳐 `PUBLIC` 또는 `PRIVATE`로 전환됩니다. 상태는 콘솔 또는 [동영상 조회](#동영상-조회) API에서 확인할 수 있습니다.
+* 업로드 직후 동영상 상태는 `REGISTERED`로 시작하며 `ENCODING`을 거쳐 `PUBLIC` 또는 `PRIVATE`로 전환됩니다. 상태는 콘솔 또는 [동영상 조회](#view-video) API에서 확인할 수 있습니다.
 * 등록된 동영상은 카카오 측에서 영구 보존되며, 템플릿이 삭제되어도 카카오 비즈센터의 동영상은 자동으로 정리되지 않습니다. 카카오 채널 관리자가 채널 비즈니스 홈의 관리 화면에서 직접 삭제할 수 있습니다.
 * 1단계 등록 후 2단계 파일 업로드가 실패하거나 지연되어 토큰(5분)이 만료되면 새 등록을 다시 호출해야 합니다. 등록만 되고 실제 업로드가 이루어지지 않은 동영상은 일정 시간이 지난 후 상태가 `ERROR`로 자동 마킹됩니다.
 
@@ -3907,7 +3907,7 @@ Content-Type: application/json;charset=UTF-8
 | - - title           | String  | X        | 동영상 제목 (업로드 직후에는 파일명, 인코딩 완료 후 카카오 비즈센터에서 수정한 값으로 동기화됨)    |
 | - - fileName        | String  | O        | 업로드 파일명                                                     |
 | - - fileSize        | Long    | O        | 파일 크기 (byte)                                                |
-| - - status          | String  | O        | 동영상 상태 ([동영상 상태](#동영상-상태) 참고)                              |
+| - - status          | String  | O        | 동영상 상태 ([동영상 상태](#video-status) 참고)                              |
 | - - thumbnailUrl    | String  | X        | 썸네일 URL (인코딩 완료 후 제공)                                       |
 | - - videoUrl        | String  | X        | 발송·관리용 URL (`PUBLIC` 상태에서 제공)                               |
 | - - playUrl         | String  | X        | 재생용 URL                                                     |


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Body text is never modified.** The model only sees heading outlines; edits apply to heading lines (and `<!-- TODO: translate body -->` stubs for missing sections) only.

## Analysis

| | |
| --- | --- |
| Engine | `claude-code (CLI)` |
| Model | `claude-sonnet-4-6` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `alpha` |
| Scope | 5 doc(s) scanned · 12 file(s) changed |
| Self-verify | ⚠️ 8 mismatch(es) remain |
| Jenkins build | http://cd.cloud.toastoven.net:8080/job/content_deploy/job/align-heading/job/main/17/ |
| Generated | 2026-07-02T23:21:57 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`alpha`): [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FAlimtalk%2Ftree%2Falpha&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FAlimtalk%2Fpull%2F249&source=ko&langs=en%2Cja)

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra demoted | extra removed | verify |
| --- | --: | --: | --: | --: | --: | --: | --: | :--: |
| `ko/alimtalk-api-guide-v2.0.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/alimtalk-api-guide-v2.0.md` | 0 | 0 | 0 | 2 | 0 | 0 | 2 | ✅ |
| `ja/alimtalk-api-guide-v2.0.md` | 0 | 0 | 0 | 2 | 0 | 0 | 2 | ✅ |
| `ko/alimtalk-api-guide-v2.1.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/alimtalk-api-guide-v2.1.md` | 0 | 0 | 0 | 2 | 0 | 0 | 2 | ✅ |
| `ja/alimtalk-api-guide-v2.1.md` | 0 | 0 | 0 | 2 | 0 | 0 | 2 | ✅ |
| `ko/alimtalk-api-guide-v2.2.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/alimtalk-api-guide-v2.2.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/alimtalk-api-guide-v2.2.md` | 0 | 0 | 0 | 2 | 0 | 0 | 2 | ✅ |
| `ja/alimtalk-api-guide.md` | 0 | 0 | 0 | 5 | 0 | 0 | 6 | ⚠️ 6 |
| `en/friendtalkupgrade-api-guide.md` | 0 | 3 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/friendtalkupgrade-api-guide.md` | 0 | 3 | 0 | 0 | 0 | 0 | 0 | ⚠️ 2 |

<details><summary>남은 불일치 (검토 필요)</summary>

- `ja/alimtalk-api-guide.md`:
  - extra_in_target (ko#None/ja#14)
  - extra_in_target (ko#None/ja#21)
  - missing_in_target (ko#31/ja#None)
  - missing_in_target (ko#32/ja#None)
  - missing_in_target (ko#33/ja#None)
  - missing_in_target (ko#34/ja#None)
- `ja/friendtalkupgrade-api-guide.md`:
  - missing_in_target (ko#21/ja#None)
  - extra_in_target (ko#None/ja#22)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/Alimtalk`