### PR TITLE
Add anchor id to first heading in ko/en/ja (compare-headings fix)

### DIFF
--- a/en/Overview.md
+++ b/en/Overview.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=e451b6f6f6d1 -->
 
-## Notification > KakaoTalk Bizmessage > Overview
+<a id="overview"></a>
+
+## Notification > KakaoTalk Bizmessage > Overview { #overview }
 
 KakaoTalk Bizmessage is a service that can send messages, AlimTalk and FriendTalk type without adding friends based on their mobile phone number. 
 It provides RESTful API for easy interworking.

--- a/en/alimtalk-api-guide-v1.4.md
+++ b/en/alimtalk-api-guide-v1.4.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=9287aa20c2c3 -->
 
-## Notification > KakaoTalk Bizmessage > AlimTalk > API v1.4 Guide
+<a id="alimtalk-api-guide-v1-4"></a>
+
+## Notification > KakaoTalk Bizmessage > AlimTalk > API v1.4 Guide { #alimtalk-api-guide-v1-4 }
 
 <a id="alimtalk"></a>
 

--- a/en/alimtalk-api-guide-v1.5.md
+++ b/en/alimtalk-api-guide-v1.5.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=a21bd637e7f0 -->
 
-## Notification > KakaoTalk Bizmessage > AlimTalk > API v1.5 Guide
+<a id="alimtalk-api-guide-v1-5"></a>
+
+## Notification > KakaoTalk Bizmessage > AlimTalk > API v1.5 Guide { #alimtalk-api-guide-v1-5 }
 
 <a id="alimtalk"></a>
 

--- a/en/alimtalk-api-guide-v2.0.md
+++ b/en/alimtalk-api-guide-v2.0.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=6622ebb72190 -->
 
-## Notification > KakaoTalk Bizmessage > AlimTalk > API v2.0 Guide
+<a id="alimtalk-api-guide-v2-0"></a>
+
+## Notification > KakaoTalk Bizmessage > AlimTalk > API v2.0 Guide { #alimtalk-api-guide-v2-0 }
 
 <a id="alimtalk"></a>
 

--- a/en/alimtalk-api-guide-v2.1.md
+++ b/en/alimtalk-api-guide-v2.1.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=59b3050f8882 -->
 
-## Notification > KakaoTalk Bizmessage > AlimTalk > API v2.1 Guide
+<a id="alimtalk-api-guide-v2-1"></a>
+
+## Notification > KakaoTalk Bizmessage > AlimTalk > API v2.1 Guide { #alimtalk-api-guide-v2-1 }
 
 <a id="alimtalk"></a>
 

--- a/en/alimtalk-api-guide-v2.2.md
+++ b/en/alimtalk-api-guide-v2.2.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=ff88f5bc1ceb -->
 
-## Notification > KakaoTalk Bizmessage > AlimTalk > API v2.2 Guide
+<a id="alimtalk-api-guide-v2-2"></a>
+
+## Notification > KakaoTalk Bizmessage > AlimTalk > API v2.2 Guide { #alimtalk-api-guide-v2-2 }
 
 <a id="alimtalk"></a>
 

--- a/en/alimtalk-api-guide.md
+++ b/en/alimtalk-api-guide.md
@@ -1,4 +1,6 @@
-## Notification > KakaoTalk Bizmessage > AlimTalk > API v2.3 Guide
+<a id="alimtalk-api-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > AlimTalk > API v2.3 Guide { #alimtalk-api-guide }
 
 <a id="alimtalk"></a>
 

--- a/en/alimtalk-console-guide.md
+++ b/en/alimtalk-console-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=3fddaef1a9f4 -->
 
-## Notification > KakaoTalk Bizmessage > AlimTalk > Console Guide
+<a id="alimtalk-console-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > AlimTalk > Console Guide { #alimtalk-console-guide }
 
 <a id="send-alimtalk"></a>
 

--- a/en/alimtalk-overview.md
+++ b/en/alimtalk-overview.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=cf26af3116e5 -->
 
-## Notification > KakaoTalk Bizmessage > AlimTalk > Overview
+<a id="alimtalk-overview"></a>
+
+## Notification > KakaoTalk Bizmessage > AlimTalk > Overview { #alimtalk-overview }
 
 Alimtalk is a service based on mobile phones with which users can send informative messages such as delivery message, schedule notification, and others without adding the recipient as a friend.
 The service provides RESTful APIs for easy integration.

--- a/en/common-api-guide.md
+++ b/en/common-api-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=8c7be9b338eb -->
 
-## Notification > KakaoTalk Bizmessage > Common > API v2.2 Guide
+<a id="common-api-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > Common > API v2.2 Guide { #common-api-guide }
 
 <a id="statistics"></a>
 

--- a/en/common-console-guide.md
+++ b/en/common-console-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=872af16524aa -->
 
-## Notification > KakaoTalk Bizmessage > Plus Friend> Console Guide
+<a id="common-console-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > Plus Friend> Console Guide { #common-console-guide }
 
 <a id="identity-verification"></a>
 

--- a/en/error-code.md
+++ b/en/error-code.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=2a9da7055af6 -->
 
-## Notification > KakaoTalk Bizmessage > Error Code
+<a id="error-code"></a>
+
+## Notification > KakaoTalk Bizmessage > Error Code { #error-code }
 
 <a id="api-response-code"></a>
 

--- a/en/friendtalk-api-guide-v1.4.md
+++ b/en/friendtalk-api-guide-v1.4.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=5073e45b7dd3 -->
 
-## Notification > KakaoTalk Bizmessage > FriendTalk > API v1.4 Guide
+<a id="friendtalk-api-guide-v1-4"></a>
+
+## Notification > KakaoTalk Bizmessage > FriendTalk > API v1.4 Guide { #friendtalk-api-guide-v1-4 }
 
 <a id="friendtalk-service-termination-notice"></a>
 

--- a/en/friendtalk-api-guide-v1.5.md
+++ b/en/friendtalk-api-guide-v1.5.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=f3806dc222dc -->
 
-## Notification > KakaoTalk Bizmessage > FriendTalk > API v1.5 Guide
+<a id="friendtalk-api-guide-v1-5"></a>
+
+## Notification > KakaoTalk Bizmessage > FriendTalk > API v1.5 Guide { #friendtalk-api-guide-v1-5 }
 
 <a id="friendtalk-service-termination-notice"></a>
 

--- a/en/friendtalk-api-guide-v2.0.md
+++ b/en/friendtalk-api-guide-v2.0.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=464ee68f7c42 -->
 
-## Notification > KakaoTalk Bizmessage > FriendTalk > API v2.0 Guide
+<a id="friendtalk-api-guide-v2-0"></a>
+
+## Notification > KakaoTalk Bizmessage > FriendTalk > API v2.0 Guide { #friendtalk-api-guide-v2-0 }
 
 <a id="friendtalk-service-end-of-life-notice"></a>
 

--- a/en/friendtalk-api-guide-v2.2.md
+++ b/en/friendtalk-api-guide-v2.2.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=29f20c5fe5db -->
 
-## Notification > KakaoTalk Bizmessage > FriendTalk > API v2.2 Guide
+<a id="friendtalk-api-guide-v2-2"></a>
+
+## Notification > KakaoTalk Bizmessage > FriendTalk > API v2.2 Guide { #friendtalk-api-guide-v2-2 }
 
 <a id="friendtalk-service-termination-notice"></a>
 

--- a/en/friendtalk-api-guide-v2.3.md
+++ b/en/friendtalk-api-guide-v2.3.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=7343fc9458a2 -->
 
-## Notification > KakaoTalk Bizmessage > FriendTalk > API v2.3 Guide
+<a id="friendtalk-api-guide-v2-3"></a>
+
+## Notification > KakaoTalk Bizmessage > FriendTalk > API v2.3 Guide { #friendtalk-api-guide-v2-3 }
 
 <a id="friendtalk-service-end-of-service-notice"></a>
 

--- a/en/friendtalk-api-guide.md
+++ b/en/friendtalk-api-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=318c3793bdb0 -->
 
-## Notification > KakaoTalk Bizmessage > FriendTalk > API v2.4 Guide
+<a id="friendtalk-api-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > FriendTalk > API v2.4 Guide { #friendtalk-api-guide }
 
 <a id="friendtalk-service-termination-notice"></a>
 

--- a/en/friendtalk-compatible-api-guide.md
+++ b/en/friendtalk-compatible-api-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=492516bf9d3d -->
 
-## Notification > KakaoTalk Bizmessage > FriendTalk > Brand Message Migration Guide
+<a id="friendtalk-compatible-api-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > FriendTalk > Brand Message Migration Guide { #friendtalk-compatible-api-guide }
 
 <a id="overview"></a>
 

--- a/en/friendtalk-console-guide.md
+++ b/en/friendtalk-console-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=00da575a6590 -->
 
-## Notification > KakaoTalk Bizmessage > FriendTalk > Console Guide
+<a id="friendtalk-console-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > FriendTalk > Console Guide { #friendtalk-console-guide }
 
 <a id="friendtalk-service-termination-notice"></a>
 

--- a/en/friendtalk-overview.md
+++ b/en/friendtalk-overview.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=33585d5af5a4 -->
 
-## Notification > KakaoTalk Bizmessage > FriendTalk > Overview
+<a id="friendtalk-overview"></a>
+
+## Notification > KakaoTalk Bizmessage > FriendTalk > Overview { #friendtalk-overview }
 
 FriendTalk is a service that can send various messages, including advertising messages such as events and occasions, to customers with added friends on my Kakao channel based on their mobile phone number. 
 It provides RESTful API for easy integration.

--- a/en/friendtalkupgrade-api-guide.md
+++ b/en/friendtalkupgrade-api-guide.md
@@ -1,4 +1,6 @@
-## Notification > KakaoTalk Bizmessage > Brand Message > API v1.0 Guide
+<a id="friendtalkupgrade-api-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > Brand Message > API v1.0 Guide { #friendtalkupgrade-api-guide }
 
 <a id="brand-message"></a>
 

--- a/en/friendtalkupgrade-console-guide.md
+++ b/en/friendtalkupgrade-console-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=3b443c0f0141 -->
 
-## Notification > KakaoTalk Bizmessage > Brand Message > Console User Guide
+<a id="friendtalkupgrade-console-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > Brand Message > Console User Guide { #friendtalkupgrade-console-guide }
 
 <a id="brand-message-sending"></a>
 

--- a/en/friendtalkupgrade-overview.md
+++ b/en/friendtalkupgrade-overview.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=7eb2dbb75382 -->
 
-## Notification > KakaoTalk Bizmessage > Brand Message > Overview
+<a id="friendtalkupgrade-overview"></a>
+
+## Notification > KakaoTalk Bizmessage > Brand Message > Overview { #friendtalkupgrade-overview }
 
 Brand Message is a message product that allows advertisers (clients) to send advertising messages to members who have agreed to receive marketing messages (hereinafter referred to as “marketing consent”), regardless of whether they are KakaoTalk channel friends.
 

--- a/en/release-notes.md
+++ b/en/release-notes.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=7e06fb48b072 -->
 
-## Notification > KakaoTalk Bizmessage > Release Notes
+<a id="release-notes"></a>
+
+## Notification > KakaoTalk Bizmessage > Release Notes { #release-notes }
 ### June 23, 2026
 #### Added Features
 * [Console] Added brand message video upload feature

--- a/en/sender-api-guide-v2.0.md
+++ b/en/sender-api-guide-v2.0.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=77de814faaab -->
 
-## Notification > KakaoTalk Bizmessage > Sender > API v2.0 Guide
+<a id="sender-api-guide-v2-0"></a>
+
+## Notification > KakaoTalk Bizmessage > Sender > API v2.0 Guide { #sender-api-guide-v2-0 }
 
 <a id="overview-of-v20-api"></a>
 

--- a/en/sender-api-guide-v2.1.md
+++ b/en/sender-api-guide-v2.1.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=ee87b06908ec -->
 
-## Notification > KakaoTalk Bizmessage > Sender > API v2.1 Guide
+<a id="sender-api-guide-v2-1"></a>
+
+## Notification > KakaoTalk Bizmessage > Sender > API v2.1 Guide { #sender-api-guide-v2-1 }
 
 <a id="overview-of-v21-api"></a>
 

--- a/en/sender-api-guide-v2.3.md
+++ b/en/sender-api-guide-v2.3.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=509feeb5926b -->
 
-## Notification > KakaoTalk Bizmessage > Sender > API v2.3 Guide
+<a id="sender-api-guide-v2-3"></a>
+
+## Notification > KakaoTalk Bizmessage > Sender > API v2.3 Guide { #sender-api-guide-v2-3 }
 
 <a id="overview-of-v23-api"></a>
 

--- a/en/sender-console-guide.md
+++ b/en/sender-console-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=f530f01ac2b8 -->
 
-## Notification > KakaoTalk Bizmessage > Sender Profile > Console Guide
+<a id="sender-console-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > Sender Profile > Console Guide { #sender-console-guide }
 
 <a id="registerauthenticate-sender-profiles"></a>
 

--- a/en/sender-overview.md
+++ b/en/sender-overview.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=0142a0759662 -->
 
-## Notification > KakaoTalk Bizmessage > Plus Friend > Overview
+<a id="sender-overview"></a>
+
+## Notification > KakaoTalk Bizmessage > Plus Friend > Overview { #sender-overview }
 According to the Kakao policy, in order to send a KakaoTalk Biz message, you must first open a business-certified channel at the KakaoTalk Channel Administrator Center to send an AlimTalk /FriendTalk.[[Create Kakao Channel and Business Certification Guide]](https://kakaobusiness.gitbook.io/main/channel/start)
 
 

--- a/en/troubleshooting-guide.md
+++ b/en/troubleshooting-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=f86d36730580 -->
 
-## Notification > KakaoTalk Bizmessage > 문제 해결 가이드
+<a id="troubleshooting-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > 문제 해결 가이드 { #troubleshooting-guide }
 
 <a id="message-for-query-delivery-button"></a>
 

--- a/en/webhook-api-guide.md
+++ b/en/webhook-api-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=ea58471275ed -->
 
-## Notification > KakaoTalk Bizmessage > Webhook > API Guide
+<a id="webhook-api-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > Webhook > API Guide { #webhook-api-guide }
 
 <span id="webhook"></span>
 <a id="webhook"></a>

--- a/ja/Overview.md
+++ b/ja/Overview.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=e451b6f6f6d1 -->
 
-## Notification > KakaoTalk Bizmessage > 概要
+<a id="overview"></a>
+
+## Notification > KakaoTalk Bizmessage > 概要 { #overview }
 
 KakaoTalk Bizmessageは、携帯電話番号に基づいて、フレンド追加せずにカカオトークユーザーにお知らせトーク、カカともへのメッセージ形式のメッセージを送信できるサービスです。
 簡単に連携するためにRESTful APIを提供します。

--- a/ja/alimtalk-api-guide-v1.4.md
+++ b/ja/alimtalk-api-guide-v1.4.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=9287aa20c2c3 -->
 
-## Notification > KakaoTalk Bizmessage > お知らせトーク > API v1.4 Guide
+<a id="alimtalk-api-guide-v1-4"></a>
+
+## Notification > KakaoTalk Bizmessage > お知らせトーク > API v1.4 Guide { #alimtalk-api-guide-v1-4 }
 
 <a id="alimtalk"></a>
 

--- a/ja/alimtalk-api-guide-v1.5.md
+++ b/ja/alimtalk-api-guide-v1.5.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=a21bd637e7f0 -->
 
-## Notification > KakaoTalk Bizmessage > お知らせトーク > API v1.5 Guide
+<a id="alimtalk-api-guide-v1-5"></a>
+
+## Notification > KakaoTalk Bizmessage > お知らせトーク > API v1.5 Guide { #alimtalk-api-guide-v1-5 }
 
 <a id="alimtalk"></a>
 

--- a/ja/alimtalk-api-guide-v2.0.md
+++ b/ja/alimtalk-api-guide-v2.0.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=6622ebb72190 -->
 
-## Notification > KakaoTalk Bizmessage > お知らせトーク > API v2.0 Guide
+<a id="alimtalk-api-guide-v2-0"></a>
+
+## Notification > KakaoTalk Bizmessage > お知らせトーク > API v2.0 Guide { #alimtalk-api-guide-v2-0 }
 
 <a id="alimtalk"></a>
 

--- a/ja/alimtalk-api-guide-v2.1.md
+++ b/ja/alimtalk-api-guide-v2.1.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=59b3050f8882 -->
 
-## Notification > KakaoTalk Bizmessage > お知らせトーク > API v2.1 Guide
+<a id="alimtalk-api-guide-v2-1"></a>
+
+## Notification > KakaoTalk Bizmessage > お知らせトーク > API v2.1 Guide { #alimtalk-api-guide-v2-1 }
 
 <a id="alimtalk"></a>
 

--- a/ja/alimtalk-api-guide-v2.2.md
+++ b/ja/alimtalk-api-guide-v2.2.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=ff88f5bc1ceb -->
 
-## Notification > KakaoTalk Bizmessage > お知らせトーク > API v2.2 Guide
+<a id="alimtalk-api-guide-v2-2"></a>
+
+## Notification > KakaoTalk Bizmessage > お知らせトーク > API v2.2 Guide { #alimtalk-api-guide-v2-2 }
 
 <a id="alimtalk"></a>
 

--- a/ja/alimtalk-api-guide.md
+++ b/ja/alimtalk-api-guide.md
@@ -1,4 +1,6 @@
-## Notification > KakaoTalk Bizmessage > お知らせトーク > API v2.3 Guide
+<a id="alimtalk-api-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > お知らせトーク > API v2.3 Guide { #alimtalk-api-guide }
 
 <a id="alimtalk"></a>
 

--- a/ja/alimtalk-console-guide.md
+++ b/ja/alimtalk-console-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=3fddaef1a9f4 -->
 
-## Notification > KakaoTalk Bizmessage > お知らせトーク > コンソール使用ガイド
+<a id="alimtalk-console-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > お知らせトーク > コンソール使用ガイド { #alimtalk-console-guide }
 
 <a id="send-alimtalk"></a>
 

--- a/ja/alimtalk-overview.md
+++ b/ja/alimtalk-overview.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=cf26af3116e5 -->
 
-## Notification > KakaoTalk Bizmessage > お知らせトーク > 概要
+<a id="alimtalk-overview"></a>
+
+## Notification > KakaoTalk Bizmessage > お知らせトーク > 概要 { #alimtalk-overview }
 
 お知らせトークは携帯電話番号を基づいて、フレンド追加せずにカカオトークユーザーに配送、予約時間などの情報性メッセージを送信できるサービスです。
 簡単に連携するためのRESTful APIを提供しています。

--- a/ja/common-api-guide.md
+++ b/ja/common-api-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=8c7be9b338eb -->
 
-## Notification > KakaoTalk Bizmessage > Common > API v2.2 Guide
+<a id="common-api-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > Common > API v2.2 Guide { #common-api-guide }
 
 <a id="statistics"></a>
 

--- a/ja/common-console-guide.md
+++ b/ja/common-console-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=872af16524aa -->
 
-## Notification > KakaoTalk Bizmessage > プラスフレンド > コンソールガイド
+<a id="common-console-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > プラスフレンド > コンソールガイド { #common-console-guide }
 
 <a id="identity-verification"></a>
 

--- a/ja/error-code.md
+++ b/ja/error-code.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=2a9da7055af6 -->
 
-## Notification > KakaoTalk Bizmessage > エラーコード
+<a id="error-code"></a>
+
+## Notification > KakaoTalk Bizmessage > エラーコード { #error-code }
 
 <a id="api-response-code"></a>
 

--- a/ja/friendtalk-api-guide-v1.4.md
+++ b/ja/friendtalk-api-guide-v1.4.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=5073e45b7dd3 -->
 
-## Notification > KakaoTalk Bizmessage > カカともへのメッセージ > API v1.4 Guide
+<a id="friendtalk-api-guide-v1-4"></a>
+
+## Notification > KakaoTalk Bizmessage > カカともへのメッセージ > API v1.4 Guide { #friendtalk-api-guide-v1-4 }
 
 <a id="friendtalk-service-termination-notice"></a>
 

--- a/ja/friendtalk-api-guide-v1.5.md
+++ b/ja/friendtalk-api-guide-v1.5.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=f3806dc222dc -->
 
-## Notification > KakaoTalk Bizmessage > カカともへのメッセージ > API v1.5 Guide
+<a id="friendtalk-api-guide-v1-5"></a>
+
+## Notification > KakaoTalk Bizmessage > カカともへのメッセージ > API v1.5 Guide { #friendtalk-api-guide-v1-5 }
 
 <a id="friendtalk-service-termination-notice"></a>
 

--- a/ja/friendtalk-api-guide-v2.0.md
+++ b/ja/friendtalk-api-guide-v2.0.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=464ee68f7c42 -->
 
-## Notification > KakaoTalk Bizmessage > カカともへのメッセージ > API v2.0 Guide
+<a id="friendtalk-api-guide-v2-0"></a>
+
+## Notification > KakaoTalk Bizmessage > カカともへのメッセージ > API v2.0 Guide { #friendtalk-api-guide-v2-0 }
 
 <a id="friendtalk-service-end-of-life-notice"></a>
 

--- a/ja/friendtalk-api-guide-v2.2.md
+++ b/ja/friendtalk-api-guide-v2.2.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=29f20c5fe5db -->
 
-## Notification > KakaoTalk Bizmessage > カカともへのメッセージ > API v2.2 Guide
+<a id="friendtalk-api-guide-v2-2"></a>
+
+## Notification > KakaoTalk Bizmessage > カカともへのメッセージ > API v2.2 Guide { #friendtalk-api-guide-v2-2 }
 
 <a id="friendtalk-service-termination-notice"></a>
 

--- a/ja/friendtalk-api-guide-v2.3.md
+++ b/ja/friendtalk-api-guide-v2.3.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=7343fc9458a2 -->
 
-## Notification > KakaoTalk Bizmessage > カカともへのメッセージ > API v2.3 Guide
+<a id="friendtalk-api-guide-v2-3"></a>
+
+## Notification > KakaoTalk Bizmessage > カカともへのメッセージ > API v2.3 Guide { #friendtalk-api-guide-v2-3 }
 
 <a id="friendtalk-service-end-of-service-notice"></a>
 

--- a/ja/friendtalk-api-guide.md
+++ b/ja/friendtalk-api-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=318c3793bdb0 -->
 
-## Notification > KakaoTalk Bizmessage > カカともへのメッセージ > API v2.4 Guide
+<a id="friendtalk-api-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > カカともへのメッセージ > API v2.4 Guide { #friendtalk-api-guide }
 
 <a id="friendtalk-service-termination-notice"></a>
 

--- a/ja/friendtalk-compatible-api-guide.md
+++ b/ja/friendtalk-compatible-api-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=492516bf9d3d -->
 
-## Notification > KakaoTalk Bizmessage > フレンドトーク > ブランドメッセージ移行ガイド
+<a id="friendtalk-compatible-api-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > フレンドトーク > ブランドメッセージ移行ガイド { #friendtalk-compatible-api-guide }
 
 <a id="overview"></a>
 

--- a/ja/friendtalk-console-guide.md
+++ b/ja/friendtalk-console-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=00da575a6590 -->
 
-## Notification > KakaoTalk Bizmessage > カカともへのメッセージ > コンソール使用ガイド
+<a id="friendtalk-console-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > カカともへのメッセージ > コンソール使用ガイド { #friendtalk-console-guide }
 
 <a id="friendtalk-service-termination-notice"></a>
 

--- a/ja/friendtalk-overview.md
+++ b/ja/friendtalk-overview.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=33585d5af5a4 -->
 
-## Notification > KakaoTalk Bizmessage > カカともへのメッセージ > 概要
+<a id="friendtalk-overview"></a>
+
+## Notification > KakaoTalk Bizmessage > カカともへのメッセージ > 概要 { #friendtalk-overview }
 
 カカともへのメッセージは、携帯電話番号に基づいて、カカオチャンネルのフレンドに追加された顧客にイベントなどの広告性メッセージを含むさまざまなメッセージを送信できるサービスです。
 簡単に連携するためにRESTful APIを提供します。

--- a/ja/friendtalkupgrade-api-guide.md
+++ b/ja/friendtalkupgrade-api-guide.md
@@ -1,4 +1,6 @@
-## Notification > KakaoTalk Bizmessage > ブランドメッセージ > API v1.0 Guide
+<a id="friendtalkupgrade-api-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > ブランドメッセージ > API v1.0 Guide { #friendtalkupgrade-api-guide }
 
 <a id="brand-message"></a>
 

--- a/ja/friendtalkupgrade-console-guide.md
+++ b/ja/friendtalkupgrade-console-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=3b443c0f0141 -->
 
-## Notification > KakaoTalk Bizmessage > ブランドメッセージ > コンソール利用ガイド
+<a id="friendtalkupgrade-console-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > ブランドメッセージ > コンソール利用ガイド { #friendtalkupgrade-console-guide }
 
 <a id="brand-message-sending"></a>
 

--- a/ja/friendtalkupgrade-overview.md
+++ b/ja/friendtalkupgrade-overview.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=7eb2dbb75382 -->
 
-## Notification > KakaoTalk Bizmessage > ブランドメッセージ > 概要
+<a id="friendtalkupgrade-overview"></a>
+
+## Notification > KakaoTalk Bizmessage > ブランドメッセージ > 概要 { #friendtalkupgrade-overview }
 
 ブランドメッセージは、広告主(クライアント企業)のマーケティング受信に同意した会員(以下、マーケティング受信同意)を対象に、カカオトークのチャネルの友だちであるかどうかにかかわらず、広告メッセージを送信できるメッセージ商品です。
 

--- a/ja/release-notes.md
+++ b/ja/release-notes.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=7e06fb48b072 -->
 
-## Notification > KakaoTalk Bizmessage > リリースノート
+<a id="release-notes"></a>
+
+## Notification > KakaoTalk Bizmessage > リリースノート { #release-notes }
 
 <a id="june-23-2026"></a>
 

--- a/ja/sender-api-guide-v2.0.md
+++ b/ja/sender-api-guide-v2.0.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=77de814faaab -->
 
-## Notification > KakaoTalk Bizmessage > Sender > API v2.0 Guide
+<a id="sender-api-guide-v2-0"></a>
+
+## Notification > KakaoTalk Bizmessage > Sender > API v2.0 Guide { #sender-api-guide-v2-0 }
 
 <a id="overview-of-v20-api"></a>
 

--- a/ja/sender-api-guide-v2.1.md
+++ b/ja/sender-api-guide-v2.1.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=ee87b06908ec -->
 
-## Notification > KakaoTalk Bizmessage > Sender > API v2.0 Guide
+<a id="sender-api-guide-v2-1"></a>
+
+## Notification > KakaoTalk Bizmessage > Sender > API v2.0 Guide { #sender-api-guide-v2-1 }
 
 <a id="overview-of-v21-api"></a>
 

--- a/ja/sender-api-guide-v2.3.md
+++ b/ja/sender-api-guide-v2.3.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=509feeb5926b -->
 
-## Notification > KakaoTalk Bizmessage > Sender > API v2.3 Guide
+<a id="sender-api-guide-v2-3"></a>
+
+## Notification > KakaoTalk Bizmessage > Sender > API v2.3 Guide { #sender-api-guide-v2-3 }
 
 <a id="overview-of-v23-api"></a>
 

--- a/ja/sender-console-guide.md
+++ b/ja/sender-console-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=f530f01ac2b8 -->
 
-## Notification > KakaoTalk Bizmessage > 送信元プロフィール > コンソールガイド
+<a id="sender-console-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > 送信元プロフィール > コンソールガイド { #sender-console-guide }
 
 <a id="registerauthenticate-sender-profiles"></a>
 

--- a/ja/sender-overview.md
+++ b/ja/sender-overview.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=0142a0759662 -->
 
-## Notification > KakaoTalk Bizmessage > プラスフレンド > 概要
+<a id="sender-overview"></a>
+
+## Notification > KakaoTalk Bizmessage > プラスフレンド > 概要 { #sender-overview }
 カカオポリシーに従ってカカオトークBizメッセージを送信するには、先にカカオトークチャンネル管理者センターでビジネス認証を受けたチャンネルを開設する必要があります。開設すると、お知らせトーク/カカともへのメッセージを送信できます。[[カカオチャンネル作成およびビジネス認証ガイド]](https://kakaobusiness.gitbook.io/main/channel/start)
 
 

--- a/ja/troubleshooting-guide.md
+++ b/ja/troubleshooting-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=f86d36730580 -->
 
-## Notification > KakaoTalk Bizmessage > 問題解決ガイド
+<a id="troubleshooting-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > 問題解決ガイド { #troubleshooting-guide }
 
 <a id="message-for-query-delivery-button"></a>
 

--- a/ja/webhook-api-guide.md
+++ b/ja/webhook-api-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=ea58471275ed -->
 
-## Notification > KakaoTalk Bizmessage > Webhook > API Guide
+<a id="webhook-api-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > Webhook > API Guide { #webhook-api-guide }
 
 <span id="webhook"></span>
 <a id="webhook"></a>

--- a/ko/Overview.md
+++ b/ko/Overview.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=e451b6f6f6d1 -->
 
-## Notification > KakaoTalk Bizmessage > 개요
+<a id="overview"></a>
+
+## Notification > KakaoTalk Bizmessage > 개요 { #overview }
 
 KakaoTalk Bizmessage는 휴대폰 번호를 기반으로 친구 추가 없이 카카오톡 사용자에게 알림톡, 친구톡 형태의 메시지를 발송할 수 있는 서비스입니다.
 손쉬운 연동을 위한 RESTful API를 제공합니다.

--- a/ko/alimtalk-api-guide-v1.4.md
+++ b/ko/alimtalk-api-guide-v1.4.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=9287aa20c2c3 -->
 
-## Notification > KakaoTalk Bizmessage > 알림톡 > API v1.4 Guide
+<a id="alimtalk-api-guide-v1-4"></a>
+
+## Notification > KakaoTalk Bizmessage > 알림톡 > API v1.4 Guide { #alimtalk-api-guide-v1-4 }
 
 <a id="alimtalk"></a>
 

--- a/ko/alimtalk-api-guide-v1.5.md
+++ b/ko/alimtalk-api-guide-v1.5.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=a21bd637e7f0 -->
 
-## Notification > KakaoTalk Bizmessage > 알림톡 > API v1.5 Guide
+<a id="alimtalk-api-guide-v1-5"></a>
+
+## Notification > KakaoTalk Bizmessage > 알림톡 > API v1.5 Guide { #alimtalk-api-guide-v1-5 }
 
 <a id="alimtalk"></a>
 

--- a/ko/alimtalk-api-guide-v2.0.md
+++ b/ko/alimtalk-api-guide-v2.0.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=6622ebb72190 -->
 
-## Notification > KakaoTalk Bizmessage > 알림톡 > API v2.0 Guide
+<a id="alimtalk-api-guide-v2-0"></a>
+
+## Notification > KakaoTalk Bizmessage > 알림톡 > API v2.0 Guide { #alimtalk-api-guide-v2-0 }
 
 <a id="alimtalk"></a>
 

--- a/ko/alimtalk-api-guide-v2.1.md
+++ b/ko/alimtalk-api-guide-v2.1.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=59b3050f8882 -->
 
-## Notification > KakaoTalk Bizmessage > 알림톡 > API v2.1 Guide
+<a id="alimtalk-api-guide-v2-1"></a>
+
+## Notification > KakaoTalk Bizmessage > 알림톡 > API v2.1 Guide { #alimtalk-api-guide-v2-1 }
 
 <a id="alimtalk"></a>
 

--- a/ko/alimtalk-api-guide-v2.2.md
+++ b/ko/alimtalk-api-guide-v2.2.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=ff88f5bc1ceb -->
 
-## Notification > KakaoTalk Bizmessage > 알림톡 > API v2.2 Guide
+<a id="alimtalk-api-guide-v2-2"></a>
+
+## Notification > KakaoTalk Bizmessage > 알림톡 > API v2.2 Guide { #alimtalk-api-guide-v2-2 }
 
 <a id="alimtalk"></a>
 

--- a/ko/alimtalk-api-guide.md
+++ b/ko/alimtalk-api-guide.md
@@ -1,4 +1,6 @@
-## Notification > KakaoTalk Bizmessage > 알림톡 > API v2.3 Guide
+<a id="alimtalk-api-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > 알림톡 > API v2.3 Guide { #alimtalk-api-guide }
 
 <a id="alimtalk"></a>
 

--- a/ko/alimtalk-console-guide.md
+++ b/ko/alimtalk-console-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=3fddaef1a9f4 -->
 
-## Notification > KakaoTalk Bizmessage > 알림톡 > 콘솔 사용 가이드
+<a id="alimtalk-console-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > 알림톡 > 콘솔 사용 가이드 { #alimtalk-console-guide }
 
 <a id="send-alimtalk"></a>
 

--- a/ko/alimtalk-overview.md
+++ b/ko/alimtalk-overview.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=cf26af3116e5 -->
 
-## Notification > KakaoTalk Bizmessage > 알림톡 > 개요
+<a id="alimtalk-overview"></a>
+
+## Notification > KakaoTalk Bizmessage > 알림톡 > 개요 { #alimtalk-overview }
 
 알림톡은 휴대폰 번호를 기반으로 친구 추가 없이 카카오톡 사용자에게 배송, 예약 시간 등의 정보성 메시지를 발송할 수 있는 서비스입니다.
 손쉬운 연동을 위한 RESTful API를 제공합니다.

--- a/ko/common-api-guide.md
+++ b/ko/common-api-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=8c7be9b338eb -->
 
-## Notification > KakaoTalk Bizmessage > Common > API v2.2 Guide
+<a id="common-api-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > Common > API v2.2 Guide { #common-api-guide }
 
 <a id="statistics"></a>
 

--- a/ko/common-console-guide.md
+++ b/ko/common-console-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=872af16524aa -->
 
-## Notification > KakaoTalk Bizmessage > 콘솔 사용 가이드
+<a id="common-console-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > 콘솔 사용 가이드 { #common-console-guide }
 
 <a id="identity-verification"></a>
 

--- a/ko/error-code.md
+++ b/ko/error-code.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=2a9da7055af6 -->
 
-## Notification > KakaoTalk Bizmessage > 오류 코드
+<a id="error-code"></a>
+
+## Notification > KakaoTalk Bizmessage > 오류 코드 { #error-code }
 
 <a id="api-response-code"></a>
 

--- a/ko/friendtalk-api-guide-v1.4.md
+++ b/ko/friendtalk-api-guide-v1.4.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=5073e45b7dd3 -->
 
-## Notification > KakaoTalk Bizmessage > 친구톡 > API v1.4 가이드
+<a id="friendtalk-api-guide-v1-4"></a>
+
+## Notification > KakaoTalk Bizmessage > 친구톡 > API v1.4 가이드 { #friendtalk-api-guide-v1-4 }
 
 <a id="friendtalk-service-termination-notice"></a>
 

--- a/ko/friendtalk-api-guide-v1.5.md
+++ b/ko/friendtalk-api-guide-v1.5.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=f3806dc222dc -->
 
-## Notification > KakaoTalk Bizmessage > 친구톡 > API v1.5 가이드
+<a id="friendtalk-api-guide-v1-5"></a>
+
+## Notification > KakaoTalk Bizmessage > 친구톡 > API v1.5 가이드 { #friendtalk-api-guide-v1-5 }
 
 <a id="friendtalk-service-termination-notice"></a>
 

--- a/ko/friendtalk-api-guide-v2.0.md
+++ b/ko/friendtalk-api-guide-v2.0.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=464ee68f7c42 -->
 
-## Notification > KakaoTalk Bizmessage > 친구톡 > API v2.0 가이드
+<a id="friendtalk-api-guide-v2-0"></a>
+
+## Notification > KakaoTalk Bizmessage > 친구톡 > API v2.0 가이드 { #friendtalk-api-guide-v2-0 }
 
 <a id="friendtalk-service-end-of-life-notice"></a>
 

--- a/ko/friendtalk-api-guide-v2.2.md
+++ b/ko/friendtalk-api-guide-v2.2.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=29f20c5fe5db -->
 
-## Notification > KakaoTalk Bizmessage > 친구톡 > API v2.2 가이드
+<a id="friendtalk-api-guide-v2-2"></a>
+
+## Notification > KakaoTalk Bizmessage > 친구톡 > API v2.2 가이드 { #friendtalk-api-guide-v2-2 }
 
 <a id="friendtalk-service-termination-notice"></a>
 

--- a/ko/friendtalk-api-guide-v2.3.md
+++ b/ko/friendtalk-api-guide-v2.3.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=7343fc9458a2 -->
 
-## Notification > KakaoTalk Bizmessage > 친구톡 > API v2.3 가이드
+<a id="friendtalk-api-guide-v2-3"></a>
+
+## Notification > KakaoTalk Bizmessage > 친구톡 > API v2.3 가이드 { #friendtalk-api-guide-v2-3 }
 
 <a id="friendtalk-service-end-of-service-notice"></a>
 

--- a/ko/friendtalk-api-guide.md
+++ b/ko/friendtalk-api-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=318c3793bdb0 -->
 
-## Notification > KakaoTalk Bizmessage > 친구톡 > API v2.4 가이드
+<a id="friendtalk-api-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > 친구톡 > API v2.4 가이드 { #friendtalk-api-guide }
 
 <a id="friendtalk-service-termination-notice"></a>
 

--- a/ko/friendtalk-compatible-api-guide.md
+++ b/ko/friendtalk-compatible-api-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=492516bf9d3d -->
 
-## Notification > KakaoTalk Bizmessage > 친구톡 > 브랜드 메시지 전환 가이드
+<a id="friendtalk-compatible-api-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > 친구톡 > 브랜드 메시지 전환 가이드 { #friendtalk-compatible-api-guide }
 
 <a id="overview"></a>
 

--- a/ko/friendtalk-console-guide.md
+++ b/ko/friendtalk-console-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=00da575a6590 -->
 
-## Notification > KakaoTalk Bizmessage > 친구톡 > 콘솔 사용 가이드
+<a id="friendtalk-console-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > 친구톡 > 콘솔 사용 가이드 { #friendtalk-console-guide }
 
 <a id="friendtalk-service-termination-notice"></a>
 

--- a/ko/friendtalk-overview.md
+++ b/ko/friendtalk-overview.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=33585d5af5a4 -->
 
-## Notification > KakaoTalk Bizmessage > 친구톡 > 개요
+<a id="friendtalk-overview"></a>
+
+## Notification > KakaoTalk Bizmessage > 친구톡 > 개요 { #friendtalk-overview }
 
 <a id="friendtalk-service-termination-notice"></a>
 

--- a/ko/friendtalkupgrade-api-guide.md
+++ b/ko/friendtalkupgrade-api-guide.md
@@ -1,4 +1,6 @@
-## Notification > KakaoTalk Bizmessage > 브랜드 메시지 > API v1.0 Guide
+<a id="friendtalkupgrade-api-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > 브랜드 메시지 > API v1.0 Guide { #friendtalkupgrade-api-guide }
 
 <a id="brand-message"></a>
 

--- a/ko/friendtalkupgrade-console-guide.md
+++ b/ko/friendtalkupgrade-console-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=3b443c0f0141 -->
 
-## Notification > KakaoTalk Bizmessage > 브랜드 메시지 > 콘솔 사용 가이드
+<a id="friendtalkupgrade-console-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > 브랜드 메시지 > 콘솔 사용 가이드 { #friendtalkupgrade-console-guide }
 
 <a id="brand-message-sending"></a>
 

--- a/ko/friendtalkupgrade-overview.md
+++ b/ko/friendtalkupgrade-overview.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=7eb2dbb75382 -->
 
-## Notification > KakaoTalk Bizmessage > 브랜드 메시지 > 개요
+<a id="friendtalkupgrade-overview"></a>
+
+## Notification > KakaoTalk Bizmessage > 브랜드 메시지 > 개요 { #friendtalkupgrade-overview }
 
 브랜드 메시지는 광고주(고객사)의 마케팅 수신 동의 회원(이하 마수동)을 대상으로 카카오톡 채널 친구 여부와 관계없이 광고성 메시지를 발송할 수 있는 메시지 상품입니다.
 

--- a/ko/release-notes.md
+++ b/ko/release-notes.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=7e06fb48b072 -->
 
-## Notification > KakaoTalk Bizmessage > 릴리스 노트
+<a id="release-notes"></a>
+
+## Notification > KakaoTalk Bizmessage > 릴리스 노트 { #release-notes }
 
 <a id="july-28-2026"></a>
 

--- a/ko/sender-api-guide-v2.0.md
+++ b/ko/sender-api-guide-v2.0.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=77de814faaab -->
 
-## Notification > KakaoTalk Bizmessage > Sender > API v2.0 Guide
+<a id="sender-api-guide-v2-0"></a>
+
+## Notification > KakaoTalk Bizmessage > Sender > API v2.0 Guide { #sender-api-guide-v2-0 }
 
 <a id="overview-of-v20-api"></a>
 

--- a/ko/sender-api-guide-v2.1.md
+++ b/ko/sender-api-guide-v2.1.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=ee87b06908ec -->
 
-## Notification > KakaoTalk Bizmessage > Sender > API v2.1 Guide
+<a id="sender-api-guide-v2-1"></a>
+
+## Notification > KakaoTalk Bizmessage > Sender > API v2.1 Guide { #sender-api-guide-v2-1 }
 
 <a id="overview-of-v21-api"></a>
 

--- a/ko/sender-api-guide-v2.3.md
+++ b/ko/sender-api-guide-v2.3.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=509feeb5926b -->
 
-## Notification > KakaoTalk Bizmessage > Sender > API v2.3 Guide
+<a id="sender-api-guide-v2-3"></a>
+
+## Notification > KakaoTalk Bizmessage > Sender > API v2.3 Guide { #sender-api-guide-v2-3 }
 
 <a id="overview-of-v23-api"></a>
 

--- a/ko/sender-console-guide.md
+++ b/ko/sender-console-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=f530f01ac2b8 -->
 
-## Notification > KakaoTalk Bizmessage > 발신 프로필 > 콘솔 사용 가이드
+<a id="sender-console-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > 발신 프로필 > 콘솔 사용 가이드 { #sender-console-guide }
 
 <a id="registerauthenticate-sender-profiles"></a>
 

--- a/ko/sender-overview.md
+++ b/ko/sender-overview.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=0142a0759662 -->
 
-## Notification > KakaoTalk Bizmessage > 발신 프로필 > 발송 전 준비사항
+<a id="sender-overview"></a>
+
+## Notification > KakaoTalk Bizmessage > 발신 프로필 > 발송 전 준비사항 { #sender-overview }
 카카오 정책에 따라 카카오톡 비즈 메시지를 발송하려면 먼저 카카오톡채널 관리자센터에서 비즈니스 인증을 받은 채널을 개설해야 알림톡/친구톡 발송이 가능합니다. [[카카오 채널 생성 및 비즈니스 인증 가이드]](https://kakaobusiness.gitbook.io/main/channel/start)
 
 

--- a/ko/troubleshooting-guide.md
+++ b/ko/troubleshooting-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=f86d36730580 -->
 
-## Notification > KakaoTalk Bizmessage > 문제 해결 가이드
+<a id="troubleshooting-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > 문제 해결 가이드 { #troubleshooting-guide }
 
 <a id="message-for-query-delivery-button"></a>
 

--- a/ko/webhook-api-guide.md
+++ b/ko/webhook-api-guide.md
@@ -1,6 +1,8 @@
 <!-- pre-align:aligned sig=ea58471275ed -->
 
-## Notification > KakaoTalk Bizmessage > Webhook > API Guide
+<a id="webhook-api-guide"></a>
+
+## Notification > KakaoTalk Bizmessage > Webhook > API Guide { #webhook-api-guide }
 
 <span id="webhook"></span>
 <a id="webhook"></a>


### PR DESCRIPTION
## Summary

각 문서의 **첫 번째 `## ` heading (breadcrumb 형태의 문서 제목)** 이 anchor id 없이 존재해서 compare-headings 뷰가 ko/en/ja 를 짝지을 수 없어 **32개 파일 모두 "id_diff"** 로 표시되던 문제 수정. 나머지 heading 들은 이미 `<a id="..."></a>` + `{ #... }` 패턴을 지키고 있음.

## Compare-headings 실증

- **Before** (alpha 브랜치): [compare 링크](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FAlimtalk&langs=en%2Cja&source=ko&ref=alpha) — **32 doc(s) with divergence(s)** (전부)
- **After** (이 PR 브랜치): [compare 링크](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FAlimtalk&langs=en%2Cja&source=ko&ref=fix%2Ffirst-heading-anchor) — **1 doc with divergence** (32 → 1, 별개 이슈 하나만 잔존)

## Fix

Slug 는 **파일명 stem** (lowercase, dots → dashes) 로 부여. ko/en/ja 3개 언어 모두 같은 slug 를 쓰므로 이후 compare-headings 에서 match 로 표시됨.

**Before** (`ko/Overview.md`):
```markdown
<!-- pre-align:aligned sig=e451b6f6f6d1 -->

## Notification > KakaoTalk Bizmessage > 개요
```

**After**:
```markdown
<!-- pre-align:aligned sig=e451b6f6f6d1 -->

<a id="overview"></a>

## Notification > KakaoTalk Bizmessage > 개요 { #overview }
```

## Slug 매핑 예시

| 파일 | Slug |
|---|---|
| Overview.md | overview |
| alimtalk-api-guide.md | alimtalk-api-guide |
| alimtalk-api-guide-v1.4.md | alimtalk-api-guide-v1-4 |
| friendtalk-api-guide-v2.3.md | friendtalk-api-guide-v2-3 |
| ... | (총 32개 stem × 3 lang = 96 files) |

## Diff

- 96 files changed (ko × 32 + en × 32 + ja × 32)
- Insertion pattern: 2 lines before first heading (`<a id="slug"></a>` + blank line) + ` { #slug }` suffix on heading

## Test plan

- [x] Local script 로 96 파일 일괄 삽입. Idempotent (재실행 시 no-op)
- [x] After-compare 링크로 32 → 1 감소 확인 (잔존 1건은 다른 문서의 기존 anchor 이슈, 이 PR 스코프 밖)